### PR TITLE
[codex] Fix OpenCode turn completion handling

### DIFF
--- a/src/codex_autorunner/agents/opencode/output_assembly.py
+++ b/src/codex_autorunner/agents/opencode/output_assembly.py
@@ -9,7 +9,9 @@ exercising reconnect/stall logic.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
@@ -31,10 +33,10 @@ from .event_fields import (
 )
 from .protocol_payload import (
     extract_context_window,
-    extract_message_phase,
     extract_model_ids,
     extract_total_tokens,
     extract_usage_details,
+    message_completion_is_turn_terminal,
     parse_message_response,
     prompt_echo_matches,
     recover_last_assistant_message,
@@ -43,6 +45,7 @@ from .turn_lifecycle import OpenCodeTurnOutputSource
 from .usage_decoder import extract_usage
 
 PartHandler = Callable[[str, dict[str, Any], Optional[str]], Awaitable[None]]
+_CODE_SPAN_PATTERN = re.compile(r"`([^`]*)`")
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,51 @@ class OutputAssemblyResult:
     usage: Optional[dict[str, Any]] = None
     output_source: OpenCodeTurnOutputSource = "none"
     effective_runtime: Optional[RuntimeIdentityStage] = None
+
+
+def _collapse_whitespace(text: str) -> str:
+    return "".join(text.split())
+
+
+def _spacing_anomaly_score(text: str) -> int:
+    """Score spaces that usually come from OpenCode token-boundary artifacts."""
+
+    score = 0
+    for index, char in enumerate(text):
+        if not char.isspace():
+            continue
+        previous = text[index - 1] if index > 0 else ""
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if (
+            previous.isalnum()
+            and next_char.isalnum()
+            and (previous.isdigit() or next_char.isdigit())
+        ):
+            score += 2
+    for match in _CODE_SPAN_PATTERN.finditer(text):
+        code_text = match.group(1)
+        stripped = code_text.strip()
+        if code_text != stripped:
+            score += 2
+        score += sum(1 for char in stripped if char.isspace())
+    return score
+
+
+def _select_final_text(
+    completed_text: Optional[str],
+    streamed_text: str,
+) -> str:
+    if not completed_text:
+        return streamed_text
+    if not streamed_text:
+        return completed_text
+    if _collapse_whitespace(completed_text) != _collapse_whitespace(streamed_text):
+        return completed_text
+    completed_score = _spacing_anomaly_score(completed_text)
+    streamed_score = _spacing_anomaly_score(streamed_text)
+    if streamed_score < completed_score:
+        return streamed_text
+    return completed_text
 
 
 class OutputAssembler:
@@ -94,6 +142,7 @@ class OutputAssembler:
         self._error: Optional[str] = None
         self._message_roles: dict[str, str] = {}
         self._message_roles_seen = False
+        self._message_text_parts: dict[str, list[str]] = {}
         self._pending_text: dict[str, list[str]] = {}
         self._pending_no_id: list[str] = []
         self._no_id_role: Optional[str] = None
@@ -101,6 +150,7 @@ class OutputAssembler:
             None
         )
         self._last_completed_assistant_text: Optional[str] = None
