### PR TITLE
[codex] Add legacy control-plane cleanup

### DIFF
--- a/docs/ops/control-plane-cleanup.md
+++ b/docs/ops/control-plane-cleanup.md
@@ -1,0 +1,38 @@
+# Non-Authoritative Control-Plane Cleanup
+
+CAR hubs own the authoritative runtime control plane under the hub root. Repo
+and worktree `.codex-autorunner/` directories can still contain legacy files
+that look authoritative, such as `manifest.yml`, `orchestration.sqlite3`,
+`hub_projection.sqlite3`, compatibility metadata, and migration locks. In a
+hub-owned workspace these files are not runtime authority; tickets,
+contextspace, filebox, GitHub context, diagnostics, and logs remain valid
+repo-local project data.
+
+Preview cleanup before changing disk state:
+
+```bash
+car cleanup control-plane --hub /path/to/hub
+car cleanup control-plane --hub /path/to/hub --json
+```
+
+The report lists each artifact, byte size, classification reason, workspace
+role, and proposed archive path. It uses the hub workspace registry and
+control-plane classification, so an explicitly launched standalone hub is not
+cleaned.
+
+Apply cleanup only after reviewing the dry run:
+
+```bash
+car cleanup control-plane --hub /path/to/hub --apply
+```
+
+The first implementation archives instead of deleting. Files move under:
+
+```text
+<hub>/.codex-autorunner/archive/control-plane-cleanup/<timestamp>/
+```
+
+To restore an archived file, move it back to the original relative path shown
+in the dry-run or apply report. Run `car doctor --repo /path/to/hub` to see a
+doctor hint that links nested control-plane artifacts back to this cleanup
+command.

--- a/docs/ops/control-plane-cleanup.md
+++ b/docs/ops/control-plane-cleanup.md
@@ -11,8 +11,8 @@ repo-local project data.
 Preview cleanup before changing disk state:
 
 ```bash
-car cleanup control-plane --hub /path/to/hub
-car cleanup control-plane --hub /path/to/hub --json
+car cleanup control-plane --path /path/to/hub
+car cleanup control-plane --path /path/to/hub --json
 ```
 
 The report lists each artifact, byte size, classification reason, workspace
@@ -24,7 +24,7 @@ workspaces, are skipped as separate control planes.
 Apply cleanup only after reviewing the dry run:
 
 ```bash
-car cleanup control-plane --hub /path/to/hub --apply
+car cleanup control-plane --path /path/to/hub --apply
 ```
 
 The first implementation archives instead of deleting. Files move under:

--- a/docs/ops/control-plane-cleanup.md
+++ b/docs/ops/control-plane-cleanup.md
@@ -18,7 +18,8 @@ car cleanup control-plane --hub /path/to/hub --json
 The report lists each artifact, byte size, classification reason, workspace
 role, and proposed archive path. It uses the hub workspace registry and
 control-plane classification, so an explicitly launched standalone hub is not
-cleaned.
+cleaned. Nested standalone hubs under the selected hub root, and their managed
+workspaces, are skipped as separate control planes.
 
 Apply cleanup only after reviewing the dry run:
 

--- a/docs/ops/state-cleanup.md
+++ b/docs/ops/state-cleanup.md
@@ -117,7 +117,7 @@ Total: deleted=22 bytes=36700160
 
 Legacy control-plane-looking files under hub-owned repo/worktree
 `.codex-autorunner/` directories are handled separately by
-`car cleanup control-plane --hub <hub>`. That command dry-runs first, archives
+`car cleanup control-plane --path <hub>`. That command dry-runs first, archives
 on `--apply`, and preserves tickets, contextspace, filebox, GitHub context,
 diagnostics, logs, and generated context artifacts.
 

--- a/docs/ops/state-cleanup.md
+++ b/docs/ops/state-cleanup.md
@@ -115,6 +115,12 @@ Total: deleted=22 bytes=36700160
 - `manifest.yml`
 - Stable reports (`reports/latest-*`, `final_report.md`)
 
+Legacy control-plane-looking files under hub-owned repo/worktree
+`.codex-autorunner/` directories are handled separately by
+`car cleanup control-plane --hub <hub>`. That command dry-runs first, archives
+on `--apply`, and preserves tickets, contextspace, filebox, GitHub context,
+diagnostics, logs, and generated context artifacts.
+
 Blocked candidates appear in the report with a `blocked=` count and a
 human-readable reason.
 

