### PR TITLE
Clean up Hermes ACP output assembly

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -58,7 +58,11 @@ from .events import (
     ACPTurnTerminalEvent,
     normalize_notification,
 )
-from .output_normalizer import ACPIngressNormalizedOutput, normalize_acp_ingress_output
+from .output_normalizer import (
+    ACPIngressInputKind,
+    ACPIngressNormalizedOutput,
+    normalize_acp_ingress_output,
+)
 from .protocol import (
     ACPAdvertisedCommand,
     ACPInitializeResult,
@@ -225,6 +229,46 @@ def _text_excerpt(value: Any, *, limit: int = 120) -> Optional[str]:
     if len(normalized) <= limit:
         return normalized
     return normalized[: limit - 3] + "..."
+
+
+def _compact_text(value: str) -> str:
+    return "".join(str(value or "").split())
+
+
+def _looks_like_transcript_projection(text: str) -> bool:
+    if not text:
+        return False
+    return bool(
+        re.search(r"(?im)(?:^|\n)\s*(?:user|human)\s*:", text)
+        and re.search(r"(?im)(?:^|\n)\s*(?:assistant|agent)\s*:", text)
+    )
+
+
+def _session_update_input_kind(
+    state: _PromptState,
+    text: str,
+) -> ACPIngressInputKind:
+    """Classify Hermes/ACP assistant updates before text assembly.
+
+    `agent_message_chunk` is an append-only delta unless the payload carries
+    clear cumulative evidence. Treating all updates as snapshots corrupts
+    markdown token splits such as "``" + "`\n".
+    """
+
+    if not text:
+        return "current_turn_delta"
+    if state.final_output and text.startswith(state.final_output):
+        return "current_turn_snapshot"
+    if _looks_like_transcript_projection(text):
+        return "current_turn_snapshot"
+    compact_incoming = _compact_text(text)
+    if not compact_incoming:
+        return "current_turn_delta"
+    for prior in state.prior_assistant_texts:
+        compact_prior = _compact_text(prior)
+        if compact_prior and compact_incoming.startswith(compact_prior):
+            return "current_turn_snapshot"
+    return "current_turn_delta"
 
 
 def _stringify(value: Any) -> str:
@@ -1202,10 +1246,15 @@ class ACPClient:
             return event
         self._note_prompt_trace_event(state, event)
         if isinstance(event, ACPOutputDeltaEvent):
+            input_kind: ACPIngressInputKind = (
+                _session_update_input_kind(state, event.delta)
+                if event.method == "session/update"
+                else "current_turn_delta"
+            )
             normalized_delta = state.note_output_delta(
                 event.delta,
-                merge_snapshot=event.method == "session/update",
-                preserve_word_boundaries=event.method == "session/update",
+                merge_snapshot=input_kind == "current_turn_snapshot",
+                preserve_word_boundaries=False,
             )
             self._log_ingress_normalization(state, normalized_delta)
             event = replace(event, delta=normalized_delta.text)

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -185,10 +185,6 @@ def _formatted_current_turn_output(
             return final_text[index:].strip()
     if _terminal_text_looks_cumulative(final_stripped, stream_stripped):
         return stream_stripped
-    if stream_stripped and "\n\n" in final_stripped:
-        terminal_tail = final_stripped.rsplit("\n\n", 1)[-1].strip()
-        if terminal_tail:
-            return terminal_tail
     return final_stripped
 
 

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -129,6 +129,17 @@ def _text_without_whitespace(value: str) -> str:
     return "".join(str(value or "").split())
 
 
+def _terminal_text_looks_cumulative(final_text: str, stream_text: str) -> bool:
+    final_compact = _text_without_whitespace(final_text)
+    stream_compact = _text_without_whitespace(stream_text)
+    return bool(
+        final_compact
+        and stream_compact
+        and final_compact.endswith(stream_compact)
+        and final_compact != stream_compact
+    )
+
+
 def _formatted_current_turn_output(
     *,
     final_output: str,
@@ -140,7 +151,8 @@ def _formatted_current_turn_output(
     to the active turn but may be tokenizer fragments with poor spacing, while
     terminal `finalOutput` preserves formatting but may include prior transcript
     text. The compact suffix match lets the stream prove the current-turn scope
-    before we trust terminal formatting.
+    before we trim terminal formatting. When it cannot prove scope, keep
+    terminal formatting rather than returning damaged stream text.
     """
 
     final_text = str(final_output or "")
@@ -171,7 +183,13 @@ def _formatted_current_turn_output(
             and "".join(reversed(compact_suffix_reversed)) == stream_compact
         ):
             return final_text[index:].strip()
-    return stream_stripped
+    if _terminal_text_looks_cumulative(final_stripped, stream_stripped):
+        return stream_stripped
+    if stream_stripped and "\n\n" in final_stripped:
+        terminal_tail = final_stripped.rsplit("\n\n", 1)[-1].strip()
+        if terminal_tail:
+            return terminal_tail
+    return final_stripped
 
 
 def _replace_session_update_content_text(content: Any, text: str) -> Any:

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -185,6 +185,16 @@ def _formatted_current_turn_output(
             return final_text[index:].strip()
     if _terminal_text_looks_cumulative(final_stripped, stream_stripped):
         return stream_stripped
+    if stream_stripped and "\n\n" in final_stripped:
+        prior_turn, terminal_tail = final_stripped.rsplit("\n\n", 1)
+        prior_turn_compact = _text_without_whitespace(prior_turn)
+        if (
+            terminal_tail.strip()
+            and prior_turn_compact
+            and prior_turn_compact not in stream_compact
+            and not prior_turn_compact.startswith(stream_compact)
+        ):
+            return terminal_tail.strip()
     return final_stripped
 
 

--- a/src/codex_autorunner/core/orchestration/runtime_state_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_state_events.py
@@ -34,6 +34,7 @@ from .runtime_payload_shapes import canonicalize_token_usage
 from .runtime_retry_semantics import is_retrying_turn_error
 
 RuntimeStateEventStatus = Literal["ok", "error", "interrupted"]
+AssistantStreamMode = Literal["delta", "snapshot"]
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,8 @@ class AssistantDelta:
     text: str
     source: str
     message_id: Optional[str] = None
+    stream_mode: AssistantStreamMode = "delta"
+    preserve_word_boundaries: bool = False
 
 
 @dataclass(frozen=True)
@@ -190,7 +193,14 @@ def normalize_runtime_state_events(raw_event: Any) -> list[RuntimeStateEvent]:
                 assistant_stream_text = _extract_output_delta(update)
 
     if assistant_stream_text:
-        events.append(AssistantDelta(text=assistant_stream_text, source=method))
+        events.append(
+            AssistantDelta(
+                text=assistant_stream_text,
+                source=method,
+                stream_mode="delta",
+                preserve_word_boundaries=False,
+            )
+        )
     if assistant_message_text:
         events.append(AssistantMessage(text=assistant_message_text, source=method))
     if failure_message:
@@ -247,6 +257,7 @@ def _extract_message_role(params: dict[str, Any]) -> str:
 
 __all__ = [
     "AssistantDelta",
+    "AssistantStreamMode",
     "AssistantMessage",
     "FailureSignal",
     "ProgressSignal",

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -413,11 +413,20 @@ class RuntimeTurnTerminalStateMachine:
         )
 
     def _note_assistant_stream_text(
-        self, text: str, *, preserve_word_boundaries: bool = False
+        self,
+        text: str,
+        *,
+        stream_mode: str = "delta",
+        preserve_word_boundaries: bool = False,
     ) -> None:
-        self._assistant_text.note_stream_snapshot(
-            text, preserve_word_boundaries=preserve_word_boundaries
-        )
+        if stream_mode == "snapshot":
+            self._assistant_text.note_stream_snapshot(
+                text, preserve_word_boundaries=preserve_word_boundaries
+            )
+        else:
+            self._assistant_text.note_stream_delta(
+                text, preserve_word_boundaries=preserve_word_boundaries
+            )
         self.last_assistant_text = self._assistant_text.text
 
     def _note_assistant_message_text(self, text: str) -> None:
@@ -448,7 +457,8 @@ class RuntimeTurnTerminalStateMachine:
         if isinstance(event, AssistantDelta):
             self._note_assistant_stream_text(
                 event.text,
-                preserve_word_boundaries=event.source == "session/update",
+                stream_mode=event.stream_mode,
+                preserve_word_boundaries=event.preserve_word_boundaries,
             )
             return
         if isinstance(event, AssistantMessage):

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -16,7 +16,7 @@ from codex_autorunner.agents.acp import (
     ACPMissingSessionError,
     ACPPermissionRequestEvent,
 )
-from codex_autorunner.agents.acp.client import _PromptState
+from codex_autorunner.agents.acp.client import _PromptState, _session_update_input_kind
 from codex_autorunner.agents.acp.errors import (
     ACPProcessCrashedError,
     ACPProtocolError,
@@ -68,6 +68,18 @@ def test_prompt_state_session_update_snapshots_merge_without_duplication() -> No
     state.note_output_delta("fixture reply", merge_snapshot=True)
 
     assert state.final_output == "fixture reply"
+
+
+def test_prompt_state_delta_preserves_literal_assistant_label() -> None:
+    state = _PromptState(session_id="session-1", turn_id="turn-1")
+
+    assert _session_update_input_kind(state, "Assistant: keep this label") == (
+        "current_turn_delta"
+    )
+    state.note_output_delta("Assistant:", preserve_word_boundaries=False)
+    state.note_output_delta(" keep this label", preserve_word_boundaries=False)
+
+    assert state.final_output == "Assistant: keep this label"
 
 
 def test_prompt_state_session_update_chunks_preserve_word_boundaries() -> None:
@@ -492,6 +504,36 @@ async def test_client_merges_cumulative_stream_chunks_without_duplication(
             for event in handle.snapshot_events()
             if event.kind == "output_delta"
         ] == ["fixture", "fixture reply"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_preserves_hermes_delta_markdown_chunks(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(
+        fixture_command("official_hermes_delta_markdown_chunks"),
+        cwd=tmp_path,
+    )
+    try:
+        created = await client.create_session(cwd=str(tmp_path))
+        handle = await client.start_prompt(created.session_id, "markdown")
+
+        result = await asyncio.wait_for(handle.wait(), timeout=0.4)
+
+        assert result.status == "completed"
+        assert result.final_output == (
+            "Processed update and orchestration are intact.\n"
+            "```\n"
+            'print("ok")\n'
+            "```"
+        )
+        assert [
+            getattr(event, "final_output", None)
+            for event in handle.snapshot_events()
+            if event.kind == "turn_terminal"
+        ] == [result.final_output]
     finally:
         await client.close()
 

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -79,24 +79,21 @@ def test_formatted_current_turn_output_keeps_terminal_when_stream_is_malformed()
     )
 
 
-def test_formatted_current_turn_output_avoids_cumulative_terminal_prefix() -> None:
+def test_formatted_current_turn_output_keeps_uncertain_multiparagraph_terminal() -> (
+    None
+):
     assert (
         _formatted_current_turn_output(
             final_output=(
-                "prior reply\n\n"
-                "Fix: processed update and orchestration\n"
+                "First paragraph.\n\n"
+                "Second paragraph.\n\n"
                 "```python\n"
                 "print('ok')\n"
                 "```"
             ),
-            stream_output=(
-                "Fix: process ed up date and orchestr ation\n"
-                "``python\n"
-                "print('ok')\n"
-                "``"
-            ),
+            stream_output="First paragraph.",
         )
-        == "Fix: processed update and orchestration\n```python\nprint('ok')\n```"
+        == "First paragraph.\n\nSecond paragraph.\n\n```python\nprint('ok')\n```"
     )
 
 

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -57,6 +57,49 @@ def test_formatted_current_turn_output_trims_cumulative_terminal_output() -> Non
     )
 
 
+def test_formatted_current_turn_output_keeps_terminal_when_stream_is_malformed() -> (
+    None
+):
+    assert (
+        _formatted_current_turn_output(
+            final_output=(
+                "Fix: processed update and orchestration\n"
+                "```python\n"
+                "print('ok')\n"
+                "```"
+            ),
+            stream_output=(
+                "Fix: process ed up date and orchestr ation\n"
+                "``python\n"
+                "print('ok')\n"
+                "``"
+            ),
+        )
+        == "Fix: processed update and orchestration\n```python\nprint('ok')\n```"
+    )
+
+
+def test_formatted_current_turn_output_avoids_cumulative_terminal_prefix() -> None:
+    assert (
+        _formatted_current_turn_output(
+            final_output=(
+                "prior reply\n\n"
+                "Fix: processed update and orchestration\n"
+                "```python\n"
+                "print('ok')\n"
+                "```"
+            ),
+            stream_output=(
+                "Fix: process ed up date and orchestr ation\n"
+                "``python\n"
+                "print('ok')\n"
+                "``"
+            ),
+        )
+        == "Fix: processed update and orchestration\n```python\nprint('ok')\n```"
+    )
+
+
 class _HermesPreflightConfig:
     def agent_binary(self, agent_id: str) -> str:
         assert agent_id == "hermes"

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -368,15 +368,25 @@ def test_runtime_turn_terminal_state_machine_reduces_semantic_events() -> None:
     assert state.terminal_signals[0].status == "ok"
 
 
-def test_runtime_turn_terminal_state_preserves_hermes_session_update_word_boundaries() -> (
-    None
-):
+def test_runtime_turn_terminal_state_preserves_hermes_session_update_deltas() -> None:
     state = RuntimeTurnTerminalStateMachine(
         backend_thread_id="thread-1",
         backend_turn_id="turn-1",
     )
 
-    for chunk in ("Alpha", "beta", "gamma", "delta", "."):
+    for chunk in (
+        "Process",
+        "ed",
+        " update",
+        ".\n",
+        "``",
+        "`\n",
+        "print",
+        '("',
+        "ok",
+        '")\n',
+        "```",
+    ):
         state.note_raw_event(
             {
                 "method": "session/update",
@@ -391,7 +401,7 @@ def test_runtime_turn_terminal_state_preserves_hermes_session_update_word_bounda
             }
         )
 
-    assert state.last_assistant_text == "Alpha beta gamma delta."
+    assert state.last_assistant_text == 'Processed update.\n```\nprint("ok")\n```'
 
 
 def test_unknown_raw_event_remains_observable_without_terminal_mutation() -> None:

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -489,18 +489,51 @@ class FakeACPServer:
         # scenarios exercise orchestration behavior instead of burning most of
         # the latency budget inside fixture sleeps under xdist load.
         time.sleep(_OFFICIAL_STREAM_UPDATE_DELAY_SECONDS)
-        self.send(
-            {
-                "method": "session/update",
-                "params": {
-                    "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "agent_message_chunk",
-                        "content": reply_content,
+        if self._scenario == "official_hermes_delta_markdown_chunks":
+            for chunk in (
+                "Process",
+                "ed",
+                " up",
+                "date",
+                " and",
+                " orchest",
+                "ration",
+                " are",
+                " intact",
+                ".\n",
+                "``",
+                "`\n",
+                "print",
+                '("',
+                "ok",
+                '")\n',
+                "```",
+            ):
+                self.send(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "sessionId": session_id,
+                            "update": {
+                                "sessionUpdate": "agent_message_chunk",
+                                "content": {"type": "text", "text": chunk},
+                            },
+                        },
+                    }
+                )
+        else:
+            self.send(
+                {
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": reply_content,
+                        },
                     },
-                },
-            }
-        )
+                }
+            )
         if self._scenario == "official_cumulative_stream_chunks":
             self.send(
                 {


### PR DESCRIPTION
## Summary

Clean up ACP/Hermes assistant output assembly so CAR treats runtime text as typed deltas, snapshots, or terminal messages instead of guessing from every `session/update` as a cumulative snapshot.

## Root Cause

Hermes `session/prompt` returns terminal status/usage but not final answer text, so CAR synthesizes final output from `agent_message_chunk` updates. CAR previously treated all `session/update` assistant chunks as snapshots, which overlap-merged true deltas such as `"``" + "`\n"` into malformed markdown and also inserted readability spaces into token splits.

## Changes

- Classify ACP `session/update` assistant text as a snapshot only when there is cumulative evidence: current-output prefix, transcript projection, or prior assistant prefix.
- Preserve ordinary ACP `agent_message_chunk` payloads as exact deltas.
- Keep Hermes terminal text authoritative while avoiding cumulative terminal prefixes when the stream indicates scoped current-turn output.
- Add typed `AssistantDelta` stream mode through the older runtime terminal state reducer.
- Add fake Hermes fixture coverage for split markdown fences and token splits.

## Validation

- Real Hermes ACP verification: preserved triple-backtick fence and no `process ed` / `orchestr ation` spacing.
- `python -m pytest tests/agents/acp/test_client.py tests/agents/hermes/test_hermes_supervisor.py tests/core/orchestration/test_runtime_turn_terminal_state.py tests/core/orchestration/test_runtime_thread_events.py tests/core/orchestration/test_runtime_thread_decoders.py tests/core/orchestration/test_stream_text_merge.py -q` — 414 passed.
- Pre-commit aggregate lane — passed: guardrails, Ruff, Black check, mypy, 9596 Python tests, web lint/build/tests.