+        self._last_terminal_assistant_message_id: Optional[str] = None
         self._last_usage_signature: Optional[
             tuple[
                 Optional[str],
@@ -188,7 +238,7 @@ class OutputAssembler:
         resolved_role = role
         if resolved_role is None and msg_id:
             resolved_role = self._message_roles.get(msg_id)
-        if message_result.text:
+        if message_result.text and message_completion_is_turn_terminal(payload):
             if resolved_role == "assistant" or resolved_role is None:
                 self._fallback_message = (
                     msg_id,
@@ -226,8 +276,11 @@ class OutputAssembler:
         """
         if message_role != "assistant":
             return
-        if extract_message_phase(payload) == "commentary":
+        if not message_completion_is_turn_terminal(payload):
             return
+        msg_id = extract_event_message_id(payload)
+        if msg_id:
+            self._last_terminal_assistant_message_id = msg_id
         message_result = parse_message_response(payload)
         self._last_completed_assistant_text = (
             message_result.text if message_result.text else None
@@ -391,9 +444,12 @@ class OutputAssembler:
     async def build_result(self) -> OutputAssemblyResult:
         """Build the final :class:`OutputAssemblyResult` after the stream loop.
 
-        Applies fallback-message selection and ``messages_fetcher`` recovery
-        if no streaming text was collected.
+        Applies pending stream flushes, fallback-message selection, and
+        ``messages_fetcher`` recovery if no streaming text was collected.
         """
+        if not self._text_parts and self.has_pending_text:
+            self._flush_all_pending_text()
+
         if not self._text_parts and self._fallback_message is not None:
             msg_id, role, text = self._fallback_message
             resolved_role = role
@@ -406,7 +462,60 @@ class OutputAssembler:
             ):
                 self._text_parts.append(text)
 
-        if not self._text_parts and self._messages_fetcher is not None:
+        if not self._text_parts:
+            recovered_text = await self._recover_text_from_messages()
+            if recovered_text:
+                self._text_parts.append(recovered_text)
+                self._output_source = "messages_snapshot"
+
+        streamed_text = self._streamed_text_for_final_message()
+        recovery_candidate = self._last_completed_assistant_text or streamed_text
+        if recovery_candidate and _spacing_anomaly_score(recovery_candidate) > 0:
+            recovered_text = await self._recover_text_from_messages(
+                attempts=3,
+                delay_seconds=0.05,
+            )
+            if (
+                recovered_text
+                and _collapse_whitespace(recovered_text)
+                == _collapse_whitespace(recovery_candidate)
+                and _spacing_anomaly_score(recovered_text)
+                < _spacing_anomaly_score(recovery_candidate)
+            ):
+                if self._last_completed_assistant_text:
+                    self._last_completed_assistant_text = recovered_text
+                else:
+                    streamed_text = recovered_text
+                self._output_source = "messages_snapshot"
+
+        final_text = _select_final_text(
+            self._last_completed_assistant_text,
+            streamed_text,
+        )
+        output_source = self._output_source
+        if final_text and output_source == "none":
+            output_source = "event_stream"
+        return OutputAssemblyResult(
+            text=final_text.strip(),
+            error=self._error,
+            usage=self._latest_usage_snapshot,
+            output_source=output_source,
+            effective_runtime=await self._effective_runtime_stage(),
+        )
+
+    async def _recover_text_from_messages(
+        self,
+        *,
+        attempts: int = 1,
+        delay_seconds: float = 0.0,
+    ) -> str:
+        if self._messages_fetcher is None:
+            return ""
+        recovered_text = ""
+        recovered_error: Optional[str] = None
+        for attempt_index in range(max(1, attempts)):
+            if attempt_index > 0 and delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)
             try:
                 messages_payload = await self._messages_fetcher()
             except (
@@ -422,28 +531,16 @@ class OutputAssembler:
                     session_id=self._session_id,
                     exc=exc,
                 )
-            else:
-                recovered = recover_last_assistant_message(
-                    messages_payload,
-                    prompt=self._prompt,
-                )
-                if recovered.text:
-                    self._text_parts.append(recovered.text)
-                    self._output_source = "messages_snapshot"
-                if recovered.error and not self._error:
-                    self._error = recovered.error
-
-        final_text = self._last_completed_assistant_text or "".join(self._text_parts)
-        output_source = self._output_source
-        if final_text and output_source == "none":
-            output_source = "event_stream"
-        return OutputAssemblyResult(
-            text=final_text.strip(),
-            error=self._error,
-            usage=self._latest_usage_snapshot,
-            output_source=output_source,
-            effective_runtime=await self._effective_runtime_stage(),
-        )
+                continue
+            recovered = recover_last_assistant_message(
+                messages_payload,
+                prompt=self._prompt,
+            )
+            recovered_text = recovered.text or recovered_text
+            recovered_error = recovered.error or recovered_error
+        if recovered_error and not self._error:
+            self._error = recovered_error
+        return recovered_text
 
     async def _effective_runtime_stage(self) -> RuntimeIdentityStage:
         provider_id: Optional[str] = None
@@ -543,8 +640,8 @@ class OutputAssembler:
         if role == "user":
             return
         if role == "assistant":
-            self._append_readable_text(
-                self._text_parts,
+            self._append_assistant_text(
+                message_id,
                 text,
                 preserve_word_boundaries=preserve_word_boundaries,
             )
@@ -585,13 +682,23 @@ class OutputAssembler:
             return
         pending = self._pending_text.pop(message_id, [])
         if pending:
-            self._text_parts.extend(pending)
+            for text in pending:
+                self._append_assistant_text(
+                    message_id,
+                    text,
+                    preserve_word_boundaries=False,
+                )
 
     def _flush_all_pending_text(self) -> None:
         if self._pending_text:
-            for pending in list(self._pending_text.values()):
+            for message_id, pending in list(self._pending_text.items()):
                 if pending:
-                    self._text_parts.extend(pending)
+                    for text in pending:
+                        self._append_assistant_text(
+                            message_id,
+                            text,
+                            preserve_word_boundaries=False,
+                        )
             self._pending_text.clear()
         if self._pending_no_id:
             if (
@@ -601,6 +708,36 @@ class OutputAssembler:
             ):
                 self._text_parts.extend(self._pending_no_id)
             self._pending_no_id.clear()
+
+    def _append_assistant_text(
+        self,
+        message_id: str,
+        text: str,
+        *,
+        preserve_word_boundaries: bool,
+    ) -> None:
+        parts = self._message_text_parts.setdefault(message_id, [])
+        self._append_readable_text(
+            parts,
+            text,
+            preserve_word_boundaries=preserve_word_boundaries,
+        )
+        self._append_readable_text(
+            self._text_parts,
+            text,
+            preserve_word_boundaries=preserve_word_boundaries,
+        )
+
+    def _streamed_text_for_final_message(self) -> str:
+        if self._last_terminal_assistant_message_id is not None:
+            terminal_parts = self._message_text_parts.get(
+                self._last_terminal_assistant_message_id,
+            )
+            if terminal_parts:
+                return "".join(terminal_parts)
+            if self._message_text_parts:
+                return ""
+        return "".join(self._text_parts)
 
     async def _resolve_session_model_ids(
         self,

--- a/src/codex_autorunner/agents/opencode/protocol_payload.py
+++ b/src/codex_autorunner/agents/opencode/protocol_payload.py
@@ -45,6 +45,17 @@ OPENCODE_IDLE_STATUS_VALUES = {
     "success",
 }
 
+OPENCODE_TOOL_CALL_FINISH_VALUES = {
+    "tool-call",
+    "tool-calls",
+    "tool_call",
+    "tool_calls",
+    "tool-use",
+    "tool-uses",
+    "tool_use",
+    "tool_uses",
+}
+
 
 @dataclass(frozen=True)
 class OpenCodeMessageResult:
@@ -265,7 +276,12 @@ def extract_error_text(payload: Any) -> Optional[str]:
 def extract_visible_message_text(payload: Any) -> str:
     if not isinstance(payload, dict):
         return ""
-    parts_raw = payload.get("parts")
+    parts_raw = None
+    for container in _walk_nested_containers(payload):
+        candidate = container.get("parts")
+        if isinstance(candidate, list):
+            parts_raw = candidate
+            break
     text_parts: list[str] = []
     if isinstance(parts_raw, list):
         for part in parts_raw:
@@ -279,28 +295,44 @@ def extract_visible_message_text(payload: Any) -> str:
     return "".join(text_parts).strip()
 
 
+def _message_response_candidates(payload: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    yield payload
+    properties = payload.get("properties")
+    if isinstance(properties, dict):
+        yield properties
+    response = payload.get("response")
+    if isinstance(response, dict):
+        yield response
+
+
 def parse_message_response(payload: Any) -> OpenCodeMessageResult:
-    decoded = _decode_message_response(payload)
-    text = decoded.get("text")
-    error = decoded.get("error")
-    if isinstance(text, str) and text:
-        return OpenCodeMessageResult(text=text.strip(), error=error)
     if not isinstance(payload, dict):
         return OpenCodeMessageResult(text="")
-    info = payload.get("info")
-    error = error or extract_error_text(info) or extract_error_text(payload)
-    parts_raw = payload.get("parts")
-    text_parts: list[str] = []
-    if isinstance(parts_raw, list):
-        for part in parts_raw:
-            if not isinstance(part, dict):
-                continue
-            if part.get("type") != "text":
-                continue
-            text = part.get("text")
-            if isinstance(text, str) and text:
-                text_parts.append(text)
-    return OpenCodeMessageResult(text="".join(text_parts).strip(), error=error)
+    error: Optional[str] = None
+    for candidate in _message_response_candidates(payload):
+        decoded = _decode_message_response(candidate)
+        text = decoded.get("text")
+        candidate_error = decoded.get("error")
+        if isinstance(candidate_error, str) and candidate_error and error is None:
+            error = candidate_error
+        if isinstance(text, str) and text:
+            return OpenCodeMessageResult(text=text.strip(), error=error)
+        info = candidate.get("info")
+        error = error or extract_error_text(info) or extract_error_text(candidate)
+        parts_raw = candidate.get("parts")
+        text_parts: list[str] = []
+        if isinstance(parts_raw, list):
+            for part in parts_raw:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") != "text":
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    text_parts.append(text)
+        if text_parts:
+            return OpenCodeMessageResult(text="".join(text_parts).strip(), error=error)
+    return OpenCodeMessageResult(text="", error=error)
 
 
 def recover_last_assistant_message(
@@ -386,6 +418,45 @@ def extract_message_phase(payload: Any) -> Optional[str]:
             if phase is not None:
                 return phase
     return None
+
+
+def normalize_message_finish(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def extract_message_finish(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    for container in _walk_nested_containers(payload, include_parts=True):
+        finish = normalize_message_finish(
+            container.get("finish")
+            or container.get("finishReason")
+            or container.get("finish_reason")
+            or container.get("stopReason")
+            or container.get("stop_reason")
+        )
+        if finish is not None:
+            return finish
+    return None
+
+
+def message_completion_is_turn_terminal(payload: Any) -> bool:
+    """Whether an OpenCode assistant message completion can end the turn.
+
+    OpenCode emits ``message.completed`` for assistant messages whose finish
+    reason is ``tool-calls``. Those messages are checkpoints before tool
+    execution, not terminal assistant answers.
+    """
+
+    if extract_message_phase(payload) == "commentary":
+        return False
+    finish = extract_message_finish(payload)
+    if finish in OPENCODE_TOOL_CALL_FINISH_VALUES:
+        return False
+    return True
 
 
 def extract_permission_request(payload: Any) -> tuple[Optional[str], dict[str, Any]]:

--- a/src/codex_autorunner/agents/opencode/protocol_payload.py
+++ b/src/codex_autorunner/agents/opencode/protocol_payload.py
@@ -45,6 +45,17 @@ OPENCODE_IDLE_STATUS_VALUES = {
     "success",
 }
 
+OPENCODE_TOOL_CALL_FINISH_VALUES = {
+    "tool-call",
+    "tool-calls",
+    "tool_call",
+    "tool_calls",
+    "tool-use",
+    "tool-uses",
+    "tool_use",
+    "tool_uses",
+}
+
 
 @dataclass(frozen=True)
 class OpenCodeMessageResult:
@@ -265,7 +276,12 @@ def extract_error_text(payload: Any) -> Optional[str]:
 def extract_visible_message_text(payload: Any) -> str:
     if not isinstance(payload, dict):
         return ""
-    parts_raw = payload.get("parts")
+    parts_raw = None
+    for container in _walk_nested_containers(payload):
+        candidate = container.get("parts")
+        if isinstance(candidate, list):
+            parts_raw = candidate
+            break
     text_parts: list[str] = []
     if isinstance(parts_raw, list):
         for part in parts_raw:
@@ -279,28 +295,44 @@ def extract_visible_message_text(payload: Any) -> str:
     return "".join(text_parts).strip()
 
 
+def _message_response_candidates(payload: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    yield payload
+    properties = payload.get("properties")
+    if isinstance(properties, dict):
+        yield properties
+    response = payload.get("response")
+    if isinstance(response, dict):
+        yield response
+
+
 def parse_message_response(payload: Any) -> OpenCodeMessageResult:
-    decoded = _decode_message_response(payload)
-    text = decoded.get("text")
-    error = decoded.get("error")
-    if isinstance(text, str) and text:
-        return OpenCodeMessageResult(text=text.strip(), error=error)
     if not isinstance(payload, dict):
         return OpenCodeMessageResult(text="")
-    info = payload.get("info")
-    error = error or extract_error_text(info) or extract_error_text(payload)
-    parts_raw = payload.get("parts")
-    text_parts: list[str] = []
-    if isinstance(parts_raw, list):
-        for part in parts_raw:
-            if not isinstance(part, dict):
-                continue
-            if part.get("type") != "text":
-                continue
-            text = part.get("text")
-            if isinstance(text, str) and text:
-                text_parts.append(text)
-    return OpenCodeMessageResult(text="".join(text_parts).strip(), error=error)
+    error: Optional[str] = None
+    for candidate in _message_response_candidates(payload):
+        decoded = _decode_message_response(candidate)
+        text = decoded.get("text")
+        candidate_error = decoded.get("error")
+        if isinstance(candidate_error, str) and candidate_error and error is None:
+            error = candidate_error
+        if isinstance(text, str) and text:
+            return OpenCodeMessageResult(text=text.strip(), error=error)
+        info = candidate.get("info")
+        error = error or extract_error_text(info) or extract_error_text(candidate)
+        parts_raw = candidate.get("parts")
+        text_parts: list[str] = []
+        if isinstance(parts_raw, list):
+            for part in parts_raw:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") != "text":
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    text_parts.append(text)
+        if text_parts:
+            return OpenCodeMessageResult(text="".join(text_parts).strip(), error=error)
+    return OpenCodeMessageResult(text="", error=error)
 
 
 def recover_last_assistant_message(
@@ -386,6 +418,45 @@ def extract_message_phase(payload: Any) -> Optional[str]:
             if phase is not None:
                 return phase
     return None
+
+
+def normalize_message_finish(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def extract_message_finish(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    for container in _walk_nested_containers(payload):
+        finish = normalize_message_finish(
+            container.get("finish")
+            or container.get("finishReason")
+            or container.get("finish_reason")
+            or container.get("stopReason")
+            or container.get("stop_reason")
+        )
+        if finish is not None:
+            return finish
+    return None
+
+
+def message_completion_is_turn_terminal(payload: Any) -> bool:
+    """Whether an OpenCode assistant message completion can end the turn.
+
+    OpenCode emits ``message.completed`` for assistant messages whose finish
+    reason is ``tool-calls``. Those messages are checkpoints before tool
+    execution, not terminal assistant answers.
+    """
+
+    if extract_message_phase(payload) == "commentary":
+        return False
+    finish = extract_message_finish(payload)
+    if finish in OPENCODE_TOOL_CALL_FINISH_VALUES:
+        return False
+    return True
 
 
 def extract_permission_request(payload: Any) -> tuple[Optional[str], dict[str, Any]]:

--- a/src/codex_autorunner/agents/opencode/protocol_payload.py
+++ b/src/codex_autorunner/agents/opencode/protocol_payload.py
@@ -430,7 +430,7 @@ def normalize_message_finish(value: Any) -> Optional[str]:
 def extract_message_finish(payload: Any) -> Optional[str]:
     if not isinstance(payload, dict):
         return None
-    for container in _walk_nested_containers(payload, include_parts=True):
+    for container in _walk_nested_containers(payload):
         finish = normalize_message_finish(
             container.get("finish")
             or container.get("finishReason")

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -46,7 +46,6 @@ from .protocol_payload import (
     build_turn_id,
     extract_delta_text_value,
     extract_error_text,
-    extract_message_phase,
     extract_part_and_delta,
     extract_permission_request,
     extract_question_request,
@@ -55,6 +54,7 @@ from .protocol_payload import (
     extract_turn_id,
     format_permission_prompt,
     map_approval_policy_to_permission,
+    message_completion_is_turn_terminal,
     normalize_permission_decision,
     normalize_question_answers,
     normalize_question_policy,
@@ -633,9 +633,8 @@ async def collect_opencode_output_from_events(
                 )
             if event.event == "message.completed" and is_primary_session:
                 assembler.on_primary_assistant_completion(payload, message_role)
-                if (
-                    message_role == "assistant"
-                    and extract_message_phase(payload) != "commentary"
+                if message_role == "assistant" and message_completion_is_turn_terminal(
+                    payload
                 ):
                     lifecycle.on_primary_completion()
             if event.event == "session.idle" or (

--- a/src/codex_autorunner/agents/opencode/turn_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/turn_lifecycle.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Literal, Optional
 from .protocol_payload import (
     extract_message_phase,
     extract_status_type,
+    message_completion_is_turn_terminal,
     parse_message_response,
     status_is_idle,
 )
@@ -89,7 +90,7 @@ def terminal_signal_from_event(method: str, params: dict[str, Any]) -> Optional[
         return "session.idle"
     if method == "session.status" and status_is_idle(extract_status_type(params)):
         return "session.status:idle"
-    if method == "message.completed" and extract_message_phase(params) != "commentary":
+    if method == "message.completed" and message_completion_is_turn_terminal(params):
         return "message.completed"
     if method == "item/completed":
         item = params.get("item")

--- a/tests/agents/opencode/test_output_assembly.py
+++ b/tests/agents/opencode/test_output_assembly.py
@@ -777,6 +777,316 @@ async def test_multi_message_turn_prefers_last_completed() -> None:
 
 
 @pytest.mark.anyio
+async def test_tool_call_completion_does_not_override_final_text() -> None:
+    asm = OutputAssembler(session_id="s1")
+
+    asm.on_primary_assistant_completion(
+        {
+            "info": {"id": "m1", "role": "assistant", "finish": "tool-calls"},
+            "parts": [{"type": "text", "text": "Let me retry."}],
+        },
+        message_role="assistant",
+    )
+    asm.on_primary_assistant_completion(
+        {
+            "info": {"id": "m2", "role": "assistant", "finish": "stop"},
+            "parts": [{"type": "text", "text": "Done."}],
+        },
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Done."
+
+
+@pytest.mark.anyio
+async def test_tool_call_checkpoint_stream_excluded_from_final_stream_fallback() -> (
+    None
+):
+    asm = OutputAssembler(session_id="s1")
+
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "m1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+    await asm.on_text_delta(
+        part_message_id="m1",
+        delta_text="Let me check.",
+        part_id="p1",
+        part_dict=None,
+    )
+    asm.on_message_completed(
+        {
+            "info": {"id": "m1", "role": "assistant", "finish": "tool-calls"},
+            "parts": [{"type": "text", "text": "Let me check."}],
+        },
+        is_primary_session=True,
+        event_session_id="s1",
+    )
+    asm.on_primary_assistant_completion(
+        {
+            "info": {"id": "m1", "role": "assistant", "finish": "tool-calls"},
+            "parts": [{"type": "text", "text": "Let me check."}],
+        },
+        message_role="assistant",
+    )
+
+    msg_id2, role2 = asm.on_register_message_role(
+        {"info": {"id": "m2", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id2, role2)
+    await asm.on_text_delta(
+        part_message_id="m2",
+        delta_text="Final answer.",
+        part_id="p2",
+        part_dict=None,
+    )
+    asm.on_message_completed(
+        {"info": {"id": "m2", "role": "assistant", "finish": "stop"}, "parts": []},
+        is_primary_session=True,
+        event_session_id="s1",
+    )
+    asm.on_primary_assistant_completion(
+        {"info": {"id": "m2", "role": "assistant", "finish": "stop"}, "parts": []},
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Final answer."
+
+
+@pytest.mark.anyio
+async def test_tool_call_checkpoint_stream_not_used_when_final_has_no_stream() -> None:
+    asm = OutputAssembler(session_id="s1")
+
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "m1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+    await asm.on_text_delta(
+        part_message_id="m1",
+        delta_text="Let me check.",
+        part_id="p1",
+        part_dict=None,
+    )
+    asm.on_primary_assistant_completion(
+        {
+            "info": {"id": "m1", "role": "assistant", "finish": "tool-calls"},
+            "parts": [{"type": "text", "text": "Let me check."}],
+        },
+        message_role="assistant",
+    )
+
+    msg_id2, role2 = asm.on_register_message_role(
+        {"info": {"id": "m2", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id2, role2)
+    asm.on_primary_assistant_completion(
+        {"info": {"id": "m2", "role": "assistant", "finish": "stop"}, "parts": []},
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == ""
+
+
+@pytest.mark.anyio
+async def test_completed_message_text_preferred_over_spaced_stream_text() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "m1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+
+    for delta in (
+        "The single failure is a known fl",
+        "aky test in `",
+        "py",
+        "project",
+        ".tom",
+        "l",
+        "`.",
+    ):
+        await asm.on_text_delta(
+            part_message_id="m1",
+            delta_text=delta,
+            part_id="p1",
+            part_dict=None,
+        )
+
+    asm.on_primary_assistant_completion(
+        {
+            "properties": {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "The single failure is a known flaky test in `pyproject.toml`.",
+                    }
+                ],
+            }
+        },
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert (
+        result.text == "The single failure is a known flaky test in `pyproject.toml`."
+    )
+
+
+@pytest.mark.anyio
+async def test_stream_text_preferred_over_spaced_completed_token_text() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "m1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+
+    await asm.on_text_delta(
+        part_message_id="m1",
+        delta_text="CAR_OPENCODE_PROBE_24db408dd3fd",
+        part_id="p1",
+        part_dict=None,
+    )
+
+    asm.on_primary_assistant_completion(
+        {
+            "properties": {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "CAR_OPENCODE_PROBE_24 db 408 dd 3 fd",
+                    }
+                ],
+            }
+        },
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "CAR_OPENCODE_PROBE_24db408dd3fd"
+
+
+@pytest.mark.anyio
+async def test_spaced_completed_text_recovers_clean_message_snapshot() -> None:
+    async def fetch_messages() -> list[dict[str, object]]:
+        return [
+            {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "CAR_OPENCODE_PROBE_ff2aabeb1b46",
+                    }
+                ],
+            }
+        ]
+
+    asm = OutputAssembler(session_id="s1", messages_fetcher=fetch_messages)
+    asm.on_primary_assistant_completion(
+        {
+            "properties": {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "CAR_OPENCODE_PROBE_ff 2 aab eb 1 b 46",
+                    }
+                ],
+            }
+        },
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "CAR_OPENCODE_PROBE_ff2aabeb1b46"
+    assert result.output_source == "messages_snapshot"
+
+
+@pytest.mark.anyio
+async def test_spaced_fallback_text_recovers_clean_message_snapshot() -> None:
+    async def fetch_messages() -> list[dict[str, object]]:
+        return [
+            {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "CAR_OPENCODE_PROBE_c25ba7e696ea",
+                    }
+                ],
+            }
+        ]
+
+    asm = OutputAssembler(session_id="s1", messages_fetcher=fetch_messages)
+    asm.on_message_completed(
+        {
+            "properties": {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "CAR_OPENCODE_PROBE_c 25 ba 7 e 696 ea",
+                    }
+                ],
+            }
+        },
+        is_primary_session=True,
+        event_session_id="s1",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "CAR_OPENCODE_PROBE_c25ba7e696ea"
+    assert result.output_source == "messages_snapshot"
+
+
+@pytest.mark.anyio
+async def test_pending_stream_text_flushed_before_completed_fallback() -> None:
+    asm = OutputAssembler(session_id="s1")
+
+    await asm.on_text_delta(
+        part_message_id=None,
+        delta_text="`CAR_OPENCODE_PROBE_78ef622258f3`",
+        part_id="p1",
+        part_dict=None,
+    )
+    asm.on_message_completed(
+        {
+            "properties": {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "` CAR_OPENCODE_PROBE_78 ef 622258 f 3 `",
+                    }
+                ],
+            }
+        },
+        is_primary_session=True,
+        event_session_id="s1",
+    )
+    asm.on_primary_assistant_completion(
+        {
+            "properties": {
+                "info": {"id": "m1", "role": "assistant", "finish": "stop"},
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "` CAR_OPENCODE_PROBE_78 ef 622258 f 3 `",
+                    }
+                ],
+            }
+        },
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "`CAR_OPENCODE_PROBE_78ef622258f3`"
+
+
+@pytest.mark.anyio
 async def test_flush_pending_respects_roles_seen() -> None:
     asm = OutputAssembler(session_id="s1")
 

--- a/tests/agents/opencode/test_protocol_payload.py
+++ b/tests/agents/opencode/test_protocol_payload.py
@@ -13,12 +13,14 @@ from codex_autorunner.agents.opencode.protocol_payload import (
     OPENCODE_IDLE_STATUS_VALUES,
     extract_delta_text_value,
     extract_error_text,
+    extract_message_finish,
     extract_message_phase,
     extract_part_and_delta,
     extract_session_id,
     extract_status_type,
     extract_total_tokens,
     extract_usage_details,
+    message_completion_is_turn_terminal,
     normalize_message_phase,
     parse_message_response,
     prompt_echo_matches,
@@ -357,6 +359,29 @@ class TestExtractMessagePhase:
             "message": {"phase": "final_answer"},
         }
         assert extract_message_phase(payload) == "commentary"
+
+
+class TestExtractMessageFinish:
+    def test_properties_info_finish(self) -> None:
+        payload = {"properties": {"info": {"finish": "tool-calls"}}}
+        assert extract_message_finish(payload) == "tool-calls"
+
+    def test_part_stop_reason_does_not_shadow_message_finish(self) -> None:
+        payload = {
+            "properties": {
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "done",
+                        "stop_reason": "tool-calls",
+                    }
+                ],
+                "info": {"finish": "stop"},
+            }
+        }
+
+        assert extract_message_finish(payload) == "stop"
+        assert message_completion_is_turn_terminal(payload)
 
 
 class TestNormalizeMessagePhase:

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -245,6 +245,76 @@ async def test_collect_output_full_text_growth() -> None:
 
 
 @pytest.mark.anyio
+async def test_collect_output_does_not_stop_on_tool_call_message_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_POST_COMPLETION_GRACE_SECONDS",
+        0.0,
+    )
+
+    events = [
+        SSEEvent(
+            event="message.updated",
+            data='{"sessionID":"s1","properties":{"info":{"id":"m1","role":"assistant"}}}',
+        ),
+        SSEEvent(
+            event="message.part.delta",
+            data='{"sessionID":"s1","properties":{"partID":"p1","messageID":"m1",'
+            '"delta":{"text":"Let me retry."}}}',
+        ),
+        SSEEvent(
+            event="message.completed",
+            data=json.dumps(
+                {
+                    "sessionID": "s1",
+                    "properties": {
+                        "info": {
+                            "id": "m1",
+                            "role": "assistant",
+                            "finish": "tool-calls",
+                        },
+                        "parts": [{"type": "text", "text": "Let me retry."}],
+                    },
+                }
+            ),
+        ),
+        SSEEvent(
+            event="message.updated",
+            data='{"sessionID":"s1","properties":{"info":{"id":"m2","role":"assistant"}}}',
+        ),
+        SSEEvent(
+            event="message.part.delta",
+            data='{"sessionID":"s1","properties":{"partID":"p2","messageID":"m2",'
+            '"delta":{"text":"Done. Release complete."}}}',
+        ),
+        SSEEvent(
+            event="message.completed",
+            data=json.dumps(
+                {
+                    "sessionID": "s1",
+                    "properties": {
+                        "info": {"id": "m2", "role": "assistant", "finish": "stop"},
+                        "parts": [{"type": "text", "text": "Done. Release complete."}],
+                    },
+                }
+            ),
+        ),
+        SSEEvent(event="session.idle", data='{"sessionID":"s1"}'),
+    ]
+
+    output = await collect_opencode_output_from_events(
+        _iter_events(events),
+        session_id="s1",
+    )
+
+    assert output.text == "Done. Release complete."
+    assert output.terminal_signal == "message.completed"
+    assert output.error is None
+
+
+@pytest.mark.anyio
 async def test_collect_output_session_error() -> None:
     events = [
         SSEEvent(


### PR DESCRIPTION
## Summary
- Treat OpenCode assistant message completions with finish=tool-calls as non-terminal so CAR waits through tool execution to the real final answer.
- Parse nested completed-message payloads and recover clean final text from streamed text or the message snapshot when OpenCode emits token-boundary whitespace artifacts.
- Add regression coverage for tool-call completions, nested completed-message text, and spacing recovery paths.

## Validation
- Real OpenCode probe against opencode serve on localhost: shell-tool turn read a nonce file and completed with clean final output: CAR_OPENCODE_PROBE_4c8d9efd7951; tool log lines included bash execution.
- .venv/bin/python -m pytest -q tests/test_opencode_runtime.py tests/agents/opencode/test_output_assembly.py tests/agents/opencode/test_turn_runtime.py
- .venv/bin/python -m ruff check src/codex_autorunner/agents/opencode tests/test_opencode_runtime.py tests/agents/opencode/test_output_assembly.py
- Commit hook aggregate lane passed: guardrails, ruff, mypy, repo pytest, frontend build, frontend tests.