### PR TITLE
[codex] Improve bulk chat retire feedback

### DIFF
--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -739,11 +739,11 @@ def _select_entry_points(group: str) -> Iterable[importlib.metadata.EntryPoint]:
     """Compatibility wrapper for `importlib.metadata.entry_points()` across py versions."""
 
     eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        return list(eps.select(group=group))
     # Python 3.9: may return a dict
     if isinstance(eps, dict):
         return eps.get(group, [])
-    if hasattr(eps, "select"):
-        return list(eps.select(group=group))
     return []
 
 

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -4336,6 +4336,51 @@ textarea:hover {
   gap: var(--space-2);
 }
 
+.chat-processing-backdrop {
+  z-index: 30;
+  cursor: wait;
+}
+
+.chat-processing-modal {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.chat-processing-progress {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-surface-sunken);
+}
+
+.chat-processing-progress span {
+  position: absolute;
+  inset-block: 0;
+  left: -35%;
+  width: 35%;
+  border-radius: inherit;
+  background: var(--color-accent);
+  animation: chat-processing-progress 1.1s ease-in-out infinite;
+}
+
+.chat-processing-note {
+  color: var(--color-ink-muted);
+  font-size: var(--font-size-1);
+}
+
+@keyframes chat-processing-progress {
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(390%);
+  }
+}
+
 .state-panel {
   display: grid;
   gap: 3px;

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -347,6 +347,8 @@
   let sending = $state(false);
   let creating = $state(false);
   let archiving = $state(false);
+  let bulkRetireRequestedCount = $state<number | null>(null);
+  let bulkRetireModal: HTMLDivElement | null = $state(null);
   let loadingModels = $state(false);
   /** Invalidates in-flight `listAgentModels` results when the user switches agents quickly. */
   let loadModelsSeq = 0;
@@ -559,6 +561,10 @@
     slashSuggestions;
     slashSelectedIndex = Math.min(slashSelectedIndex, Math.max(slashSuggestions.length - 1, 0));
   });
+  $effect(() => {
+    if (!bulkRetireInProgress) return;
+    void tick().then(() => bulkRetireModal?.focus());
+  });
   let clockNowMs = $state(Date.now());
   let lastScrolledChatId: string | null = null;
   let lastScrolledCardCount = 0;
@@ -620,6 +626,12 @@
   );
   const archiveFilterCount = $derived(filterCounts.archived);
   const showArchiveFilterToggle = $derived(statusFilter === 'archived' || archiveFilterCount > 0);
+  const bulkRetireInProgress = $derived(archiving && bulkRetireRequestedCount !== null);
+  const bulkRetireStatusText = $derived(
+    bulkRetireRequestedCount === 1
+      ? 'Retiring 1 active chat. The list will refresh when the backend catches up.'
+      : `Retiring ${bulkRetireRequestedCount ?? activeChatCount} active chats. The list will refresh when the backend catches up.`
+  );
   const canLoadMoreChats = $derived(statusFilter !== 'drafts' && Boolean(selectedChatWindow?.window?.nextCursor));
   const initialChatIndexError = $derived(chatIndexLoadError());
   const visibleChatError = $derived(chatError ?? (!hasUsableChatIndex ? initialChatIndexError : null));
@@ -1443,24 +1455,29 @@
     });
     if (!ok) return;
     archiving = true;
+    bulkRetireRequestedCount = activeChatCount;
     composeError = null;
