### PR TITLE
[codex] fix chat row selection route race

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
@@ -85,6 +85,28 @@ describe('ChatDetailPageController', () => {
     expect(harness.liveProjection.activate).toHaveBeenCalledWith('deep-linked-chat', { quiet: false });
   });
 
+  it('keeps a route-selected chat active when read-model publication runs synchronously', async () => {
+    const harness = createHarness();
+    harness.store.applyChatIndexSnapshot(chatIndexSnapshot([
+      chatIndexRow('previous-chat'),
+      chatIndexRow('selected-chat')
+    ]));
+    harness.controller.mount({
+      route: route('previous-chat'),
+      currentRequest: { filter: 'all', limit: 50 },
+      ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.sessionState.activeChatId).toBe('previous-chat');
+    harness.liveProjection.activate.mockClear();
+
+    harness.controller.setRoute(route('selected-chat'));
+
+    expect(harness.sessionState.activeChatId).toBe('selected-chat');
+    expect(harness.liveProjection.activate).toHaveBeenCalledWith('selected-chat', { quiet: false });
+  });
+
   it('debounces filter refreshes through the chat index session', () => {
     vi.useFakeTimers();
     const harness = createHarness();

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -1360,6 +1360,7 @@
 
   async function selectChat(chatId: string): Promise<void> {
     await syncCommittedDetailUrl(chatId, { mode: 'push' });
+    pageController.setRoute(currentRouteSnapshot());
     await pageController.selectChat(chatId, { syncUrl: true });
   }
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -1361,7 +1361,6 @@
   async function selectChat(chatId: string): Promise<void> {
     await syncCommittedDetailUrl(chatId, { mode: 'push' });
     pageController.setRoute(currentRouteSnapshot());
-    await pageController.selectChat(chatId, { syncUrl: true });
   }
 
   function chatIdFromRowEvent(event: Event, fallbackChatId: string): string {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -1359,8 +1359,8 @@
   }
 
   async function selectChat(chatId: string): Promise<void> {
-    await pageController.selectChat(chatId, { syncUrl: true });
     await syncCommittedDetailUrl(chatId, { mode: 'push' });
+    await pageController.selectChat(chatId, { syncUrl: true });
   }
 
   function chatIdFromRowEvent(event: Event, fallbackChatId: string): string {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -108,7 +108,7 @@ describe('/chats page', () => {
     expect(syncCommittedBody).not.toContain('pendingCommittedDetailUrlChatId');
   });
 
-  it('pushes the selected chat URL and updates the cached route before activating the detail controller', () => {
+  it('pushes the selected chat URL and lets the updated route activate the detail controller', () => {
     const source = chatDetailPageSource();
     const selectChatBody = source.match(
       /async function selectChat[\s\S]*?\n  function chatIdFromRowEvent/
@@ -116,8 +116,9 @@ describe('/chats page', () => {
 
     expect(selectChatBody).toBeTruthy();
     expect(selectChatBody).toMatch(
-      /await syncCommittedDetailUrl\(chatId, \{ mode: 'push' \}\);[\s\S]*?pageController\.setRoute\(currentRouteSnapshot\(\)\);[\s\S]*?await pageController\.selectChat\(chatId, \{ syncUrl: true \}\);/
+      /await syncCommittedDetailUrl\(chatId, \{ mode: 'push' \}\);[\s\S]*?pageController\.setRoute\(currentRouteSnapshot\(\)\);/
     );
+    expect(selectChatBody).not.toContain('pageController.selectChat');
   });
 
   it('keeps migrated PMA transcript, stream, queue, send, and normalization calls out of the page', () => {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -108,6 +108,18 @@ describe('/chats page', () => {
     expect(syncCommittedBody).not.toContain('pendingCommittedDetailUrlChatId');
   });
 
+  it('pushes the selected chat URL before activating the detail controller', () => {
+    const source = chatDetailPageSource();
+    const selectChatBody = source.match(
+      /async function selectChat[\s\S]*?\n  function chatIdFromRowEvent/
+    )?.[0];
+
+    expect(selectChatBody).toBeTruthy();
+    expect(selectChatBody).toMatch(
+      /await syncCommittedDetailUrl\(chatId, \{ mode: 'push' \}\);[\s\S]*?await pageController\.selectChat\(chatId, \{ syncUrl: true \}\);/
+    );
+  });
+
   it('keeps migrated PMA transcript, stream, queue, send, and normalization calls out of the page', () => {
     const pageSource = chatDetailPageSource();
     const forbiddenTokens = [

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -108,7 +108,7 @@ describe('/chats page', () => {
     expect(syncCommittedBody).not.toContain('pendingCommittedDetailUrlChatId');
   });
 
-  it('pushes the selected chat URL before activating the detail controller', () => {
+  it('pushes the selected chat URL and updates the cached route before activating the detail controller', () => {
     const source = chatDetailPageSource();
     const selectChatBody = source.match(
       /async function selectChat[\s\S]*?\n  function chatIdFromRowEvent/
@@ -116,7 +116,7 @@ describe('/chats page', () => {
 
     expect(selectChatBody).toBeTruthy();
     expect(selectChatBody).toMatch(
-      /await syncCommittedDetailUrl\(chatId, \{ mode: 'push' \}\);[\s\S]*?await pageController\.selectChat\(chatId, \{ syncUrl: true \}\);/
+      /await syncCommittedDetailUrl\(chatId, \{ mode: 'push' \}\);[\s\S]*?pageController\.setRoute\(currentRouteSnapshot\(\)\);[\s\S]*?await pageController\.selectChat\(chatId, \{ syncUrl: true \}\);/
     );
   });
 


### PR DESCRIPTION
## Summary
- Fixes chat row selection by pushing the selected `/chats/{id}` URL before activating the detail controller.
- Adds a regression assertion so future edits keep URL projection ahead of controller activation.

## Root cause
Row selection activated the new chat while the browser URL still pointed at the previous chat. The read-model store publishes synchronously during activation, so the page controller reconciled against the stale route and could reselect the old chat. The URL was then pushed to the new chat, leaving the URL and right-hand panel out of sync until refresh.

## Validation
- `pnpm web:test -- --run src/routes/chats/page.test.ts`
- `pnpm web:lint`
- pre-commit web-ui lane: full pytest 9594 passed, web build passed, full web tests 892 passed / 2 skipped, SPA shell check passed
