### PR TITLE
Fix queued chat progress ordering

### DIFF
--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1982,10 +1982,26 @@ async def _run_discord_orchestrated_turn_for_message(
         )
         if callable(claim_queued_notice_progress_message):
             with contextlib.suppress(TypeError):
-                reusable_progress_message_id = claim_queued_notice_progress_message(
+                queued_notice_message_id = claim_queued_notice_progress_message(
                     channel_id=channel_id,
                     source_message_id=source_message_id,
                 )
+                if queued_notice_message_id:
+                    with contextlib.suppress(
+                        DiscordPermanentError,
+                        DiscordTransientError,
+                        RuntimeError,
+                        ConnectionError,
+                        OSError,
+                    ):
+                        await service._delete_channel_message_safe(
+                            channel_id,
+                            queued_notice_message_id,
+                            record_id=(
+                                "discord:queued-progress-started:"
+                                f"{managed_thread_id}:{source_message_id}"
+                            ),
+                        )
     if not reusable_progress_message_id:
         # PMA message ingress posts an immediate "Received. Preparing turn..."
         # placeholder before the managed-turn runner starts. Claim it here so the

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1981,27 +1981,28 @@ async def _run_discord_orchestrated_turn_for_message(
             service, "_claim_queued_notice_progress_message", None
         )
         if callable(claim_queued_notice_progress_message):
+            queued_notice_message_id = None
             with contextlib.suppress(TypeError):
                 queued_notice_message_id = claim_queued_notice_progress_message(
                     channel_id=channel_id,
                     source_message_id=source_message_id,
                 )
-                if queued_notice_message_id:
-                    with contextlib.suppress(
-                        DiscordPermanentError,
-                        DiscordTransientError,
-                        RuntimeError,
-                        ConnectionError,
-                        OSError,
-                    ):
-                        await service._delete_channel_message_safe(
-                            channel_id,
-                            queued_notice_message_id,
-                            record_id=(
-                                "discord:queued-progress-started:"
-                                f"{managed_thread_id}:{source_message_id}"
-                            ),
-                        )
+            if queued_notice_message_id:
+                with contextlib.suppress(
+                    DiscordPermanentError,
+                    DiscordTransientError,
+                    RuntimeError,
+                    ConnectionError,
+                    OSError,
+                ):
+                    await service._delete_channel_message_safe(
+                        channel_id,
+                        queued_notice_message_id,
+                        record_id=(
+                            "discord:queued-progress-started:"
+                            f"{managed_thread_id}:{source_message_id}"
+                        ),
+                    )
     if not reusable_progress_message_id:
         # PMA message ingress posts an immediate "Received. Preparing turn..."
         # placeholder before the managed-turn runner starts. Claim it here so the

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -2084,10 +2084,16 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             and placeholder_id is not None
             and placeholder_text != PLACEHOLDER_TEXT
         ):
