### PR TITLE
[codex] Fix OpenCode question tool turn handling

### DIFF
--- a/src/codex_autorunner/adapters/agents/opencode_backend.py
+++ b/src/codex_autorunner/adapters/agents/opencode_backend.py
@@ -508,10 +508,10 @@ class OpenCodeBackend(AgentBackend):
                     effective_runtime=output_result.effective_runtime,
                 )
 
-            if output_result.text:
-                yield Completed(timestamp=now_iso(), final_message=output_result.text)
-            elif output_result.error:
+            if output_result.error:
                 yield Failed(timestamp=now_iso(), error_message=output_result.error)
+            elif output_result.text:
+                yield Completed(timestamp=now_iso(), final_message=output_result.text)
             else:
                 yield Completed(timestamp=now_iso(), final_message="")
         finally:

--- a/src/codex_autorunner/agents/opencode/protocol_payload.py
+++ b/src/codex_autorunner/agents/opencode/protocol_payload.py
@@ -532,6 +532,58 @@ def extract_question_request(payload: Any) -> tuple[Optional[str], dict[str, Any
     return request_id, props
 
 
+def extract_question_tool_request(
+    part: Any,
+) -> tuple[Optional[str], dict[str, Any], Optional[str], Optional[str]]:
+    """Extract a question request encoded as an OpenCode tool part.
+
+    Some OpenCode builds expose the user-input helper as a normal ``tool`` part
+    named ``question`` instead of a top-level ``question.asked`` event.  The
+    request payload lives under ``state.input.questions`` and the part id is the
+    only stable request identifier in the stream.
+    """
+
+    if not isinstance(part, dict):
+        return None, {}, None, None
+    if part.get("type") != "tool" or part.get("tool") != "question":
+        return None, {}, None, None
+
+    state = part.get("state")
+    state_payload = state if isinstance(state, dict) else {}
+    input_payload = state_payload.get("input")
+    if not isinstance(input_payload, dict):
+        input_payload = part.get("input")
+    if not isinstance(input_payload, dict):
+        input_payload = {}
+
+    request_id = None
+    for container in (state_payload, input_payload, part):
+        if not isinstance(container, dict):
+            continue
+        for key in ("id", "requestID", "requestId"):
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                request_id = value.strip()
+                break
+        if request_id:
+            break
+
+    questions = _normalize_questions(input_payload.get("questions"))
+    props = dict(input_payload)
+    props["questions"] = questions
+    if request_id:
+        props["id"] = request_id
+    props["source"] = "tool_part"
+
+    status_raw = state_payload.get("status")
+    status = status_raw.strip().lower() if isinstance(status_raw, str) else None
+    error_raw = state_payload.get("error")
+    error = (
+        error_raw.strip() if isinstance(error_raw, str) and error_raw.strip() else None
+    )
+    return request_id, props, status, error
+
+
 def extract_question_option_label(option: Any) -> Optional[str]:
     if isinstance(option, str):
         return option.strip() or None

--- a/src/codex_autorunner/agents/opencode/protocol_payload.py
+++ b/src/codex_autorunner/agents/opencode/protocol_payload.py
@@ -539,8 +539,9 @@ def extract_question_tool_request(
 
     Some OpenCode builds expose the user-input helper as a normal ``tool`` part
     named ``question`` instead of a top-level ``question.asked`` event.  The
-    request payload lives under ``state.input.questions`` and the part id is the
-    only stable request identifier in the stream.
+    request payload lives under ``state.input.questions``.  The request id must
+    come from the question state/input payload; the tool part id identifies only
+    the rendered part and is not valid for ``/question/{requestID}/reply``.
     """
 
     if not isinstance(part, dict):

--- a/src/codex_autorunner/agents/opencode/protocol_payload.py
+++ b/src/codex_autorunner/agents/opencode/protocol_payload.py
@@ -557,7 +557,7 @@ def extract_question_tool_request(
         input_payload = {}
 
     request_id = None
-    for container in (state_payload, input_payload, part):
+    for container in (state_payload, input_payload):
         if not isinstance(container, dict):
             continue
         for key in ("id", "requestID", "requestId"):

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -282,6 +282,8 @@ async def collect_opencode_output_from_events(
 
     terminal_signal: Optional[str] = None
     fatal_question_tool_error: Optional[str] = None
+    terminal_assistant_completion_seen = False
+    nonterminal_assistant_checkpoint_seen = False
 
     async def _handle_question_request(
         request_id: Optional[str],
@@ -620,6 +622,12 @@ async def collect_opencode_output_from_events(
                             assembler.error = fatal_question_tool_error
                             break
                         if question_status not in {"completed", "complete", "success"}:
+                            if not question_request_id:
+                                fatal_question_tool_error = (
+                                    "OpenCode question tool missing request id"
+                                )
+                                assembler.error = fatal_question_tool_error
+                                break
                             await _handle_question_request(
                                 question_request_id,
                                 question_props,
@@ -692,9 +700,15 @@ async def collect_opencode_output_from_events(
                 )
             if event.event == "message.completed" and is_primary_session:
                 assembler.on_primary_assistant_completion(payload, message_role)
-                if message_role == "assistant" and message_completion_is_turn_terminal(
-                    payload
+                completion_is_terminal = message_completion_is_turn_terminal(payload)
+                if message_role in {"assistant", None} and completion_is_terminal:
+                    terminal_assistant_completion_seen = True
+                elif (
+                    message_role in {"assistant", None}
+                    and parse_message_response(payload).text
                 ):
+                    nonterminal_assistant_checkpoint_seen = True
+                if message_role == "assistant" and completion_is_terminal:
                     lifecycle.on_primary_completion()
             if event.event == "session.idle" or (
                 event.event == "session.status"
@@ -731,6 +745,20 @@ async def collect_opencode_output_from_events(
             output_source=result.output_source,
             effective_runtime=result.effective_runtime,
         )
+    elif (
+        result.text
+        and result.output_source == "event_stream"
+        and nonterminal_assistant_checkpoint_seen
+        and not terminal_assistant_completion_seen
+    ):
+        error = "OpenCode turn ended without terminal assistant message"
+        result = OutputAssemblyResult(
+            text="",
+            error=error,
+            usage=result.usage,
+            output_source=result.output_source,
+            effective_runtime=result.effective_runtime,
+        )
     if (
         error
         and error.startswith(_OPENCODE_FIRST_EVENT_TIMEOUT_REASON)
@@ -738,6 +766,14 @@ async def collect_opencode_output_from_events(
         and result.text
     ):
         error = None
+    if error and result.text:
+        result = OutputAssemblyResult(
+            text="",
+            error=error,
+            usage=result.usage,
+            output_source=result.output_source,
+            effective_runtime=result.effective_runtime,
+        )
     return OpenCodeTurnOutput(
         text=result.text,
         error=error,

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -35,7 +35,7 @@ from .event_fields import (
 from .event_fields import (
     extract_part_message_id as extract_event_part_message_id,
 )
-from .output_assembly import OutputAssembler
+from .output_assembly import OutputAssembler, OutputAssemblyResult
 from .protocol_payload import (
     OPENCODE_PERMISSION_REJECT,
     PERMISSION_ALLOW,
@@ -49,6 +49,7 @@ from .protocol_payload import (
     extract_part_and_delta,
     extract_permission_request,
     extract_question_request,
+    extract_question_tool_request,
     extract_session_id,
     extract_status_type,
     extract_turn_id,
@@ -280,6 +281,149 @@ async def collect_opencode_output_from_events(
         raise ValueError("events or event_stream_factory must be provided")
 
     terminal_signal: Optional[str] = None
+    fatal_question_tool_error: Optional[str] = None
+
+    async def _handle_question_request(
+        request_id: Optional[str],
+        props: dict[str, Any],
+        *,
+        event_session_id: Optional[str],
+        source: str,
+    ) -> None:
+        nonlocal fatal_question_tool_error
+        questions = props.get("questions") if isinstance(props, dict) else []
+        question_count = len(questions) if isinstance(questions, list) else 0
+        log_event(
+            logger,
+            logging.INFO,
+            "opencode.question.asked",
+            request_id=request_id,
+            question_count=question_count,
+            session_id=event_session_id,
+            source=source,
+        )
+        if not request_id:
+            return
+        dedupe_key = (event_session_id, request_id)
+        if dedupe_key in seen_question_request_ids:
+            return
+        seen_question_request_ids.add(dedupe_key)
+        if question_handler is not None:
+            try:
+                answers = await question_handler(request_id, props)
+            except Exception as exc:  # intentional: pluggable callback handler
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "opencode.question.auto_reply_failed",
+                    request_id=request_id,
+                    session_id=event_session_id,
+                    source=source,
+                    exc=exc,
+                )
+                if reject_question is not None:
+                    try:
+                        await reject_question(request_id)
+                    except (OSError, RuntimeError, ValueError):
+                        logger.debug(
+                            "reject_question after auto_reply_failed failed",
+                            exc_info=True,
+                        )
+                return
+            if answers is None:
+                if reject_question is not None:
+                    try:
+                        await reject_question(request_id)
+                    except (OSError, RuntimeError, ValueError):
+                        logger.debug(
+                            "reject_question for null answers failed",
+                            exc_info=True,
+                        )
+                return
+            normalized_answers = normalize_question_answers(
+                answers, question_count=question_count
+            )
+            if reply_question is not None:
+                try:
+                    await reply_question(request_id, normalized_answers)
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        "opencode.question.replied",
+                        request_id=request_id,
+                        question_count=question_count,
+                        session_id=event_session_id,
+                        mode="handler",
+                        source=source,
+                    )
+                except (OSError, RuntimeError, ValueError) as exc:
+                    log_event(
+                        logger,
+                        logging.WARNING,
+                        "opencode.question.auto_reply_failed",
+                        request_id=request_id,
+                        session_id=event_session_id,
+                        source=source,
+                        exc=exc,
+                    )
+                    if source == "tool_part":
+                        fatal_question_tool_error = (
+                            "OpenCode question reply failed: " f"{exc}"
+                        )
+            return
+        if normalized_question_policy == "ignore":
+            return
+        if normalized_question_policy == "reject":
+            if reject_question is not None:
+                try:
+                    await reject_question(request_id)
+                except (OSError, RuntimeError, ValueError) as exc:
+                    log_event(
+                        logger,
+                        logging.WARNING,
+                        "opencode.question.auto_reply_failed",
+                        request_id=request_id,
+                        session_id=event_session_id,
+                        source=source,
+                        exc=exc,
+                    )
+            return
+        auto_answers = auto_answers_for_questions(
+            questions if isinstance(questions, list) else [],
+            normalized_question_policy,
+        )
+        normalized_answers = normalize_question_answers(
+            auto_answers, question_count=question_count
+        )
+        if reply_question is not None:
+            try:
+                await reply_question(request_id, normalized_answers)
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "opencode.question.auto_replied",
+                    request_id=request_id,
+                    question_count=question_count,
+                    session_id=event_session_id,
+                    policy=normalized_question_policy,
+                    answers=summarize_question_answers(normalized_answers),
+                    source=source,
+                )
+            except (OSError, RuntimeError, ValueError) as exc:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "opencode.question.auto_reply_failed",
+                    request_id=request_id,
+                    session_id=event_session_id,
+                    source=source,
+                    exc=exc,
+                )
+                if source == "tool_part":
+                    fatal_question_tool_error = (
+                        "OpenCode question reply failed: " f"{exc}"
+                    )
+
     try:
         while True:
             if should_stop is not None and should_stop():
@@ -358,123 +502,12 @@ async def collect_opencode_output_from_events(
             is_primary_session = event_session_id == session_id or not event_session_id
             if event.event == "question.asked":
                 request_id, props = extract_question_request(payload)
-                questions = props.get("questions") if isinstance(props, dict) else []
-                question_count = len(questions) if isinstance(questions, list) else 0
-                log_event(
-                    logger,
-                    logging.INFO,
-                    "opencode.question.asked",
-                    request_id=request_id,
-                    question_count=question_count,
-                    session_id=event_session_id,
+                await _handle_question_request(
+                    request_id,
+                    props,
+                    event_session_id=event_session_id,
+                    source="event",
                 )
-                if not request_id:
-                    continue
-                dedupe_key = (event_session_id, request_id)
-                if dedupe_key in seen_question_request_ids:
-                    continue
-                seen_question_request_ids.add(dedupe_key)
-                if question_handler is not None:
-                    try:
-                        answers = await question_handler(request_id, props)
-                    except Exception as exc:  # intentional: pluggable callback handler
-                        log_event(
-                            logger,
-                            logging.WARNING,
-                            "opencode.question.auto_reply_failed",
-                            request_id=request_id,
-                            session_id=event_session_id,
-                            exc=exc,
-                        )
-                        if reject_question is not None:
-                            try:
-                                await reject_question(request_id)
-                            except (OSError, RuntimeError, ValueError):
-                                logger.debug(
-                                    "reject_question after auto_reply_failed failed",
-                                    exc_info=True,
-                                )
-                        continue
-                    if answers is None:
-                        if reject_question is not None:
-                            try:
-                                await reject_question(request_id)
-                            except (OSError, RuntimeError, ValueError):
-                                logger.debug(
-                                    "reject_question for null answers failed",
-                                    exc_info=True,
-                                )
-                        continue
-                    normalized_answers = normalize_question_answers(
-                        answers, question_count=question_count
-                    )
-                    if reply_question is not None:
-                        try:
-                            await reply_question(request_id, normalized_answers)
-                            log_event(
-                                logger,
-                                logging.INFO,
-                                "opencode.question.replied",
-                                request_id=request_id,
-                                question_count=question_count,
-                                session_id=event_session_id,
-                                mode="handler",
-                            )
-                        except (OSError, RuntimeError, ValueError) as exc:
-                            log_event(
-                                logger,
-                                logging.WARNING,
-                                "opencode.question.auto_reply_failed",
-                                request_id=request_id,
-                                session_id=event_session_id,
-                                exc=exc,
-                            )
-                    continue
-                if normalized_question_policy == "ignore":
-                    continue
-                if normalized_question_policy == "reject":
-                    if reject_question is not None:
-                        try:
-                            await reject_question(request_id)
-                        except (OSError, RuntimeError, ValueError) as exc:
-                            log_event(
-                                logger,
-                                logging.WARNING,
-                                "opencode.question.auto_reply_failed",
-                                request_id=request_id,
-                                session_id=event_session_id,
-                                exc=exc,
-                            )
-                    continue
-                auto_answers = auto_answers_for_questions(
-                    questions if isinstance(questions, list) else [],
-                    normalized_question_policy,
-                )
-                normalized_answers = normalize_question_answers(
-                    auto_answers, question_count=question_count
-                )
-                if reply_question is not None:
-                    try:
-                        await reply_question(request_id, normalized_answers)
-                        log_event(
-                            logger,
-                            logging.INFO,
-                            "opencode.question.auto_replied",
-                            request_id=request_id,
-                            question_count=question_count,
-                            session_id=event_session_id,
-                            policy=normalized_question_policy,
-                            answers=summarize_question_answers(normalized_answers),
-                        )
-                    except (OSError, RuntimeError, ValueError) as exc:
-                        log_event(
-                            logger,
-                            logging.WARNING,
-                            "opencode.question.auto_reply_failed",
-                            request_id=request_id,
-                            session_id=event_session_id,
-                            exc=exc,
-                        )
                 continue
             if event.event == "permission.asked":
                 request_id, props = extract_permission_request(payload)
@@ -570,6 +603,32 @@ async def collect_opencode_output_from_events(
                     if isinstance(part_type, str)
                     else assembler.lookup_part_type(part_id)
                 )
+                if resolved_part_type == "tool" and isinstance(part_dict, dict):
+                    (
+                        question_request_id,
+                        question_props,
+                        question_status,
+                        question_error,
+                    ) = extract_question_tool_request(part_dict)
+                    if question_request_id or question_props:
+                        if question_status == "error":
+                            fatal_question_tool_error = "OpenCode question tool failed"
+                            if question_error:
+                                fatal_question_tool_error = (
+                                    f"{fatal_question_tool_error}: {question_error}"
+                                )
+                            assembler.error = fatal_question_tool_error
+                            break
+                        if question_status not in {"completed", "complete", "success"}:
+                            await _handle_question_request(
+                                question_request_id,
+                                question_props,
+                                event_session_id=event_session_id,
+                                source="tool_part",
+                            )
+                            if fatal_question_tool_error is not None:
+                                assembler.error = fatal_question_tool_error
+                                break
                 if part_with_session is None and (
                     isinstance(part_id, str)
                     or isinstance(part_message_id, str)
@@ -663,6 +722,15 @@ async def collect_opencode_output_from_events(
 
     result = await assembler.build_result()
     error = result.error
+    if fatal_question_tool_error:
+        error = fatal_question_tool_error
+        result = OutputAssemblyResult(
+            text="",
+            error=error,
+            usage=result.usage,
+            output_source=result.output_source,
+            effective_runtime=result.effective_runtime,
+        )
     if (
         error
         and error.startswith(_OPENCODE_FIRST_EVENT_TIMEOUT_REASON)

--- a/src/codex_autorunner/agents/opencode/turn_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/turn_lifecycle.py
@@ -135,7 +135,7 @@ def lifecycle_result_from_observation(
 
     return OpenCodeTurnLifecycleResult(
         state=state,
-        assistant_text=observation.assistant_text,
+        assistant_text="" if observation.error else observation.assistant_text,
         terminal_signal=terminal_signal,
         output_source=observation.output_source,
         command_completed=command_completed,

--- a/tests/agents/opencode/test_protocol_payload.py
+++ b/tests/agents/opencode/test_protocol_payload.py
@@ -509,6 +509,7 @@ class TestExtractQuestionToolRequest:
                 "type": "tool",
                 "tool": "question",
                 "state": {
+                    "id": "que_q1",
                     "status": "error",
                     "input": {
                         "questions": [
@@ -523,11 +524,29 @@ class TestExtractQuestionToolRequest:
             }
         )
 
-        assert request_id == "part-q1"
+        assert request_id == "que_q1"
         assert props["source"] == "tool_part"
         assert props["questions"][0]["question"] == "Continue?"
         assert status == "error"
         assert error == "The user dismissed this question"
+
+    def test_does_not_use_tool_part_id_as_request_id(self) -> None:
+        request_id, props, status, error = extract_question_tool_request(
+            {
+                "id": "prt_q1",
+                "type": "tool",
+                "tool": "question",
+                "state": {
+                    "status": "pending",
+                    "input": {"questions": [{"question": "Continue?"}]},
+                },
+            }
+        )
+
+        assert request_id is None
+        assert props["questions"][0]["question"] == "Continue?"
+        assert status == "pending"
+        assert error is None
 
     def test_ignores_non_question_tools(self) -> None:
         request_id, props, status, error = extract_question_tool_request(

--- a/tests/agents/opencode/test_protocol_payload.py
+++ b/tests/agents/opencode/test_protocol_payload.py
@@ -16,6 +16,7 @@ from codex_autorunner.agents.opencode.protocol_payload import (
     extract_message_finish,
     extract_message_phase,
     extract_part_and_delta,
+    extract_question_tool_request,
     extract_session_id,
     extract_status_type,
     extract_total_tokens,
@@ -498,6 +499,45 @@ class TestPromptEchoMatches:
 
     def test_non_string_text(self) -> None:
         assert prompt_echo_matches(42, prompt="hello") is False
+
+
+class TestExtractQuestionToolRequest:
+    def test_extracts_tool_part_question_payload(self) -> None:
+        request_id, props, status, error = extract_question_tool_request(
+            {
+                "id": "part-q1",
+                "type": "tool",
+                "tool": "question",
+                "state": {
+                    "status": "error",
+                    "input": {
+                        "questions": [
+                            {
+                                "question": "Continue?",
+                                "options": [{"label": "Yes"}, {"label": "No"}],
+                            }
+                        ]
+                    },
+                    "error": "The user dismissed this question",
+                },
+            }
+        )
+
+        assert request_id == "part-q1"
+        assert props["source"] == "tool_part"
+        assert props["questions"][0]["question"] == "Continue?"
+        assert status == "error"
+        assert error == "The user dismissed this question"
+
+    def test_ignores_non_question_tools(self) -> None:
+        request_id, props, status, error = extract_question_tool_request(
+            {"id": "part-1", "type": "tool", "tool": "bash"}
+        )
+
+        assert request_id is None
+        assert props == {}
+        assert status is None
+        assert error is None
 
 
 class TestExtractTotalTokens:

--- a/tests/agents/opencode/test_turn_lifecycle.py
+++ b/tests/agents/opencode/test_turn_lifecycle.py
@@ -134,6 +134,25 @@ def test_lifecycle_snapshot_recovery_is_explicit() -> None:
     assert result.output_source == "messages_snapshot"
 
 
+def test_lifecycle_failed_observation_does_not_preserve_assistant_text() -> None:
+    result = lifecycle_result_from_observation(
+        OpenCodeTurnObservation(
+            assistant_text="partial text",
+            error="boom",
+            output_source="event_stream",
+            terminal_signal="session.error",
+        ),
+        raw_events=[],
+        command_completed=True,
+        command_accepted_before_terminal=True,
+        collector_completed=True,
+    )
+
+    assert result.state == OpenCodeTurnLifecycleState.FAILED
+    assert result.assistant_text == ""
+    assert result.error == "boom"
+
+
 @pytest.mark.asyncio
 async def test_lifecycle_marks_command_completed_when_failure_follows_collect() -> None:
     async def _command() -> None:

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -300,6 +300,151 @@ async def test_turn_runtime_collector_fails_failed_question_tool_part() -> None:
 
 
 @pytest.mark.asyncio
+async def test_turn_runtime_collector_fails_question_tool_part_missing_request_id() -> (
+    None
+):
+    async def _events():
+        yield SSEEvent(
+            event="message.part.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "prt-q1",
+                            "type": "tool",
+                            "tool": "question",
+                            "state": {
+                                "status": "pending",
+                                "input": {
+                                    "questions": [{"question": "Continue?"}],
+                                },
+                            },
+                        }
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="session.status",
+            data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+        )
+
+    output = await collect_opencode_output_from_events(
+        _events(),
+        session_id="session-1",
+    )
+
+    assert output.text == ""
+    assert output.error == "OpenCode question tool missing request id"
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_collector_error_clears_partial_text() -> None:
+    async def _events():
+        yield SSEEvent(
+            event="message.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "info": {"id": "msg-1", "role": "assistant"},
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="message.part.delta",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "text-1",
+                            "messageID": "msg-1",
+                            "type": "text",
+                        },
+                        "delta": {"text": "partial"},
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="session.error",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "error": {"message": "boom"},
+                }
+            ),
+        )
+
+    output = await collect_opencode_output_from_events(
+        _events(),
+        session_id="session-1",
+    )
+
+    assert output.text == ""
+    assert output.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_idle_after_only_tool_call_checkpoint_is_not_final_output() -> (
+    None
+):
+    async def _events():
+        yield SSEEvent(
+            event="message.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "info": {"id": "msg-1", "role": "assistant"},
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="message.part.delta",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "text-1",
+                            "messageID": "msg-1",
+                            "type": "text",
+                        },
+                        "delta": {"text": "Let me check."},
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="message.completed",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "info": {
+                        "id": "msg-1",
+                        "role": "assistant",
+                        "finish": "tool-calls",
+                    },
+                    "parts": [{"type": "text", "text": "Let me check."}],
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="session.status",
+            data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+        )
+
+    output = await collect_opencode_output_from_events(
+        _events(),
+        session_id="session-1",
+    )
+
+    assert output.text == ""
+    assert output.error == "OpenCode turn ended without terminal assistant message"
+
+
+@pytest.mark.asyncio
 async def test_turn_runtime_cancels_preconnected_stream_once(tmp_path: Path) -> None:
     client = _HangingStreamClient()
     stream = await pre_connect_event_stream(client, tmp_path, "session-1")

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -185,6 +185,7 @@ async def test_turn_runtime_collector_handles_question_tool_part() -> None:
                             "type": "tool",
                             "tool": "question",
                             "state": {
+                                "id": "que-q1",
                                 "status": "pending",
                                 "input": {
                                     "questions": [
@@ -215,7 +216,7 @@ async def test_turn_runtime_collector_handles_question_tool_part() -> None:
     )
 
     assert output.error is None
-    assert question_answers == [("part-q1", [["Yes"]])]
+    assert question_answers == [("que-q1", [["Yes"]])]
 
 
 @pytest.mark.asyncio

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
@@ -169,6 +170,135 @@ async def test_turn_runtime_collector_normalizes_permission_and_question_policy(
 
 
 @pytest.mark.asyncio
+async def test_turn_runtime_collector_handles_question_tool_part() -> None:
+    question_answers: list[tuple[str, list[list[str]]]] = []
+
+    async def _events():
+        yield SSEEvent(
+            event="message.part.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "part-q1",
+                            "type": "tool",
+                            "tool": "question",
+                            "state": {
+                                "status": "pending",
+                                "input": {
+                                    "questions": [
+                                        {
+                                            "question": "Continue?",
+                                            "options": [{"label": "Yes"}],
+                                        }
+                                    ]
+                                },
+                            },
+                        }
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="session.status",
+            data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+        )
+
+    output = await collect_opencode_output_from_events(
+        _events(),
+        session_id="session-1",
+        question_handler=lambda request_id, props: _answer_question(request_id, props),
+        reply_question=lambda request_id, answers: _record_question_answer(
+            question_answers, request_id, answers
+        ),
+    )
+
+    assert output.error is None
+    assert question_answers == [("part-q1", [["Yes"]])]
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_collector_fails_failed_question_tool_part() -> None:
+    async def _events():
+        yield SSEEvent(
+            event="message.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "info": {"id": "msg-1", "role": "assistant"},
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="message.part.delta",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "text-1",
+                            "messageID": "msg-1",
+                            "type": "text",
+                        },
+                        "delta": {"text": "Let me check first."},
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="message.completed",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "info": {
+                        "id": "msg-1",
+                        "role": "assistant",
+                        "finish": "tool-calls",
+                    },
+                    "parts": [{"type": "text", "text": "Let me check first."}],
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="message.part.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "part-q1",
+                            "type": "tool",
+                            "tool": "question",
+                            "state": {
+                                "status": "error",
+                                "input": {
+                                    "questions": [{"question": "Continue?"}],
+                                },
+                                "error": "The user dismissed this question",
+                            },
+                        }
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="session.status",
+            data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+        )
+
+    output = await collect_opencode_output_from_events(
+        _events(),
+        session_id="session-1",
+    )
+
+    assert output.text == ""
+    assert output.error == (
+        "OpenCode question tool failed: The user dismissed this question"
+    )
+
+
+@pytest.mark.asyncio
 async def test_turn_runtime_cancels_preconnected_stream_once(tmp_path: Path) -> None:
     client = _HangingStreamClient()
     stream = await pre_connect_event_stream(client, tmp_path, "session-1")
@@ -191,6 +321,19 @@ async def _record_permission(
 
 async def _record_question_rejection(target: list[str], request_id: str) -> None:
     target.append(request_id)
+
+
+async def _answer_question(request_id: str, props: dict[str, Any]) -> list[list[str]]:
+    _ = request_id, props
+    return [["Yes"]]
+
+
+async def _record_question_answer(
+    target: list[tuple[str, list[list[str]]]],
+    request_id: str,
+    answers: list[list[str]],
+) -> None:
+    target.append((request_id, answers))
 
 
 class _HangingStreamClient:

--- a/tests/test_opencode_backend_streaming.py
+++ b/tests/test_opencode_backend_streaming.py
@@ -13,7 +13,12 @@ from codex_autorunner.agents.opencode.runtime import (
     OpenCodeTurnOutput,
     extract_session_id,
 )
-from codex_autorunner.core.ports.run_event import Completed, OutputDelta, TokenUsage
+from codex_autorunner.core.ports.run_event import (
+    Completed,
+    Failed,
+    OutputDelta,
+    TokenUsage,
+)
 from codex_autorunner.core.sse import SSEEvent
 
 
@@ -227,6 +232,36 @@ async def test_opencode_backend_passes_first_event_timeout_to_collector(
         isinstance(event, Completed) and event.final_message == "ok"
         for event in run_events
     )
+
+
+@pytest.mark.anyio
+async def test_opencode_backend_failed_output_takes_precedence_over_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_collect(client, **kwargs):
+        _ = client
+        ready_event = kwargs.get("ready_event")
+        if ready_event is not None:
+            ready_event.set()
+        return OpenCodeTurnOutput(text="partial", error="boom")
+
+    monkeypatch.setattr(
+        opencode_backend_module,
+        "collect_opencode_output",
+        _fake_collect,
+    )
+
+    backend = OpenCodeBackend(workspace_root=tmp_path, supervisor=None)
+    backend._client = _FakeOpenCodeClient([])  # type: ignore
+
+    run_events = [event async for event in backend.run_turn_events("s-error", "Ping")]
+
+    assert any(
+        isinstance(event, Failed) and event.error_message == "boom"
+        for event in run_events
+    )
+    assert not any(isinstance(event, Completed) for event in run_events)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Recognize OpenCode `tool: question` message parts as user-input requests when they are pending.
- Treat already-failed OpenCode question tool parts as fatal turn errors so nonterminal progress text cannot be shown as a completed final answer.
- Add protocol and collector regression coverage for the deployed failure shape.

## Validation
- `.venv/bin/python -m pytest -q tests/agents/opencode/test_turn_runtime.py tests/agents/opencode/test_protocol_payload.py tests/agents/opencode/test_output_assembly.py tests/agents/opencode/test_opencode_harness.py -q`
- live OpenCode replay from session `ses_194fae6d5ffeidjnR4nZlKV2nL`: patched collector returned empty text and `OpenCode question tool failed: The user dismissed this question`
- pre-commit aggregate lane: guardrails, black, ruff, import boundaries, mypy, pytest `9581 items`, web build, and frontend tests `895 passed | 2 skipped`