--- a/src/codex_autorunner/core/control_plane_cleanup.py
+++ b/src/codex_autorunner/core/control_plane_cleanup.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from .config_sources import CONFIG_FILENAME
 from .hub_topology import (
     ControlPlaneRole,
     HubTopologyRepository,
@@ -113,6 +114,21 @@ def plan_control_plane_cleanup(
 
     for path in _candidate_paths(resolved_hub):
         workspace_root = path.parent.parent
+        nested_hub_root = _nested_standalone_hub_root(
+            workspace_root,
+            outer_hub_root=resolved_hub,
+        )
+        if nested_hub_root is not None:
+            skipped.append(
+                {
+                    "path": _display_path(path, resolved_hub),
+                    "reason": (
+                        "nested standalone hub control plane under "
+                        f"{_display_path(nested_hub_root, resolved_hub)}"
+                    ),
+                }
+            )
+            continue
         entry = repository.classify_workspace_path(workspace_root)
         if entry.control_plane_role == ControlPlaneRole.STANDALONE_HUB:
             skipped.append(
@@ -204,6 +220,28 @@ def _candidate_paths(hub_root: Path) -> Iterable[Path]:
             candidate = state_root / filename
             if candidate.is_file() or candidate.is_symlink():
                 yield candidate.resolve()
+
+
+def _nested_standalone_hub_root(
+    workspace_root: Path,
+    *,
+    outer_hub_root: Path,
+) -> Path | None:
+    resolved_outer = outer_hub_root.resolve()
+    current = workspace_root.resolve()
+    for candidate in (current, *current.parents):
+        if candidate == resolved_outer:
+            return None
+        try:
+            candidate.relative_to(resolved_outer)
+        except ValueError:
+            return None
+        state_root = candidate / ".codex-autorunner"
+        if (candidate / CONFIG_FILENAME).is_file() and (
+            state_root / HUB_MANIFEST_FILENAME
+        ).is_file():
+            return candidate
+    return None
 
 
 def _artifact_for_path(

--- a/src/codex_autorunner/core/control_plane_cleanup.py
+++ b/src/codex_autorunner/core/control_plane_cleanup.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import dataclasses
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from .hub_topology import (
+    ControlPlaneRole,
+    HubTopologyRepository,
+    NonAuthoritativeArtifact,
+    WorkspaceRegistryEntry,
+)
+from .state_roots import (
+    HUB_MANIFEST_FILENAME,
+    HUB_PROJECTION_DB_FILENAME,
+    ORCHESTRATION_COMPATIBILITY_METADATA_FILENAME,
+    ORCHESTRATION_DB_FILENAME,
+)
+
+_CLEANUP_ARCHIVE_ROOT = Path(".codex-autorunner") / "archive" / "control-plane-cleanup"
+_SAFE_CLEANUP_ROLES = {
+    ControlPlaneRole.HUB_OWNED,
+    ControlPlaneRole.REPO_LOCAL_DATA,
+}
+_ARTIFACT_FILENAMES = frozenset(
+    {
+        HUB_MANIFEST_FILENAME,
+        ORCHESTRATION_DB_FILENAME,
+        f"{ORCHESTRATION_DB_FILENAME}-wal",
+        f"{ORCHESTRATION_DB_FILENAME}-shm",
+        HUB_PROJECTION_DB_FILENAME,
+        f"{HUB_PROJECTION_DB_FILENAME}-wal",
+        f"{HUB_PROJECTION_DB_FILENAME}-shm",
+        ORCHESTRATION_COMPATIBILITY_METADATA_FILENAME,
+        f"{ORCHESTRATION_DB_FILENAME}.migrate.lock",
+    }
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class ControlPlaneCleanupCandidate:
+    path: Path
+    kind: str
+    size_bytes: int
+    reason: str
+    proposed_action: str
+    workspace_root: Path
+    control_plane_role: ControlPlaneRole
+    repo_id: str | None
+    archive_path: Path | None = None
+
+    def to_payload(self, hub_root: Path) -> dict[str, Any]:
+        return {
+            "path": _display_path(self.path, hub_root),
+            "kind": self.kind,
+            "size_bytes": self.size_bytes,
+            "reason": self.reason,
+            "proposed_action": self.proposed_action,
+            "workspace_root": _display_path(self.workspace_root, hub_root),
+            "control_plane_role": self.control_plane_role.value,
+            "repo_id": self.repo_id,
+            "archive_path": (
+                _display_path(self.archive_path, hub_root)
+                if self.archive_path is not None
+                else None
+            ),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class ControlPlaneCleanupReport:
+    hub_root: Path
+    dry_run: bool
+    candidates: tuple[ControlPlaneCleanupCandidate, ...]
+    skipped: tuple[dict[str, str], ...] = ()
+    errors: tuple[str, ...] = ()
+
+    @property
+    def total_reclaimable_bytes(self) -> int:
+        return sum(candidate.size_bytes for candidate in self.candidates)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "hub_root": str(self.hub_root),
+            "dry_run": self.dry_run,
+            "candidate_count": len(self.candidates),
+            "total_reclaimable_bytes": self.total_reclaimable_bytes,
+            "candidates": [
+                candidate.to_payload(self.hub_root) for candidate in self.candidates
+            ],
+            "skipped": list(self.skipped),
+            "errors": list(self.errors),
+        }
+
+
+def plan_control_plane_cleanup(
+    *,
+    hub_root: Path,
+    manifest_path: Path,
+    archive_stamp: str | None = None,
+) -> ControlPlaneCleanupReport:
+    """Classify and report non-authoritative control-plane-looking artifacts."""
+    resolved_hub = hub_root.resolve()
+    repository = HubTopologyRepository(
+        hub_root=resolved_hub,
+        manifest_path=manifest_path,
+    )
+    stamp = archive_stamp or _archive_stamp()
+    candidates: list[ControlPlaneCleanupCandidate] = []
+    skipped: list[dict[str, str]] = []
+
+    for path in _candidate_paths(resolved_hub):
+        workspace_root = path.parent.parent
+        entry = repository.classify_workspace_path(workspace_root)
+        if entry.control_plane_role == ControlPlaneRole.STANDALONE_HUB:
+            skipped.append(
+                {
+                    "path": _display_path(path, resolved_hub),
+                    "reason": "explicit standalone hub control plane",
+                }
+            )
+            continue
+        if entry.control_plane_role not in _SAFE_CLEANUP_ROLES:
+            skipped.append(
+                {
+                    "path": _display_path(path, resolved_hub),
+                    "reason": f"classified as {entry.control_plane_role.value}",
+                }
+            )
+            continue
+        artifact = _artifact_for_path(entry, path)
+        if artifact is None:
+            skipped.append(
+                {
+                    "path": _display_path(path, resolved_hub),
+                    "reason": "not classified as a non-authoritative artifact",
+                }
+            )
+            continue
+        candidates.append(
+            ControlPlaneCleanupCandidate(
+                path=path,
+                kind=artifact.kind,
+                size_bytes=_file_size(path),
+                reason=artifact.reason,
+                proposed_action="archive",
+                workspace_root=entry.workspace_root,
+                control_plane_role=entry.control_plane_role,
+                repo_id=entry.repo_id,
+                archive_path=_archive_path(
+                    hub_root=resolved_hub,
+                    source=path,
+                    stamp=stamp,
+                ),
+            )
+        )
+
+    return ControlPlaneCleanupReport(
+        hub_root=resolved_hub,
+        dry_run=True,
+        candidates=tuple(candidates),
+        skipped=tuple(skipped),
+    )
+
+
+def apply_control_plane_cleanup(
+    report: ControlPlaneCleanupReport,
+) -> ControlPlaneCleanupReport:
+    moved: list[ControlPlaneCleanupCandidate] = []
+    errors: list[str] = []
+    for candidate in report.candidates:
+        archive_path = candidate.archive_path
+        if archive_path is None:
+            errors.append(f"{candidate.path}: missing archive path")
+            continue
+        if not candidate.path.exists():
+            errors.append(f"{candidate.path}: disappeared before archive")
+            continue
+        try:
+            archive_path.parent.mkdir(parents=True, exist_ok=True)
+            destination = _unique_destination(archive_path)
+            shutil.move(str(candidate.path), str(destination))
+            moved.append(dataclasses.replace(candidate, archive_path=destination))
+        except OSError as exc:
+            errors.append(f"{candidate.path}: {exc}")
+
+    return ControlPlaneCleanupReport(
+        hub_root=report.hub_root,
+        dry_run=False,
+        candidates=tuple(moved),
+        skipped=report.skipped,
+        errors=tuple([*report.errors, *errors]),
+    )
+
+
+def _candidate_paths(hub_root: Path) -> Iterable[Path]:
+    state_dir_name = ".codex-autorunner"
+    for state_root in sorted(hub_root.glob(f"**/{state_dir_name}")):
+        if not state_root.is_dir() or state_root.is_symlink():
+            continue
+        for filename in sorted(_ARTIFACT_FILENAMES):
+            candidate = state_root / filename
+            if candidate.is_file() or candidate.is_symlink():
+                yield candidate.resolve()
+
+
+def _artifact_for_path(
+    entry: WorkspaceRegistryEntry,
+    path: Path,
+) -> NonAuthoritativeArtifact | None:
+    for artifact in entry.non_authoritative_artifacts:
+        if artifact.path == path:
+            return artifact
+    return None
+
+
+def _archive_path(*, hub_root: Path, source: Path, stamp: str) -> Path:
+    try:
+        rel = source.relative_to(hub_root)
+    except ValueError:
+        rel = Path(source.name)
+    return hub_root / _CLEANUP_ARCHIVE_ROOT / stamp / rel
+
+
+def _unique_destination(path: Path) -> Path:
+    if not path.exists():
+        return path
+    for index in range(1, 1000):
+        candidate = path.with_name(f"{path.name}.{index}")
+        if not candidate.exists():
+            return candidate
+    raise OSError(f"unable to choose a unique archive path for {path}")
+
+
+def _file_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _display_path(path: Path | None, hub_root: Path) -> str:
+    if path is None:
+        return ""
+    try:
+        return str(path.relative_to(hub_root))
+    except ValueError:
+        return str(path)
+
+
+def _archive_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+__all__ = [
+    "ControlPlaneCleanupCandidate",
+    "ControlPlaneCleanupReport",
+    "apply_control_plane_cleanup",
+    "plan_control_plane_cleanup",
+]

--- a/src/codex_autorunner/core/diagnostics/hub.py
+++ b/src/codex_autorunner/core/diagnostics/hub.py
@@ -276,7 +276,7 @@ def hub_control_plane_doctor_checks(hub_config: HubConfig) -> list[DoctorCheck]:
                 ),
                 severity="info",
                 check_id="hub.control_plane.nested_artifacts",
-                fix=f"Preview cleanup with: car cleanup control-plane --hub {hub_config.root}",
+                fix=f"Preview cleanup with: car cleanup control-plane --path {hub_config.root}",
             )
         )
     else:
@@ -287,7 +287,7 @@ def hub_control_plane_doctor_checks(hub_config: HubConfig) -> list[DoctorCheck]:
                 message="No nested non-authoritative orchestration DBs or manifests found.",
                 severity="info",
                 check_id="hub.control_plane.nested_artifacts",
-                fix=f"Use: car cleanup control-plane --hub {hub_config.root} for a full artifact report.",
+                fix=f"Use: car cleanup control-plane --path {hub_config.root} for a full artifact report.",
             )
         )
     return checks