-    const result = await webApi.pma.retireActiveThreads();
-    if (result.ok) {
-      const targets = result.data.threads.map((chat) => chat.id);
-      await invalidateChatMutations(targets);
-      showCommandNotice(
-        result.data.errorCount > 0
-          ? `Retired ${result.data.retiredCount}; ${result.data.errorCount} failed.`
-          : `Retired ${result.data.retiredCount} chats.`
-      );
-      if (activeChatId && targets.includes(activeChatId)) {
-        closeStream();
-        await goto(chatsHubHref(null));
+    try {
+      const result = await webApi.pma.retireActiveThreads();
+      if (result.ok) {
+        const targets = result.data.threads.map((chat) => chat.id);
+        await invalidateChatMutations(targets);
+        showCommandNotice(
+          result.data.errorCount > 0
+            ? `Retired ${result.data.retiredCount}; ${result.data.errorCount} failed.`
+            : `Retired ${result.data.retiredCount} chats.`
+        );
+        if (activeChatId && targets.includes(activeChatId)) {
+          closeStream();
+          await goto(chatsHubHref(null));
+        }
+      } else {
+        composeError = result.error;
       }
-    } else {
-      composeError = result.error;
+    } finally {
+      archiving = false;
+      bulkRetireRequestedCount = null;
     }
-    archiving = false;
   }
 
   async function replaceDetailUrl(detailId: string): Promise<void> {
@@ -2336,6 +2353,13 @@
     setComposerDraft(draft);
     markComposerEdited();
     autosizeComposer();
+  }
+
+  function trapBulkRetireModalKeydown(event: KeyboardEvent): void {
+    event.stopPropagation();
+    if (event.key !== 'Tab') return;
+    event.preventDefault();
+    bulkRetireModal?.focus();
   }
 
 </script>
@@ -3459,6 +3483,33 @@
             <button type="button" class="ghost-button" onclick={cancelLinkDialog}>Cancel</button>
             <button type="button" class="send-button" disabled={!linkDraft.trim()} onclick={addLink}>Attach</button>
           </div>
+        </div>
+      </div>
+    {/if}
+    {#if bulkRetireInProgress}
+      <div class="modal-backdrop chat-processing-backdrop" role="presentation">
+        <div
+          bind:this={bulkRetireModal}
+          class="approval-modal chat-processing-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="chat-bulk-retire-title"
+          aria-describedby="chat-bulk-retire-status"
+          tabindex="-1"
+          onclick={(event) => event.stopPropagation()}
+          onkeydown={trapBulkRetireModalKeydown}
+        >
+          <span class="artifact-type">Processing</span>
+          <h2 id="chat-bulk-retire-title">Retiring active chats</h2>
+          <p id="chat-bulk-retire-status">{bulkRetireStatusText}</p>
+          <div
+            class="chat-processing-progress"
+            role="progressbar"
+            aria-label="Retiring active chats"
+          >
+            <span></span>
+          </div>
+          <p class="chat-processing-note">Keep this tab open while CAR marks the chats retired.</p>
         </div>
       </div>
     {/if}

--- a/tests/core/apps/test_apply.py
+++ b/tests/core/apps/test_apply.py
@@ -123,7 +123,7 @@ def _run_ticket_linter(repo_root: Path) -> subprocess.CompletedProcess[str]:
     env["PYTHONWARNINGS"] = (
         warning_filter
         if not env.get("PYTHONWARNINGS")
-        else f"{warning_filter},{env['PYTHONWARNINGS']}"
+        else f"{env['PYTHONWARNINGS']},{warning_filter}"
     )
     return subprocess.run(
         [

--- a/tests/core/apps/test_apply.py
+++ b/tests/core/apps/test_apply.py
@@ -117,6 +117,14 @@ def _run_ticket_linter(repo_root: Path) -> subprocess.CompletedProcess[str]:
         if not env.get("PYTHONPATH")
         else f"{src_dir}{os.pathsep}{env['PYTHONPATH']}"
     )
+    warning_filter = (
+        "ignore:Using `httpx` with `starlette.testclient` is deprecated:Warning"
+    )
+    env["PYTHONWARNINGS"] = (
+        warning_filter
+        if not env.get("PYTHONWARNINGS")
+        else f"{warning_filter},{env['PYTHONWARNINGS']}"
+    )
     return subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Summary
- Show a blocking processing modal while retiring all active chats and refreshing the chat read model.
- Add focus handling and Tab trapping so the blocking modal does not leave keyboard focus on the background UI.
- Suppress the known Starlette testclient warning in the ticket-linter subprocess test so linter stderr assertions remain about linter output.

## Validation
- Subagent review completed; one accessibility issue was found and fixed.
- `pnpm web:lint`
- `pnpm web:test -- --run src/routes/chats/page.test.ts`
- Guarded commit lane `web-core-contract`: black, ruff, contracts, mypy, full pytest (`9594 passed`), Web UI lab, web lint, web build, full web tests (`891 passed`, `2 skipped`), SPA shell check.