-            await self._edit_message_text(
+            await self._delete_message(
                 message.chat_id,
                 placeholder_id,
-                PLACEHOLDER_TEXT,
+                thread_id=message.thread_id,
+            )
+            placeholder_id = await self._send_placeholder(
+                message.chat_id,
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+                text=PLACEHOLDER_TEXT,
             )
         return placeholder_id
 

--- a/tests/discord_message_turns_queue_notice_support.py
+++ b/tests/discord_message_turns_queue_notice_support.py
@@ -139,3 +139,131 @@ async def test_orchestrated_turn_pma_queued_sends_fresh_progress_placeholder(
     assert rest.edited_channel_messages
     assert rest.edited_channel_messages[0]["message_id"] != "notice-1"
     assert "queued" in rest.edited_channel_messages[-1]["payload"]["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_turn_replaces_queued_notice_with_fresh_progress_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rest = _FakeRest()
+    thread = SimpleNamespace(thread_target_id="thread-1")
+    started_execution = SimpleNamespace(
+        execution=SimpleNamespace(status="queued", execution_id="turn-2"),
+        thread=thread,
+    )
+
+    async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return started_execution
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = _config(tmp_path)
+            self._store = _Store()
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+            self._spawn_task = asyncio.create_task
+            self.claim_calls: list[tuple[str, str]] = []
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        async def _delete_channel_message_safe(
+            self,
+            channel_id: str,
+            message_id: str,
+            *,
+            record_id: Optional[str] = None,
+        ) -> None:
+            _ = record_id
+            await rest.delete_channel_message(
+                channel_id=channel_id,
+                message_id=message_id,
+            )
+
+        def _claim_queued_notice_progress_message(
+            self,
+            *,
+            channel_id: str,
+            source_message_id: str,
+        ) -> Optional[str]:
+            self.claim_calls.append((channel_id, source_message_id))
+            return "notice-1"
+
+        def _register_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module.ManagedThreadTurnCoordinator,
+        "ensure_queue_worker",
+        lambda *args, **kwargs: None,
+    )
+
+    service = _Service()
+    result = (
+        await discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+            service,
+            workspace_root=tmp_path,
+            prompt_text="hi",
+            input_items=None,
+            source_message_id="m-2",
+            agent="codex",
+            model_override=None,
+            reasoning_effort=None,
+            session_key="s1",
+            orchestrator_channel_key="channel-1",
+            managed_thread_surface_key=None,
+            mode="repo",
+            pma_enabled=False,
+            execution_prompt="hi",
+            public_execution_error="err",
+            timeout_error="timeout",
+            interrupted_error="interrupt",
+            approval_mode="never",
+            sandbox_policy="dangerFullAccess",
+            max_actions=12,
+            min_edit_interval_seconds=1.0,
+            heartbeat_interval_seconds=2.0,
+        )
+    )
+
+    assert result.send_final_message is False
+    assert service.claim_calls == [("channel-1", "m-2")]
+    assert rest.deleted_channel_messages == [
+        {"channel_id": "channel-1", "message_id": "notice-1"}
+    ]
+    assert len(rest.channel_messages) == 1
+    assert rest.edited_channel_messages
+    assert rest.edited_channel_messages[0]["message_id"] == "msg-1"

--- a/tests/test_telegram_single_owner_invariants.py
+++ b/tests/test_telegram_single_owner_invariants.py
@@ -692,8 +692,13 @@ class TestPlaceholderDeliveryInvariants:
         second_wait.set()
         await asyncio.gather(task_one, task_two)
 
-        placeholder_id = handler._placeholder_ids[2]
-        assert (placeholder_id, PLACEHOLDER_TEXT) in handler._edit_calls
+        assert handler._delete_calls == [(10, 102)]
+        working_placeholders = [
+            call
+            for call in handler._placeholder_calls
+            if call["reply_to"] == 2 and call["text"] == PLACEHOLDER_TEXT
+        ]
+        assert working_placeholders
 
     @pytest.mark.anyio
     async def test_successful_delivery_deletes_placeholder(self) -> None:

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -518,8 +518,13 @@ async def test_turn_placeholder_sent_while_queued() -> None:
     second_wait.set()
     await asyncio.gather(task_one, task_two)
 
-    placeholder_id = handler._placeholder_ids[2]
-    assert (placeholder_id, PLACEHOLDER_TEXT) in handler._edit_calls
+    assert handler._delete_calls == [(10, 102)]
+    working_placeholders = [
+        call
+        for call in handler._placeholder_calls
+        if call["reply_to"] == 2 and call["text"] == PLACEHOLDER_TEXT
+    ]
+    assert working_placeholders
 
 
 @pytest.mark.anyio
@@ -544,8 +549,9 @@ async def test_queue_wait_uses_refreshed_placeholder_when_available() -> None:
     finally:
         handler._turn_semaphore.release()
 
-    assert resolved_placeholder_id == 222
-    assert handler._edit_calls[-1] == (222, PLACEHOLDER_TEXT)
+    assert resolved_placeholder_id == 101
+    assert handler._delete_calls == [(10, 222)]
+    assert handler._placeholder_calls[-1]["text"] == PLACEHOLDER_TEXT
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- retire queued Discord notices instead of reusing them as active progress anchors
- replace Telegram queued placeholders with fresh working placeholders when queued turns start
- update queue-ordering regressions and placeholder ownership invariants

## Validation
- .venv/bin/python -m pytest tests/test_telegram_turn_queue.py tests/test_telegram_single_owner_invariants.py::TestPlaceholderDeliveryInvariants::test_queued_placeholder_text_is_promoted_to_working tests/discord_message_turns_queue_notice_support.py tests/chat_surface_lab/test_latency_budgets.py::test_latency_budget_suite_writes_artifacts_covers_budgets_and_includes_north_star -q
- .venv/bin/python -m ruff check src/codex_autorunner/adapters/discord/message_turns.py src/codex_autorunner/adapters/telegram/handlers/commands/execution.py tests/test_telegram_turn_queue.py tests/test_telegram_single_owner_invariants.py tests/discord_message_turns_queue_notice_support.py && git diff --check
- CODEX_FAST_TEST_WORKERS=1 git commit -m "Fix queued chat progress ordering" (pre-commit: 9566 fast tests passed; chat-surface lab passed; latency budget suite GREEN)