--- a/src/codex_autorunner/core/diagnostics/hub.py
+++ b/src/codex_autorunner/core/diagnostics/hub.py
@@ -4,17 +4,12 @@ from pathlib import Path
 
 from ...manifest import load_manifest, load_manifest_with_issues
 from ..config import HubConfig
+from ..control_plane_cleanup import plan_control_plane_cleanup
 from ..destinations import (
     probe_docker_readiness,
     resolve_effective_repo_destination,
 )
 from ..orchestration.sqlite import collect_orchestration_control_plane_status
-from ..state_roots import (
-    HUB_MANIFEST_FILENAME,
-    ORCHESTRATION_DB_FILENAME,
-    resolve_hub_manifest_path,
-    resolve_hub_orchestration_db_path,
-)
 from .types import DoctorCheck
 
 
@@ -256,37 +251,18 @@ def hub_control_plane_doctor_checks(hub_config: HubConfig) -> list[DoctorCheck]:
         )
     )
 
-    canonical_db = resolve_hub_orchestration_db_path(hub_config.root).resolve()
-    canonical_manifest = resolve_hub_manifest_path(
-        hub_config.root,
-        raw_config=hub_config.raw,
-    ).resolve()
-    nested_db_count = 0
-    nested_manifest_count = 0
-    for pattern, filename in (
-        (
-            f"**/.codex-autorunner/{ORCHESTRATION_DB_FILENAME}",
-            ORCHESTRATION_DB_FILENAME,
-        ),
-        (f"**/.codex-autorunner/{HUB_MANIFEST_FILENAME}", HUB_MANIFEST_FILENAME),
-    ):
-        try:
-            candidates = list(hub_config.root.glob(pattern))
-        except OSError:
-            candidates = []
-        for candidate in candidates:
-            try:
-                resolved = candidate.resolve()
-            except OSError:
-                continue
-            if filename == ORCHESTRATION_DB_FILENAME:
-                if resolved == canonical_db:
-                    continue
-                nested_db_count += 1
-            else:
-                if resolved == canonical_manifest:
-                    continue
-                nested_manifest_count += 1
+    cleanup_report = plan_control_plane_cleanup(
+        hub_root=hub_config.root,
+        manifest_path=hub_config.manifest_path,
+    )
+    nested_db_count = sum(
+        1
+        for candidate in cleanup_report.candidates
+        if candidate.kind == "orchestration_db"
+    )
+    nested_manifest_count = sum(
+        1 for candidate in cleanup_report.candidates if candidate.kind == "manifest"
+    )
     if nested_db_count or nested_manifest_count:
         checks.append(
             DoctorCheck(
@@ -300,6 +276,7 @@ def hub_control_plane_doctor_checks(hub_config: HubConfig) -> list[DoctorCheck]:
                 ),
                 severity="info",
                 check_id="hub.control_plane.nested_artifacts",
+                fix=f"Preview cleanup with: car cleanup control-plane --hub {hub_config.root}",
             )
         )
     else:
@@ -310,6 +287,7 @@ def hub_control_plane_doctor_checks(hub_config: HubConfig) -> list[DoctorCheck]:
                 message="No nested non-authoritative orchestration DBs or manifests found.",
                 severity="info",
                 check_id="hub.control_plane.nested_artifacts",
+                fix=f"Use: car cleanup control-plane --hub {hub_config.root} for a full artifact report.",
             )
         )
     return checks

--- a/src/codex_autorunner/core/hub_topology.py
+++ b/src/codex_autorunner/core/hub_topology.py
@@ -21,7 +21,12 @@ from .destinations import (
 from .git_utils import git_available, git_branch, git_is_clean
 from .locks import DEFAULT_RUNNER_CMD_HINTS, assess_lock, process_alive
 from .state import RunnerState, load_state, now_iso
-from .state_roots import ORCHESTRATION_DB_FILENAME, resolve_repo_runner_state_db_path
+from .state_roots import (
+    HUB_PROJECTION_DB_FILENAME,
+    ORCHESTRATION_COMPATIBILITY_METADATA_FILENAME,
+    ORCHESTRATION_DB_FILENAME,
+    resolve_repo_runner_state_db_path,
+)
 from .utils import atomic_write
 
 logger = logging.getLogger("codex_autorunner.hub_topology")
@@ -559,6 +564,41 @@ def _non_authoritative_artifacts(
             "orchestration_db",
             state_root / ORCHESTRATION_DB_FILENAME,
             "workspace orchestration database is not runtime authority for this hub",
+        ),
+        (
+            "orchestration_db_wal",
+            state_root / f"{ORCHESTRATION_DB_FILENAME}-wal",
+            "workspace orchestration WAL is not runtime authority for this hub",
+        ),
+        (
+            "orchestration_db_shm",
+            state_root / f"{ORCHESTRATION_DB_FILENAME}-shm",
+            "workspace orchestration SHM is not runtime authority for this hub",
+        ),
+        (
+            "hub_projection_db",
+            state_root / HUB_PROJECTION_DB_FILENAME,
+            "workspace hub projection database is not runtime authority for this hub",
+        ),
+        (
+            "hub_projection_db_wal",
+            state_root / f"{HUB_PROJECTION_DB_FILENAME}-wal",
+            "workspace hub projection WAL is not runtime authority for this hub",
+        ),
+        (
+            "hub_projection_db_shm",
+            state_root / f"{HUB_PROJECTION_DB_FILENAME}-shm",
+            "workspace hub projection SHM is not runtime authority for this hub",
+        ),
+        (
+            "orchestration_compatibility_metadata",
+            state_root / ORCHESTRATION_COMPATIBILITY_METADATA_FILENAME,
+            "workspace compatibility metadata is not runtime authority for this hub",
+        ),
+        (
+            "orchestration_migration_lock",
+            state_root / f"{ORCHESTRATION_DB_FILENAME}.migrate.lock",
+            "workspace migration lock is not runtime authority for this hub",
         ),
     ]
     for kind, candidate, reason in candidates:

