### PR TITLE
[codex] Stabilize SCM polling feedback dedup

### DIFF
--- a/src/codex_autorunner/adapters/github/polling.py
+++ b/src/codex_autorunner/adapters/github/polling.py
@@ -51,6 +51,7 @@ from .polling_snapshot import (
     build_snapshot,
     initial_post_open_boost_until,
     snapshot_with_polling_metadata,
+    snapshot_without_backfilled_comments,
 )
 from .publisher import build_github_publish_executors
 
@@ -379,6 +380,20 @@ class GitHubScmPollingService:
                 now_iso_fn=now_iso,
             )
         except Exception:
+            retry_snapshot = snapshot_without_backfilled_comments(
+                snapshot,
+                reference_timestamp=now_timestamp,
+                window_seconds=polling_config.comment_backfill_window_seconds,
+                parse_optional_iso=_parse_optional_iso,
+            )
+            self._watch_store.refresh_watch(
+                watch_id=watch.watch_id,
+                snapshot=snapshot_with_polling_metadata(
+                    snapshot=retry_snapshot,
+                    previous_snapshot=snapshot,
+                    post_open_boost_until=post_open_boost,
+                ),
+            )
             _LOGGER.warning(
                 "Failed emitting SCM polling comment backfill for %s#%s",
                 binding.repo_slug,

--- a/src/codex_autorunner/adapters/github/polling_events.py
+++ b/src/codex_autorunner/adapters/github/polling_events.py
@@ -1,122 +1,139 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
-import uuid
+from dataclasses import dataclass
 from typing import Any, Callable, Mapping
 
 from ...core.pr_bindings import PrBinding
-from ...core.publish_journal import PublishOperation
-from ...core.scm_events import ScmEventStore
+from ...core.scm_events import ScmEvent, ScmEventStore
 from ...core.scm_polling_watches import ScmPollingWatch
 from ...core.text_utils import _mapping, _normalize_text
 from .polling_snapshot import _comment_timestamp, snapshot_map
 
 _LOGGER = logging.getLogger(__name__)
-_PROCESSED_REVIEW_COMMENTS_KEY = "processed_review_comment_ids"
-_MAX_PROCESSED_REVIEW_COMMENTS_PER_SCOPE = 500
 
 
-def _processed_review_comment_scope(binding: PrBinding) -> str:
-    return _normalize_text(binding.thread_target_id) or "unbound"
+@dataclass(frozen=True)
+class PollEventRecord:
+    event: ScmEvent
+    created: bool
 
 
-def _processed_review_comments(snapshot: Mapping[str, Any]) -> dict[str, Any]:
-    processed = snapshot.get(_PROCESSED_REVIEW_COMMENTS_KEY)
-    return dict(processed) if isinstance(processed, Mapping) else {}
+def _canonical_payload(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _canonical_payload(mapped_value)
+            for key, mapped_value in sorted(
+                value.items(), key=lambda item: str(item[0])
+            )
+            if mapped_value is not None
+        }
+    if isinstance(value, list):
+        return [_canonical_payload(item) for item in value]
+    return value
 
 
-def _processed_review_comments_for_scope(
-    snapshot: Mapping[str, Any],
+def _stable_poll_event_id(
     *,
-    binding: PrBinding,
-) -> dict[str, str]:
-    scoped = _processed_review_comments(snapshot)
-    scope = _processed_review_comment_scope(binding)
-    values = scoped.get(scope)
-    if not isinstance(values, Mapping):
-        return {}
-    normalized: dict[str, str] = {}
-    for key, value in values.items():
-        comment_id = _normalize_text(key)
-        processed_at = _normalize_text(value)
-        if comment_id is not None and processed_at is not None:
-            normalized[comment_id] = processed_at
-    return normalized
-
-
-def _inherit_processed_review_comments(
-    *,
-    previous_snapshot: Mapping[str, Any],
-    snapshot: dict[str, Any],
-) -> None:
-    processed = _processed_review_comments(previous_snapshot)
-    if processed:
-        snapshot[_PROCESSED_REVIEW_COMMENTS_KEY] = processed
-
-
-def _review_comment_was_processed(
+    event_type: str,
+    watch: ScmPollingWatch,
     payload: Mapping[str, Any],
+) -> str:
+    payload_map = _mapping(payload)
+    identity_payload: dict[str, Any] = {
+        "event_type": event_type,
+        "payload": _canonical_payload(payload_map),
+        "pr_number": watch.pr_number,
+        "provider": "github",
+        "repo_slug": watch.repo_slug,
+    }
+    if event_type in {"issue_comment", "pull_request_review_comment"}:
+        identity_payload["subject"] = {
+            "comment_id": _normalize_text(payload_map.get("comment_id")),
+            "updated_at": _comment_timestamp(payload_map),
+        }
+    elif event_type == "pull_request_review":
+        identity_payload["subject"] = {
+            "review_id": _normalize_text(payload_map.get("review_id")),
+            "submitted_at": _normalize_text(payload_map.get("submitted_at")),
+        }
+    elif event_type == "check_run":
+        identity_payload["subject"] = {
+            "conclusion": _normalize_text(payload_map.get("conclusion")),
+            "details_url": _normalize_text(payload_map.get("details_url")),
+            "head_sha": _normalize_text(payload_map.get("head_sha")),
+            "name": _normalize_text(payload_map.get("name")),
+        }
+    encoded = json.dumps(
+        _canonical_payload(identity_payload),
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:32]
+    return f"github:poll:{event_type}:{digest}"
+
+
+def _record_poll_event(
     *,
-    processed: Mapping[str, str],
+    event_store: ScmEventStore,
+    watch: ScmPollingWatch,
+    binding: PrBinding,
+    event_type: str,
+    occurred_at: str,
+    received_at: str,
+    payload: Mapping[str, Any],
+) -> PollEventRecord:
+    event_id = _stable_poll_event_id(
+        event_type=event_type,
+        watch=watch,
+        payload=payload,
+    )
+    event = event_store.record_event_if_new(
+        event_id=event_id,
+        provider="github",
+        event_type=event_type,
+        occurred_at=occurred_at,
+        received_at=received_at,
+        repo_slug=watch.repo_slug,
+        repo_id=binding.repo_id or watch.repo_id,
+        pr_number=watch.pr_number,
+        correlation_id=f"scm-poll:{watch.watch_id}",
+        payload=dict(payload),
+    )
+    if event is not None:
+        return PollEventRecord(event=event, created=True)
+    existing = event_store.get_event(event_id)
+    if existing is None:
+        raise RuntimeError("SCM event row missing after duplicate poll event")
+    return PollEventRecord(event=existing, created=False)
+
+
+def _automation_needs_poll_event(
+    *,
+    automation_service: Any,
+    event: ScmEvent,
 ) -> bool:
-    comment_id = _normalize_text(payload.get("comment_id"))
-    if comment_id is None:
+    checker = getattr(automation_service, "scm_event_needs_processing", None)
+    if not callable(checker):
         return False
-    processed_at = _normalize_text(processed.get(comment_id))
-    if processed_at is None:
-        return False
-    updated_at = _comment_timestamp(payload)
-    if updated_at is None:
-        return True
-    return updated_at <= processed_at
+    return bool(checker(event.event_id))
 
 
-def _mark_review_comment_processed(
-    snapshot: dict[str, Any],
-    payload: Mapping[str, Any],
+def _ingest_poll_event(
     *,
-    binding: PrBinding,
-) -> None:
-    comment_id = _normalize_text(payload.get("comment_id"))
-    if comment_id is None:
-        return
-    processed_at = _comment_timestamp(payload) or _normalize_text(
-        payload.get("created_at")
-    )
-    if processed_at is None:
-        return
-    scoped = _processed_review_comments(snapshot)
-    scope = _processed_review_comment_scope(binding)
-    existing_scope_values = scoped.get(scope)
-    scope_values = (
-        dict(existing_scope_values)
-        if isinstance(existing_scope_values, Mapping)
-        else {}
-    )
-    scope_values[comment_id] = processed_at
-    if len(scope_values) > _MAX_PROCESSED_REVIEW_COMMENTS_PER_SCOPE:
-        scope_values = dict(
-            sorted(scope_values.items(), key=lambda item: item[1], reverse=True)[
-                :_MAX_PROCESSED_REVIEW_COMMENTS_PER_SCOPE
-            ]
-        )
-    scoped[scope] = scope_values
-    snapshot[_PROCESSED_REVIEW_COMMENTS_KEY] = scoped
-
-
-def _ingest_created_enqueue(result: Any) -> bool:
-    operations = getattr(result, "publish_operations", None)
-    if operations is None:
-        return True
-    for operation in operations:
-        if (
-            isinstance(operation, PublishOperation)
-            and operation.operation_kind == "enqueue_managed_turn"
-        ):
-            return True
-        if getattr(operation, "operation_kind", None) == "enqueue_managed_turn":
-            return True
-    return False
+    automation_service: Any,
+    record: PollEventRecord,
+) -> bool:
+    if not record.created and not _automation_needs_poll_event(
+        automation_service=automation_service,
+        event=record.event,
+    ):
+        return False
+    _ingest_and_process_scm_automation_jobs(automation_service, record.event)
+    return True
 
 
 def _ingest_and_process_scm_automation_jobs(automation_service: Any, event: Any) -> Any:
@@ -154,10 +171,6 @@ def emit_new_conditions(
     now_iso_fn: Any,
 ) -> int:
     snapshot = snapshot if isinstance(snapshot, dict) else dict(snapshot)
-    _inherit_processed_review_comments(
-        previous_snapshot=previous_snapshot,
-        snapshot=snapshot,
-    )
     current_head_sha = _normalize_text(snapshot.get("head_sha"))
     previous_reviews = snapshot_map(previous_snapshot, "changes_requested_reviews")
     current_reviews = snapshot_map(snapshot, "changes_requested_reviews")
@@ -169,10 +182,6 @@ def emit_new_conditions(
         previous_snapshot, "review_thread_comments"
     )
     current_review_thread_comments = snapshot_map(snapshot, "review_thread_comments")
-    processed_review_comments = _processed_review_comments_for_scope(
-        snapshot,
-        binding=binding,
-    )
 
     has_new = False
     for key in current_reviews:
@@ -198,10 +207,6 @@ def emit_new_conditions(
             if (
                 not bool(payload.get("thread_resolved"))
                 and key not in previous_review_thread_comments
-                and not _review_comment_was_processed(
-                    _mapping(payload),
-                    processed=processed_review_comments,
-                )
             ):
                 has_new = True
                 break
@@ -214,20 +219,17 @@ def emit_new_conditions(
     for key, payload in current_reviews.items():
         if key in previous_reviews:
             continue
-        event = event_store.record_event(
-            event_id=f"github:poll:review:{watch.watch_id}:{uuid.uuid4().hex[:12]}",
-            provider="github",
+        record = _record_poll_event(
+            event_store=event_store,
+            watch=watch,
+            binding=binding,
             event_type="pull_request_review",
             occurred_at=_normalize_text(payload.get("submitted_at")) or now_iso_fn(),
             received_at=now_iso_fn(),
-            repo_slug=watch.repo_slug,
-            repo_id=binding.repo_id or watch.repo_id,
-            pr_number=watch.pr_number,
-            correlation_id=f"scm-poll:{watch.watch_id}",
-            payload=dict(payload),
+            payload=_mapping(payload),
         )
-        _ingest_and_process_scm_automation_jobs(automation_service, event)
-        emitted += 1
+        if _ingest_poll_event(automation_service=automation_service, record=record):
+            emitted += 1
 
     for key, payload in current_checks.items():
         if key in previous_checks:
@@ -237,40 +239,32 @@ def emit_new_conditions(
             current_head_sha=current_head_sha,
         ):
             continue
-        event = event_store.record_event(
-            event_id=f"github:poll:check:{watch.watch_id}:{uuid.uuid4().hex[:12]}",
-            provider="github",
+        record = _record_poll_event(
+            event_store=event_store,
+            watch=watch,
+            binding=binding,
             event_type="check_run",
             occurred_at=now_iso_fn(),
             received_at=now_iso_fn(),
-            repo_slug=watch.repo_slug,
-            repo_id=binding.repo_id or watch.repo_id,
-            pr_number=watch.pr_number,
-            correlation_id=f"scm-poll:{watch.watch_id}",
-            payload=dict(payload),
+            payload=_mapping(payload),
         )
-        _ingest_and_process_scm_automation_jobs(automation_service, event)
-        emitted += 1
+        if _ingest_poll_event(automation_service=automation_service, record=record):
+            emitted += 1
 
     for key, payload in current_issue_comments.items():
         if key in previous_issue_comments:
             continue
-        event = event_store.record_event(
-            event_id=(
-                f"github:poll:issue-comment:{watch.watch_id}:{uuid.uuid4().hex[:12]}"
-            ),
-            provider="github",
+        record = _record_poll_event(
+            event_store=event_store,
+            watch=watch,
+            binding=binding,
             event_type="issue_comment",
             occurred_at=_comment_timestamp(payload) or now_iso_fn(),
             received_at=now_iso_fn(),
-            repo_slug=watch.repo_slug,
-            repo_id=binding.repo_id or watch.repo_id,
-            pr_number=watch.pr_number,
-            correlation_id=f"scm-poll:{watch.watch_id}",
-            payload=dict(payload),
+            payload=_mapping(payload),
         )
-        _ingest_and_process_scm_automation_jobs(automation_service, event)
-        emitted += 1
+        if _ingest_poll_event(automation_service=automation_service, record=record):
+            emitted += 1
 
     for key, payload in current_review_thread_comments.items():
         if bool(payload.get("thread_resolved")):
@@ -278,10 +272,16 @@ def emit_new_conditions(
         if key in previous_review_thread_comments:
             continue
         payload_mapping = _mapping(payload)
-        if _review_comment_was_processed(
-            payload_mapping,
-            processed=processed_review_comments,
-        ):
+        record = _record_poll_event(
+            event_store=event_store,
+            watch=watch,
+            binding=binding,
+            event_type="pull_request_review_comment",
+            occurred_at=_comment_timestamp(payload) or now_iso_fn(),
+            received_at=now_iso_fn(),
+            payload=payload_mapping,
+        )
+        if not _ingest_poll_event(automation_service=automation_service, record=record):
             _LOGGER.info(
                 "Suppressed duplicate SCM polling review comment event "
                 "watch_id=%s thread_target_id=%s comment_id=%s",
@@ -290,33 +290,6 @@ def emit_new_conditions(
                 _normalize_text(payload_mapping.get("comment_id")),
             )
             continue
-        event = event_store.record_event(
-            event_id=(
-                f"github:poll:review-comment:{watch.watch_id}:{uuid.uuid4().hex[:12]}"
-            ),
-            provider="github",
-            event_type="pull_request_review_comment",
-            occurred_at=_comment_timestamp(payload) or now_iso_fn(),
-            received_at=now_iso_fn(),
-            repo_slug=watch.repo_slug,
-            repo_id=binding.repo_id or watch.repo_id,
-            pr_number=watch.pr_number,
-            correlation_id=f"scm-poll:{watch.watch_id}",
-            payload=dict(payload_mapping),
-        )
-        ingest_result = _ingest_and_process_scm_automation_jobs(
-            automation_service, event
-        )
-        if _ingest_created_enqueue(ingest_result):
-            _mark_review_comment_processed(
-                snapshot,
-                payload_mapping,
-                binding=binding,
-            )
-            processed_review_comments = _processed_review_comments_for_scope(
-                snapshot,
-                binding=binding,
-            )
         emitted += 1
 
     if emitted:

--- a/src/codex_autorunner/adapters/github/polling_events.py
+++ b/src/codex_autorunner/adapters/github/polling_events.py
@@ -39,10 +39,15 @@ def _stable_poll_event_id(
     *,
     event_type: str,
     watch: ScmPollingWatch,
+    binding: PrBinding,
     payload: Mapping[str, Any],
 ) -> str:
     payload_map = _mapping(payload)
     identity_payload: dict[str, Any] = {
+        "binding": {
+            "binding_id": binding.binding_id,
+            "thread_target_id": binding.thread_target_id,
+        },
         "event_type": event_type,
         "payload": _canonical_payload(payload_map),
         "pr_number": watch.pr_number,
@@ -89,6 +94,7 @@ def _record_poll_event(
     event_id = _stable_poll_event_id(
         event_type=event_type,
         watch=watch,
+        binding=binding,
         payload=payload,
     )
     event = event_store.record_event_if_new(

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -1843,6 +1843,24 @@ class ScmAutomationService:
             if job.event_id == automation_event.event_id
         )
 
+    def scm_event_needs_processing(self, event_id: str) -> bool:
+        normalized_event_id = _normalize_text(event_id)
+        if normalized_event_id is None:
+            return False
+        automation_event_id = f"scm:{normalized_event_id}"
+        automation_event = self._automation_store.get_event(automation_event_id)
+        if automation_event is None:
+            return True
+        event_jobs = tuple(
+            job
+            for job in self._automation_store.list_jobs(limit=1000)
+            if job.event_id == automation_event_id and _is_scm_publish_bridge_job(job)
+        )
+        if not event_jobs:
+            actions = automation_event.payload.get("actions")
+            return isinstance(actions, list) and bool(actions)
+        return any(job.state == "pending" for job in event_jobs)
+
     def process_scm_automation_jobs(
         self,
         *,

--- a/src/codex_autorunner/core/scm_events.py
+++ b/src/codex_autorunner/core/scm_events.py
@@ -94,6 +94,40 @@ class ScmEventStore:
     def __init__(self, hub_root: Path) -> None:
         self._hub_root = Path(hub_root)
 
+    def record_event_if_new(
+        self,
+        *,
+        provider: str,
+        event_type: str,
+        occurred_at: Optional[str] = None,
+        received_at: Optional[str] = None,
+        repo_slug: Optional[str] = None,
+        repo_id: Optional[str] = None,
+        pr_number: Optional[int] = None,
+        delivery_id: Optional[str] = None,
+        correlation_id: Optional[str] = None,
+        payload: Optional[dict[str, Any]] = None,
+        raw_payload: Optional[dict[str, Any]] = None,
+        event_id: str,
+        max_raw_payload_bytes: int = 65_536,
+    ) -> Optional[ScmEvent]:
+        return self._record_event(
+            provider=provider,
+            event_type=event_type,
+            occurred_at=occurred_at,
+            received_at=received_at,
+            repo_slug=repo_slug,
+            repo_id=repo_id,
+            pr_number=pr_number,
+            delivery_id=delivery_id,
+            correlation_id=correlation_id,
+            payload=payload,
+            raw_payload=raw_payload,
+            event_id=event_id,
+            max_raw_payload_bytes=max_raw_payload_bytes,
+            require_new=False,
+        )
+
     def record_event(
         self,
         *,
@@ -111,6 +145,44 @@ class ScmEventStore:
         event_id: Optional[str] = None,
         max_raw_payload_bytes: int = 65_536,
     ) -> ScmEvent:
+        event = self._record_event(
+            provider=provider,
+            event_type=event_type,
+            occurred_at=occurred_at,
+            received_at=received_at,
+            repo_slug=repo_slug,
+            repo_id=repo_id,
+            pr_number=pr_number,
+            delivery_id=delivery_id,
+            correlation_id=correlation_id,
+            payload=payload,
+            raw_payload=raw_payload,
+            event_id=event_id,
+            max_raw_payload_bytes=max_raw_payload_bytes,
+            require_new=True,
+        )
+        if event is None:
+            raise RuntimeError("SCM event row missing after insert")
+        return event
+
+    def _record_event(
+        self,
+        *,
+        provider: str,
+        event_type: str,
+        occurred_at: Optional[str],
+        received_at: Optional[str],
+        repo_slug: Optional[str],
+        repo_id: Optional[str],
+        pr_number: Optional[int],
+        delivery_id: Optional[str],
+        correlation_id: Optional[str],
+        payload: Optional[dict[str, Any]],
+        raw_payload: Optional[dict[str, Any]],
+        event_id: Optional[str],
+        max_raw_payload_bytes: int,
+        require_new: bool,
+    ) -> Optional[ScmEvent]:
         normalized_provider = _normalize_text(provider)
         normalized_event_type = _normalize_text(event_type)
         normalized_event_id = _normalize_text(event_id) or uuid.uuid4().hex
@@ -144,9 +216,10 @@ class ScmEventStore:
         normalized_pr_number = _normalize_int(pr_number, field_name="pr_number")
 
         with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
-            conn.execute(
-                """
-                INSERT INTO orch_scm_events (
+            verb = "INSERT" if require_new else "INSERT OR IGNORE"
+            cursor = conn.execute(
+                f"""
+                {verb} INTO orch_scm_events (
                     event_id,
                     provider,
                     event_type,
@@ -178,6 +251,8 @@ class ScmEventStore:
                     created_at,
                 ),
             )
+            if not require_new and cursor.rowcount == 0:
+                return None
             row = conn.execute(
                 """
                 SELECT *

--- a/tests/adapters/github/test_polling.py
+++ b/tests/adapters/github/test_polling.py
@@ -17,6 +17,7 @@ from codex_autorunner.adapters.github.polling import (
     GitHubScmPollingService,
 )
 from codex_autorunner.adapters.github.polling_events import emit_new_conditions
+from codex_autorunner.core.automation import AutomationEvent
 from codex_autorunner.core.automation.store import AutomationStore
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
@@ -123,6 +124,32 @@ class _AutomationServiceFake:
         _ = limit
         type(self).process_calls += 1
         return []
+
+
+class _FailingAutomationServiceFake(_AutomationServiceFake):
+    def ingest_event(self, event) -> None:
+        _ = event
+        raise RuntimeError("automation ingestion failed")
+
+
+class _RetryNeededAutomationServiceFake(_AutomationServiceFake):
+    def scm_event_needs_processing(self, event_id: str) -> bool:
+        _ = event_id
+        return True
+
+
+class _AutomationStoreNeedsProcessingStub:
+    def __init__(self, event: AutomationEvent | None, jobs=None) -> None:
+        self._event = event
+        self._jobs = list(jobs or [])
+
+    def get_event(self, event_id: str):
+        _ = event_id
+        return self._event
+
+    def list_jobs(self, *, limit: int):
+        _ = limit
+        return list(self._jobs)
 
 
 class _DiscoveringGitHubServiceStub(_GitHubServiceStub):
@@ -587,10 +614,17 @@ def test_polling_config_defaults_to_30_minute_post_open_boost() -> None:
     assert config.no_activity_tier == "cold"
 
 
-def test_emit_new_conditions_dedupes_review_comments_by_processed_comment_id(
+def test_emit_new_conditions_dedupes_review_comments_by_stable_event_id(
     tmp_path: Path,
 ) -> None:
-    binding = _polling_test_binding()
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
     watch = _polling_watch_for_binding(tmp_path, binding)
     _AutomationServiceFake.ingested_events = []
     _AutomationServiceFake.process_calls = 0
@@ -622,6 +656,212 @@ def test_emit_new_conditions_dedupes_review_comments_by_processed_comment_id(
         (event_type, payload["comment_id"])
         for event_type, payload, _config in _AutomationServiceFake.ingested_events
     ] == [("pull_request_review_comment", "2844")]
+
+
+def test_emit_new_conditions_retries_existing_event_when_automation_needs_processing(
+    tmp_path: Path,
+) -> None:
+    binding = _polling_test_binding()
+    watch = _polling_watch_for_binding(tmp_path, binding)
+    _AutomationServiceFake.ingested_events = []
+    snapshot: dict[str, object] = {
+        "review_thread_comments": {"poll-a": _review_comment_payload("2844")}
+    }
+
+    with pytest.raises(RuntimeError, match="automation ingestion failed"):
+        emit_new_conditions(
+            event_store=ScmEventStore(tmp_path),
+            watch=watch,
+            binding=binding,
+            previous_snapshot={"review_thread_comments": {}},
+            snapshot=snapshot,
+            automation_service_factory=lambda: _FailingAutomationServiceFake(tmp_path),
+            now_iso_fn=lambda: "2026-03-30T00:05:00Z",
+        )
+
+    emitted = emit_new_conditions(
+        event_store=ScmEventStore(tmp_path),
+        watch=watch,
+        binding=binding,
+        previous_snapshot={"review_thread_comments": {}},
+        snapshot=snapshot,
+        automation_service_factory=lambda: _RetryNeededAutomationServiceFake(tmp_path),
+        now_iso_fn=lambda: "2026-03-30T00:06:00Z",
+    )
+
+    assert emitted == 1
+    assert [
+        (event_type, payload["comment_id"])
+        for event_type, payload, _config in _AutomationServiceFake.ingested_events
+    ] == [("pull_request_review_comment", "2844")]
+
+
+def test_arm_watch_backfill_failure_keeps_comment_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    comment = _review_comment_payload("2844")
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "abc123",
+                "createdAt": "2026-03-30T00:00:00Z",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+            review_threads_payload=[
+                {
+                    "isResolved": False,
+                    "comments": [comment],
+                }
+            ],
+        )
+
+    monkeypatch.setattr(github_polling, "now_iso", lambda: "2026-03-30T00:05:00Z")
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(post_open_boost_minutes=0),
+        github_service_factory=_factory,
+    )
+    automation_services = [
+        _FailingAutomationServiceFake(tmp_path),
+        _RetryNeededAutomationServiceFake(tmp_path),
+    ]
+    monkeypatch.setattr(
+        service,
+        "_build_automation_service",
+        lambda **kwargs: automation_services.pop(0),
+    )
+    _AutomationServiceFake.ingested_events = []
+
+    watch = service.arm_watch(
+        binding=binding,
+        workspace_root=tmp_path / "repo",
+        next_poll_at="2026-03-30T00:00:00Z",
+    )
+
+    assert watch is not None
+    refreshed = ScmPollingWatchStore(tmp_path).get_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+    )
+    assert refreshed is not None
+    assert refreshed.snapshot.get("review_thread_comments") is None
+
+    counts = service.process(limit=1)
+
+    assert counts["events_emitted"] == 1
+    assert [
+        (event_type, payload["comment_id"])
+        for event_type, payload, _config in _AutomationServiceFake.ingested_events
+    ] == [("pull_request_review_comment", "2844")]
+
+
+def test_scm_event_needs_processing_ignores_actionless_existing_event() -> None:
+    service = object.__new__(ScmAutomationService)
+    event = AutomationEvent.create(
+        event_id="scm:github:poll:ignored",
+        event_type="scm.github.pull_request_review_comment.created",
+        source="scm.github",
+        payload={"actions": []},
+    )
+    service._automation_store = _AutomationStoreNeedsProcessingStub(event)
+
+    assert service.scm_event_needs_processing("github:poll:ignored") is False
+
+
+@pytest.mark.parametrize(
+    ("snapshot_key", "event_type", "payload"),
+    [
+        (
+            "changes_requested_reviews",
+            "pull_request_review",
+            {
+                "action": "submitted",
+                "review_id": "rev-1",
+                "review_state": "CHANGES_REQUESTED",
+                "submitted_at": "2026-03-30T00:04:00Z",
+            },
+        ),
+        (
+            "failed_checks",
+            "check_run",
+            {
+                "action": "completed",
+                "name": "unit-tests",
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": "abc123",
+                "details_url": "https://example.invalid/checks/1",
+            },
+        ),
+        (
+            "issue_comments",
+            "issue_comment",
+            {
+                "action": "created",
+                "comment_id": "issue-comment-1",
+                "body": "Please follow up.",
+                "updated_at": "2026-03-30T00:04:00Z",
+            },
+        ),
+    ],
+)
+def test_emit_new_conditions_dedupes_non_thread_events_by_stable_event_id(
+    tmp_path: Path,
+    snapshot_key: str,
+    event_type: str,
+    payload: dict[str, object],
+) -> None:
+    binding = _polling_test_binding()
+    watch = _polling_watch_for_binding(tmp_path, binding)
+    _AutomationServiceFake.ingested_events = []
+    base_snapshot: dict[str, object] = {"head_sha": "abc123"}
+    first_snapshot = {**base_snapshot, snapshot_key: {"poll-a": payload}}
+    second_snapshot = {**base_snapshot, snapshot_key: {"poll-b": payload}}
+
+    assert (
+        emit_new_conditions(
+            event_store=ScmEventStore(tmp_path),
+            watch=watch,
+            binding=binding,
+            previous_snapshot={**base_snapshot, snapshot_key: {}},
+            snapshot=first_snapshot,
+            automation_service_factory=lambda: _AutomationServiceFake(tmp_path),
+            now_iso_fn=lambda: "2026-03-30T00:05:00Z",
+        )
+        == 1
+    )
+    assert (
+        emit_new_conditions(
+            event_store=ScmEventStore(tmp_path),
+            watch=watch,
+            binding=binding,
+            previous_snapshot=first_snapshot,
+            snapshot=second_snapshot,
+            automation_service_factory=lambda: _AutomationServiceFake(tmp_path),
+            now_iso_fn=lambda: "2026-03-30T00:06:00Z",
+        )
+        == 0
+    )
+
+    assert [observed[0] for observed in _AutomationServiceFake.ingested_events] == [
+        event_type
+    ]
 
 
 def test_emit_new_conditions_dispatches_only_new_comment_in_mixed_poll(

--- a/tests/adapters/github/test_polling.py
+++ b/tests/adapters/github/test_polling.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -656,6 +656,52 @@ def test_emit_new_conditions_dedupes_review_comments_by_stable_event_id(
         (event_type, payload["comment_id"])
         for event_type, payload, _config in _AutomationServiceFake.ingested_events
     ] == [("pull_request_review_comment", "2844")]
+
+
+def test_emit_new_conditions_redelivers_comment_when_binding_gets_thread_target(
+    tmp_path: Path,
+) -> None:
+    store = PrBindingStore(tmp_path)
+    unbound_binding = store.upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    unbound_watch = _polling_watch_for_binding(tmp_path, unbound_binding)
+    _AutomationServiceFake.ingested_events = []
+    snapshot: dict[str, object] = {
+        "review_thread_comments": {"poll-a": _review_comment_payload("2844")}
+    }
+
+    first_emitted = _emit_review_comment_snapshot(
+        tmp_path,
+        watch=unbound_watch,
+        binding=unbound_binding,
+        previous_snapshot={"review_thread_comments": {}},
+        snapshot=snapshot,
+    )
+    bound_binding = replace(unbound_binding, thread_target_id="thread-123")
+    bound_watch = _polling_watch_for_binding(tmp_path, bound_binding)
+    second_emitted = _emit_review_comment_snapshot(
+        tmp_path,
+        watch=bound_watch,
+        binding=bound_binding,
+        previous_snapshot={"review_thread_comments": {}},
+        snapshot=snapshot,
+    )
+
+    assert first_emitted == 1
+    assert second_emitted == 1
+    assert [
+        (event_type, payload["comment_id"])
+        for event_type, payload, _config in _AutomationServiceFake.ingested_events
+    ] == [
+        ("pull_request_review_comment", "2844"),
+        ("pull_request_review_comment", "2844"),
+    ]
 
 
 def test_emit_new_conditions_retries_existing_event_when_automation_needs_processing(

--- a/tests/core/test_scm_events.py
+++ b/tests/core/test_scm_events.py
@@ -53,6 +53,39 @@ def test_record_event_and_list_filtered_events(tmp_path: Path) -> None:
     assert by_pr[0].raw_payload == {"pull_request": {"number": 17}}
 
 
+def test_record_event_if_new_returns_none_for_existing_event_id(tmp_path: Path) -> None:
+    store = ScmEventStore(tmp_path)
+
+    created = store.record_event_if_new(
+        event_id="github:poll:pull_request_review_comment:comment-1",
+        provider="github",
+        event_type="pull_request_review_comment",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=17,
+        occurred_at="2026-03-25T00:00:00Z",
+        received_at="2026-03-25T00:00:01Z",
+        payload={"action": "created", "comment_id": "comment-1"},
+    )
+    duplicate = store.record_event_if_new(
+        event_id="github:poll:pull_request_review_comment:comment-1",
+        provider="github",
+        event_type="pull_request_review_comment",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=17,
+        occurred_at="2026-03-25T00:00:00Z",
+        received_at="2026-03-25T00:05:00Z",
+        payload={"action": "created", "comment_id": "comment-1"},
+    )
+
+    assert created is not None
+    assert duplicate is None
+    assert [event.event_id for event in store.list_events(limit=10)] == [
+        "github:poll:pull_request_review_comment:comment-1"
+    ]
+
+
 def test_record_event_rejects_oversized_raw_payload(tmp_path: Path) -> None:
     store = ScmEventStore(tmp_path)
 


### PR DESCRIPTION
## Summary
- Replace snapshot-side processed review comment tracking with durable canonical SCM poll event IDs.
- Add ScmEventStore.record_event_if_new() as the single durable claim point for polled SCM events.
- Allow duplicate observations to retry only when the canonical automation work is missing or still pending.
- Keep initial backfill comments retryable when automation ingestion fails by restoring the pre-backfill watch snapshot.

## Review Notes
- Mini swarm review completed with two focused reviewers after implementation.
- Addressed the initial retry gap where a claimed SCM event could suppress failed automation ingestion.
- Addressed the backfill failure path so arm_watch does not permanently baseline a failed comment.
- Addressed the actionless existing-event case so no-op events do not retry forever.

## Verification
- Commit hook aggregate lane passed.
- Python formatting, ruff, import boundaries, contract checks, and strict repo-wide mypy passed.
- Repo-wide pytest passed: 9595 tests.
- Web Hub build passed.
- Web Hub frontend tests passed: 893 passed, 2 skipped.
- Focused SCM polling/core tests passed before commit.