--- a/src/codex_autorunner/surfaces/cli/commands/cleanup.py
+++ b/src/codex_autorunner/surfaces/cli/commands/cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import logging
 from pathlib import Path
 from typing import Callable, Optional
@@ -22,6 +23,10 @@ from ....core.archive_retention import (
 from ....core.config import (
     ConfigError,
     load_hub_config,
+)
+from ....core.control_plane_cleanup import (
+    apply_control_plane_cleanup,
+    plan_control_plane_cleanup,
 )
 from ....core.filebox_retention import (
     prune_filebox_root,
@@ -95,6 +100,31 @@ from ..ops_cleanup import (
 logger = logging.getLogger(__name__)
 
 
+def _render_control_plane_cleanup_human(report) -> str:
+    prefix = "DRY RUN: " if report.dry_run else "APPLIED: "
+    lines = [
+        f"{prefix}control-plane cleanup candidates={len(report.candidates)} "
+        f"reclaimable_bytes={report.total_reclaimable_bytes}",
+    ]
+    for candidate in report.candidates:
+        payload = candidate.to_payload(report.hub_root)
+        action = "would archive" if report.dry_run else "archived"
+        archive = payload["archive_path"] or "(none)"
+        lines.append(
+            f"- {payload['path']} size={payload['size_bytes']} "
+            f"kind={payload['kind']} role={payload['control_plane_role']} "
+            f"action={action} -> {archive}"
+        )
+        lines.append(f"  reason: {payload['reason']}")
+    if report.skipped:
+        lines.append(f"skipped={len(report.skipped)}")
+    for error in report.errors:
+        lines.append(f"ERROR: {error}")
+    if report.dry_run:
+        lines.append("Pass --apply to archive these artifacts.")
+    return "\n".join(lines)
+
+
 def _build_force_attestation(
     force_attestation: Optional[str], *, target_scope: str
 ) -> Optional[dict[str, str]]:
@@ -112,6 +142,45 @@ def register_cleanup_commands(
     *,
     require_repo_config: Callable[[Optional[Path], Optional[Path]], RuntimeContext],
 ) -> None:
+    @cleanup_app.command("control-plane")
+    def cleanup_control_plane(
+        hub: Optional[Path] = typer.Option(
+            None,
+            "--hub",
+            "--path",
+            help="Hub root or config path. Defaults to cwd walk-up.",
+        ),
+        apply: bool = typer.Option(
+            False,
+            "--apply",
+            help="Archive classified artifacts. Omit to dry-run only.",
+        ),
+        json_output: bool = typer.Option(
+            False,
+            "--json",
+            help="Output JSON for scripting.",
+        ),
+    ) -> None:
+        """Archive non-authoritative legacy CAR control-plane artifacts."""
+        try:
+            hub_config = load_hub_config(hub or Path.cwd())
+        except ConfigError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+
+        report = plan_control_plane_cleanup(
+            hub_root=hub_config.root,
+            manifest_path=hub_config.manifest_path,
+        )
+        if apply:
+            report = apply_control_plane_cleanup(report)
+
+        if json_output:
+            typer.echo(json.dumps(report.to_payload(), indent=2))
+        else:
+            typer.echo(_render_control_plane_cleanup_human(report))
+        if report.errors:
+            raise typer.Exit(code=1)
+
     @cleanup_app.command("processes")
     def cleanup_processes(
         repo: Optional[Path] = typer.Option(None, "--repo", help="Repo path"),

--- a/src/codex_autorunner/surfaces/cli/commands/cleanup.py
+++ b/src/codex_autorunner/surfaces/cli/commands/cleanup.py
@@ -144,12 +144,7 @@ def register_cleanup_commands(
 ) -> None:
     @cleanup_app.command("control-plane")
     def cleanup_control_plane(
-        hub: Optional[Path] = typer.Option(
-            None,
-            "--hub",
-            "--path",
-            help="Hub root or config path. Defaults to cwd walk-up.",
-        ),
+        hub: Optional[Path] = hub_root_path_option(),
         apply: bool = typer.Option(
             False,
             "--apply",

--- a/tests/core/test_control_plane_cleanup.py
+++ b/tests/core/test_control_plane_cleanup.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_autorunner.core.control_plane_cleanup import (
+    apply_control_plane_cleanup,
+    plan_control_plane_cleanup,
+)
+from codex_autorunner.manifest import Manifest, ManifestRepo, save_manifest
+
+
+def _save_manifest(hub_root: Path, manifest: Manifest) -> Path:
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    save_manifest(manifest_path, manifest, hub_root)
+    return manifest_path
+
+
+def test_control_plane_cleanup_reports_nested_manifest_and_stale_dbs(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    state_root = repo_root / ".codex-autorunner"
+    state_root.mkdir(parents=True)
+    manifest_path = _save_manifest(
+        hub_root,
+        Manifest(
+            version=3,
+            repos=[ManifestRepo(id="repo", path=Path("workspace/repo"), kind="base")],
+        ),
+    )
+    (state_root / "manifest.yml").write_text("version: 3\nrepos: []\n")
+    (state_root / "orchestration.sqlite3").write_bytes(b"stale-db")
+    (state_root / "orchestration.sqlite3-wal").write_bytes(b"wal")
+    (state_root / "hub_projection.sqlite3").write_bytes(b"projection")
+    (state_root / "orchestration-compatibility.json").write_text("{}\n")
+    (state_root / "orchestration.sqlite3.migrate.lock").write_text("lock\n")
+
+    report = plan_control_plane_cleanup(
+        hub_root=hub_root,
+        manifest_path=manifest_path,
+        archive_stamp="stamp",
+    )
+
+    assert report.dry_run is True
+    assert report.total_reclaimable_bytes > 0
+    assert {candidate.kind for candidate in report.candidates} == {
+        "manifest",
+        "orchestration_db",
+        "orchestration_db_wal",
+        "hub_projection_db",
+        "orchestration_compatibility_metadata",
+        "orchestration_migration_lock",
+    }
+    assert all(
+        candidate.control_plane_role.value == "hub_owned"
+        for candidate in report.candidates
+    )
+    assert all(
+        candidate.proposed_action == "archive" for candidate in report.candidates
+    )
+
+
+def test_control_plane_cleanup_apply_archives_only_control_plane_artifacts(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    state_root = repo_root / ".codex-autorunner"
+    tickets_dir = state_root / "tickets"
+    context_dir = state_root / "contextspace"
+    tickets_dir.mkdir(parents=True)
+    context_dir.mkdir()
+    (tickets_dir / "TICKET-001.md").write_text("# keep\n")
+    (context_dir / "active_context.md").write_text("keep\n")
+    manifest_path = _save_manifest(
+        hub_root,
+        Manifest(
+            version=3,
+            repos=[ManifestRepo(id="repo", path=Path("workspace/repo"), kind="base")],
+        ),
+    )
+    stale_db = state_root / "orchestration.sqlite3"
+    stale_db.write_bytes(b"stale-db")
+
+    dry_run = plan_control_plane_cleanup(
+        hub_root=hub_root,
+        manifest_path=manifest_path,
+        archive_stamp="stamp",
+    )
+    applied = apply_control_plane_cleanup(dry_run)
+
+    assert stale_db.exists() is False
+    assert (
+        hub_root
+        / ".codex-autorunner/archive/control-plane-cleanup/stamp/workspace/repo/.codex-autorunner/orchestration.sqlite3"
+    ).read_bytes() == b"stale-db"
+    assert (tickets_dir / "TICKET-001.md").read_text() == "# keep\n"
+    assert (context_dir / "active_context.md").read_text() == "keep\n"
+    assert applied.dry_run is False
+    assert applied.errors == ()
+
+
+def test_control_plane_cleanup_never_touches_standalone_hub(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    manifest_path = _save_manifest(hub_root, Manifest(version=3, repos=[]))
+    live_db = hub_root / ".codex-autorunner" / "orchestration.sqlite3"
+    live_db.write_bytes(b"live")
+
+    report = plan_control_plane_cleanup(
+        hub_root=hub_root,
+        manifest_path=manifest_path,
+        archive_stamp="stamp",
+    )
+
+    assert report.candidates == ()
+    assert live_db.read_bytes() == b"live"
+    assert {(item["path"], item["reason"]) for item in report.skipped} == {
+        (
+            ".codex-autorunner/manifest.yml",
+            "explicit standalone hub control plane",
+        ),
+        (
+            ".codex-autorunner/orchestration.sqlite3",
+            "explicit standalone hub control plane",
+        ),
+    }

--- a/tests/core/test_control_plane_cleanup.py
+++ b/tests/core/test_control_plane_cleanup.py
@@ -125,3 +125,87 @@ def test_control_plane_cleanup_never_touches_standalone_hub(tmp_path: Path) -> N
             "explicit standalone hub control plane",
         ),
     }
+
+
+def test_control_plane_cleanup_skips_nested_standalone_hub(
+    tmp_path: Path,
+) -> None:
+    outer_hub_root = tmp_path / "outer"
+    nested_hub_root = outer_hub_root / "workspace" / "nested-hub"
+    outer_manifest_path = _save_manifest(
+        outer_hub_root,
+        Manifest(version=3, repos=[]),
+    )
+    nested_manifest_path = _save_manifest(
+        nested_hub_root,
+        Manifest(version=3, repos=[]),
+    )
+    (nested_hub_root / ".codex-autorunner" / "config.yml").write_text(
+        "mode: hub\n",
+        encoding="utf-8",
+    )
+    nested_db = nested_hub_root / ".codex-autorunner" / "orchestration.sqlite3"
+    nested_db.write_bytes(b"nested-live")
+
+    dry_run = plan_control_plane_cleanup(
+        hub_root=outer_hub_root,
+        manifest_path=outer_manifest_path,
+        archive_stamp="stamp",
+    )
+    applied = apply_control_plane_cleanup(dry_run)
+
+    assert dry_run.candidates == ()
+    assert applied.candidates == ()
+    assert nested_manifest_path.exists()
+    assert nested_db.read_bytes() == b"nested-live"
+    skipped = {(item["path"], item["reason"]) for item in dry_run.skipped}
+    assert {
+        (
+            "workspace/nested-hub/.codex-autorunner/manifest.yml",
+            "nested standalone hub control plane under workspace/nested-hub",
+        ),
+        (
+            "workspace/nested-hub/.codex-autorunner/orchestration.sqlite3",
+            "nested standalone hub control plane under workspace/nested-hub",
+        ),
+    } <= skipped
+
+
+def test_control_plane_cleanup_skips_workspaces_inside_nested_standalone_hub(
+    tmp_path: Path,
+) -> None:
+    outer_hub_root = tmp_path / "outer"
+    nested_hub_root = outer_hub_root / "workspace" / "nested-hub"
+    nested_repo_root = nested_hub_root / "workspace" / "repo"
+    nested_repo_state = nested_repo_root / ".codex-autorunner"
+    nested_repo_state.mkdir(parents=True)
+    outer_manifest_path = _save_manifest(
+        outer_hub_root,
+        Manifest(version=3, repos=[]),
+    )
+    _save_manifest(
+        nested_hub_root,
+        Manifest(
+            version=3,
+            repos=[ManifestRepo(id="repo", path=Path("workspace/repo"), kind="base")],
+        ),
+    )
+    (nested_hub_root / ".codex-autorunner" / "config.yml").write_text(
+        "mode: hub\n",
+        encoding="utf-8",
+    )
+    nested_repo_db = nested_repo_state / "orchestration.sqlite3"
+    nested_repo_db.write_bytes(b"nested-repo-db")
+
+    report = plan_control_plane_cleanup(
+        hub_root=outer_hub_root,
+        manifest_path=outer_manifest_path,
+        archive_stamp="stamp",
+    )
+
+    assert report.candidates == ()
+    assert nested_repo_db.read_bytes() == b"nested-repo-db"
+    assert (
+        "workspace/nested-hub/workspace/repo/.codex-autorunner/orchestration.sqlite3",
+        "nested standalone hub control plane under workspace/nested-hub",
+    ) in {(item["path"], item["reason"]) for item in report.skipped}

--- a/tests/test_cli_control_plane_cleanup.py
+++ b/tests/test_cli_control_plane_cleanup.py
@@ -33,7 +33,7 @@ def test_cleanup_control_plane_dry_run_json_reports_reclaimable_artifacts(
         [
             "cleanup",
             "control-plane",
-            "--hub",
+            "--path",
             str(hub_root_only),
             "--json",
         ],
@@ -73,7 +73,7 @@ def test_cleanup_control_plane_apply_archives_artifacts(
         [
             "cleanup",
             "control-plane",
-            "--hub",
+            "--path",
             str(hub_root_only),
             "--apply",
             "--json",

--- a/tests/test_cli_control_plane_cleanup.py
+++ b/tests/test_cli_control_plane_cleanup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from codex_autorunner.cli import app
+from codex_autorunner.manifest import Manifest, ManifestRepo, save_manifest
+
+runner = CliRunner()
+
+
+def test_cleanup_control_plane_dry_run_json_reports_reclaimable_artifacts(
+    hub_root_only: Path,
+) -> None:
+    repo_root = hub_root_only / "workspace" / "repo"
+    state_root = repo_root / ".codex-autorunner"
+    state_root.mkdir(parents=True)
+    save_manifest(
+        hub_root_only / ".codex-autorunner" / "manifest.yml",
+        Manifest(
+            version=3,
+            repos=[ManifestRepo(id="repo", path=Path("workspace/repo"), kind="base")],
+        ),
+        hub_root_only,
+    )
+    (state_root / "manifest.yml").write_text("version: 3\nrepos: []\n")
+    (state_root / "orchestration.sqlite3").write_bytes(b"stale")
+
+    result = runner.invoke(
+        app,
+        [
+            "cleanup",
+            "control-plane",
+            "--hub",
+            str(hub_root_only),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert payload["candidate_count"] == 2
+    assert payload["total_reclaimable_bytes"] > 0
+    assert {candidate["path"] for candidate in payload["candidates"]} == {
+        "workspace/repo/.codex-autorunner/manifest.yml",
+        "workspace/repo/.codex-autorunner/orchestration.sqlite3",
+    }
+    assert (state_root / "orchestration.sqlite3").exists()
+
+
+def test_cleanup_control_plane_apply_archives_artifacts(
+    hub_root_only: Path,
+) -> None:
+    repo_root = hub_root_only / "workspace" / "repo"
+    state_root = repo_root / ".codex-autorunner"
+    state_root.mkdir(parents=True)
+    save_manifest(
+        hub_root_only / ".codex-autorunner" / "manifest.yml",
+        Manifest(
+            version=3,
+            repos=[ManifestRepo(id="repo", path=Path("workspace/repo"), kind="base")],
+        ),
+        hub_root_only,
+    )
+    stale_db = state_root / "orchestration.sqlite3"
+    stale_db.write_bytes(b"stale")
+
+    result = runner.invoke(
+        app,
+        [
+            "cleanup",
+            "control-plane",
+            "--hub",
+            str(hub_root_only),
+            "--apply",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is False
+    assert payload["candidate_count"] == 1
+    assert stale_db.exists() is False
+    archived_path = hub_root_only / payload["candidates"][0]["archive_path"]
+    assert archived_path.read_bytes() == b"stale"


### PR DESCRIPTION
## Summary

- Add `car cleanup control-plane` to dry-run and archive non-authoritative legacy CAR control-plane artifacts under hub-owned workspaces.
- Reuse hub workspace/control-plane classification, preserving standalone hubs and repo-local project data such as tickets, contextspace, filebox, and GitHub context.
- Link doctor output to the cleanup command and document archive/restore behavior.

Closes #1953

## Validation

- `CODEX_FAST_TEST_WORKERS=4 git commit -m "Add legacy control-plane cleanup"` ran the repo aggregate hook successfully:
  - guardrails, ruff, black, import/contracts checks
  - mypy strict: success
  - pytest: 9582 passed
  - Web UI lab, lint, build, frontend tests: 895 passed / 2 skipped
- Focused checks also passed:
  - `.venv/bin/python -m ruff check ...`
  - `.venv/bin/python -m ruff format --check ...`
  - `.venv/bin/python -m pytest -q tests/core/test_control_plane_cleanup.py tests/test_cli_control_plane_cleanup.py tests/test_doctor_checks.py::test_hub_control_plane_doctor_reports_authority_and_nested_artifacts tests/core/test_workspace_registry.py::test_nested_manifest_and_local_orchestration_db_are_non_authoritative`
