### PR TITLE
[codex] Unify assistant output assembly

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -38,7 +38,10 @@ from ...core.acp_lifecycle import (
     should_register_server_turn_alias as _should_register_server_turn_alias,
 )
 from ...core.logging_utils import log_event
-from ...core.orchestration.stream_text_merge import AssistantOutputState
+from ...core.orchestration.assistant_output_assembly import (
+    AssistantOutputAssembler,
+    AssistantOutputEvent,
+)
 from ...core.text_utils import _normalize_optional_text
 from .errors import (
     ACPError,
@@ -152,14 +155,22 @@ class _PromptState:
     last_output_normalized: bool = False
     session_update_counts: Counter[str] = field(default_factory=Counter)
     missing_turn_id_fallback_counts: Counter[str] = field(default_factory=Counter)
-    _assistant_text: AssistantOutputState = field(
-        default_factory=AssistantOutputState,
+    _assistant_text: AssistantOutputAssembler = field(
+        default_factory=AssistantOutputAssembler,
         init=False,
         repr=False,
     )
 
     def __post_init__(self) -> None:
-        self._assistant_text = AssistantOutputState(stream_text=self.final_output)
+        self._assistant_text = AssistantOutputAssembler()
+        if self.final_output:
+            self._assistant_text.note(
+                AssistantOutputEvent(
+                    kind="snapshot",
+                    text=self.final_output,
+                    scope=self.turn_id,
+                )
+            )
 
     def note_output_delta(
         self,
@@ -180,12 +191,22 @@ class _PromptState:
             self.last_output_normalized = True
             return normalized
         if merge_snapshot:
-            self._assistant_text.note_stream_snapshot(
-                normalized.text, preserve_word_boundaries=preserve_word_boundaries
+            self._assistant_text.note(
+                AssistantOutputEvent(
+                    kind="snapshot",
+                    text=normalized.text,
+                    scope=self.turn_id,
+                    preserve_word_boundaries=preserve_word_boundaries,
+                )
             )
         else:
-            self._assistant_text.note_stream_delta(
-                normalized.text, preserve_word_boundaries=preserve_word_boundaries
+            self._assistant_text.note(
+                AssistantOutputEvent(
+                    kind="delta",
+                    text=normalized.text,
+                    scope=self.turn_id,
+                    preserve_word_boundaries=preserve_word_boundaries,
+                )
             )
         self.final_output = self._assistant_text.text
         self.last_output_normalized = self.last_output_normalized or bool(
@@ -210,7 +231,13 @@ class _PromptState:
             if normalized.classification == "invalid_stale_output":
                 self.last_output_normalized = True
                 return normalized
-            self._assistant_text.note_final_message(normalized.text)
+            self._assistant_text.note(
+                AssistantOutputEvent(
+                    kind="final_message",
+                    text=normalized.text,
+                    scope=self.turn_id,
+                )
+            )
             self.final_output = self._assistant_text.text
             self.last_output_normalized = self.last_output_normalized or bool(
                 normalized.trimmed
@@ -1251,13 +1278,20 @@ class ACPClient:
                 if event.method == "session/update"
                 else "current_turn_delta"
             )
+            assembly_kind = (
+                "snapshot" if input_kind == "current_turn_snapshot" else "delta"
+            )
             normalized_delta = state.note_output_delta(
                 event.delta,
-                merge_snapshot=input_kind == "current_turn_snapshot",
+                merge_snapshot=assembly_kind == "snapshot",
                 preserve_word_boundaries=False,
             )
             self._log_ingress_normalization(state, normalized_delta)
-            event = replace(event, delta=normalized_delta.text)
+            event = replace(
+                event,
+                delta=normalized_delta.text,
+                assembly_kind=assembly_kind,
+            )
         elif isinstance(event, ACPMessageEvent) and event.message:
             normalized_message = state.note_assistant_message(event.message)
             if normalized_message is not None:

--- a/src/codex_autorunner/agents/acp/events.py
+++ b/src/codex_autorunner/agents/acp/events.py
@@ -38,11 +38,13 @@ class ACPTurnStartedEvent(ACPEventEnvelope):
 @dataclass(frozen=True)
 class ACPOutputDeltaEvent(ACPEventEnvelope):
     delta: str = ""
+    assembly_kind: str = "delta"
 
 
 @dataclass(frozen=True)
 class ACPMessageEvent(ACPEventEnvelope):
     message: str = ""
+    assembly_kind: str = "final_message"
 
 
 @dataclass(frozen=True)
@@ -67,6 +69,7 @@ class ACPTurnTerminalEvent(ACPEventEnvelope):
     status: str = ""
     final_output: str = ""
     error_message: Optional[str] = None
+    assembly_kind: str = "final_message"
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/agents/codex/harness.py
+++ b/src/codex_autorunner/agents/codex/harness.py
@@ -11,6 +11,10 @@ from ...adapters.app_server.client import (
 )
 from ...adapters.app_server.event_buffer import AppServerEventBuffer
 from ...adapters.app_server.supervisor import WorkspaceAppServerSupervisor
+from ...core.orchestration.assistant_output_assembly import (
+    AssistantOutputEvent,
+    assemble_assistant_output,
+)
 from ...core.runtime_identity import RUNTIME_STAGE_EFFECTIVE, RuntimeIdentityStage
 from ...core.time_utils import now_iso
 from ..base import AgentHarness
@@ -415,17 +419,7 @@ class CodexHarness(AgentHarness):
             result = await handle.wait(timeout=timeout)
         finally:
             self._turn_handles.pop((conversation_id, turn_id), None)
-        agent_messages = [
-            message.strip()
-            for message in getattr(result, "agent_messages", []) or []
-            if isinstance(message, str) and message.strip()
-        ]
-        assistant_text = ""
-        final_message = getattr(result, "final_message", "")
-        if isinstance(final_message, str):
-            assistant_text = final_message.strip()
-        if not assistant_text:
-            assistant_text = "\n\n".join(agent_messages).strip()
+        assistant_text = _assemble_codex_assistant_text(result)
         return TerminalTurnResult(
             status=(
                 str(result.status)
@@ -479,6 +473,34 @@ class CodexHarness(AgentHarness):
                 "model_source": "unknown",
             },
         )
+
+
+def _assemble_codex_assistant_text(result: Any) -> str:
+    events: list[AssistantOutputEvent] = []
+    final_message = getattr(result, "final_message", "")
+    if isinstance(final_message, str) and final_message.strip():
+        events.append(
+            AssistantOutputEvent(
+                kind="final_message",
+                text=final_message.strip(),
+                scope="final-message",
+            )
+        )
+    else:
+        agent_messages = [
+            message.strip()
+            for message in getattr(result, "agent_messages", []) or []
+            if isinstance(message, str) and message.strip()
+        ]
+        if agent_messages:
+            events.append(
+                AssistantOutputEvent(
+                    kind="final_message",
+                    text="\n\n".join(agent_messages),
+                    scope="agent-messages",
+                )
+            )
+    return assemble_assistant_output(events)
 
 
 __all__ = ["CodexHarness"]

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -7,7 +7,16 @@ import time
 from dataclasses import dataclass, field
 from os.path import basename
 from pathlib import Path
-from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Sequence
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+)
 
 from ...core.acp_lifecycle import (
     active_turn_matches as _active_turn_matches,
@@ -17,9 +26,9 @@ from ...core.acp_lifecycle import (
 )
 from ...core.config import HubConfig, RepoConfig
 from ...core.logging_utils import log_event
-from ...core.orchestration.runtime_thread_events import (
-    RuntimeThreadRunEventState,
-    normalize_runtime_progress_event,
+from ...core.orchestration.assistant_output_assembly import (
+    AssistantOutputAssembler,
+    AssistantOutputEvent,
 )
 from ...core.orchestration.turn_event_buffer import TurnEventBuffer
 from ...core.text_utils import _normalize_optional_text
@@ -109,6 +118,70 @@ def _extract_session_summary(payload: Mapping[str, Any]) -> Optional[str]:
     return None
 
 
+def _extract_acp_content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        text = content.get("text")
+        return text if isinstance(text, str) else ""
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _assistant_output_event_from_acp_notification(
+    raw_event: Mapping[str, Any],
+) -> Optional[AssistantOutputEvent]:
+    method = str(raw_event.get("method") or "").strip()
+    params = raw_event.get("params")
+    if not isinstance(params, Mapping):
+        return None
+    turn_id = _normalize_optional_text(params.get("turnId") or params.get("turn_id"))
+    if method == "session/update":
+        update = params.get("update")
+        if not isinstance(update, Mapping):
+            return None
+        if (
+            _normalize_optional_text(
+                update.get("sessionUpdate") or update.get("session_update")
+            )
+            != "agent_message_chunk"
+        ):
+            return None
+        text = _extract_acp_content_text(update.get("content"))
+        if not text:
+            return None
+        raw_kind = str(params.get("assistantOutputKind") or "").strip()
+        kind: Literal["delta", "snapshot"]
+        if raw_kind == "delta":
+            kind = "delta"
+        else:
+            kind = "snapshot"
+        return AssistantOutputEvent(
+            kind=kind,
+            text=text,
+            scope=turn_id,
+            preserve_word_boundaries=kind == "snapshot",
+        )
+    if method in {"prompt/message", "turn/message"}:
+        message_text = _normalize_optional_text(
+            params.get("message") or params.get("text")
+        )
+        if not message_text:
+            return None
+        return AssistantOutputEvent(
+            kind="final_message", text=message_text, scope=turn_id
+        )
+    return None
+
+
 async def _assistant_text_from_turn_events(
     raw_events: Sequence[Mapping[str, Any]],
 ) -> str:
@@ -119,10 +192,12 @@ async def _assistant_text_from_turn_events(
     safer current-turn source when present.
     """
 
-    state = RuntimeThreadRunEventState()
+    assembler = AssistantOutputAssembler()
     for raw_event in raw_events:
-        await normalize_runtime_progress_event(dict(raw_event), state)
-    return state.assistant_stream_text.strip()
+        event = _assistant_output_event_from_acp_notification(raw_event)
+        if event is not None and event.kind in {"delta", "snapshot"}:
+            assembler.note(event)
+    return assembler.stream_text.strip()
 
 
 def _text_without_whitespace(value: str) -> str:
@@ -215,6 +290,7 @@ def _canonical_acp_notification(event: Any) -> Optional[dict[str, Any]]:
     payload["params"] = params
     method = str(payload.get("method") or "").strip()
     if isinstance(event, ACPOutputDeltaEvent):
+        params["assistantOutputKind"] = event.assembly_kind or "delta"
         if method == "session/update":
             update = dict(params.get("update") or {})
             update["content"] = _replace_session_update_content_text(
@@ -226,9 +302,11 @@ def _canonical_acp_notification(event: Any) -> Optional[dict[str, Any]]:
             params["delta"] = event.delta
             params["text"] = event.delta
     elif isinstance(event, ACPMessageEvent):
+        params["assistantOutputKind"] = event.assembly_kind or "final_message"
         params["message"] = event.message
         params["text"] = event.message
     elif isinstance(event, ACPTurnTerminalEvent):
+        params["assistantOutputKind"] = event.assembly_kind or "final_message"
         params["finalOutput"] = event.final_output
     return payload
 

--- a/src/codex_autorunner/agents/opencode/output_assembly.py
+++ b/src/codex_autorunner/agents/opencode/output_assembly.py
@@ -19,6 +19,10 @@ import httpx
 
 from ...core.coercion import coerce_int
 from ...core.logging_utils import log_event
+from ...core.orchestration.assistant_output_assembly import (
+    AssistantOutputAssembler,
+    AssistantOutputEvent,
+)
 from ...core.orchestration.stream_text_merge import (
     append_assistant_stream_text_readably,
 )
@@ -46,6 +50,7 @@ from .usage_decoder import extract_usage
 
 PartHandler = Callable[[str, dict[str, Any], Optional[str]], Awaitable[None]]
 _CODE_SPAN_PATTERN = re.compile(r"`([^`]*)`")
+_NO_MESSAGE_SCOPE = "<no-message>"
 
 
 @dataclass(frozen=True)
@@ -136,13 +141,15 @@ class OutputAssembler:
         self._logger = logger or logging.getLogger(__name__)
 
         self._text_parts: list[str] = []
+        self._assistant_output = AssistantOutputAssembler()
         self._part_lengths: dict[str, int] = {}
         self._part_accumulated_text: dict[str, str] = {}
-        self._last_full_text = ""
+        self._last_full_text_by_scope: dict[str, str] = {}
         self._error: Optional[str] = None
         self._message_roles: dict[str, str] = {}
         self._message_roles_seen = False
         self._message_text_parts: dict[str, list[str]] = {}
+        self._last_text_message_id: Optional[str] = None
         self._pending_text: dict[str, list[str]] = {}
         self._pending_no_id: list[str] = []
         self._no_id_role: Optional[str] = None
@@ -166,6 +173,8 @@ class OutputAssembler:
         self._latest_usage_snapshot: Optional[dict[str, Any]] = None
         self._output_source: OpenCodeTurnOutputSource = "none"
         self._part_types: dict[str, str] = {}
+        self._part_type_fallbacks: dict[str, str] = {}
+        self._ambiguous_part_type_ids: set[str] = set()
         self._providers_cache: Optional[list[dict[str, Any]]] = None
         self._context_window_cache: dict[str, Optional[int]] = {}
         self._session_model_ids: Optional[tuple[Optional[str], Optional[str]]] = None
@@ -274,17 +283,31 @@ class OutputAssembler:
         Also checks whether the completion phase is ``commentary`` — commentary
         completions do not override ``last_completed_assistant_text``.
         """
+        message_result = parse_message_response(payload)
         if message_role != "assistant":
-            return
+            if message_role is not None:
+                return
+            if not message_result.text or prompt_echo_matches(
+                message_result.text,
+                prompt=self._prompt,
+            ):
+                return
         if not message_completion_is_turn_terminal(payload):
             return
         msg_id = extract_event_message_id(payload)
         if msg_id:
             self._last_terminal_assistant_message_id = msg_id
-        message_result = parse_message_response(payload)
         self._last_completed_assistant_text = (
             message_result.text if message_result.text else None
         )
+        if self._last_completed_assistant_text:
+            self._assistant_output.note(
+                AssistantOutputEvent(
+                    kind="final_message",
+                    text=self._last_completed_assistant_text,
+                    scope=msg_id,
+                )
+            )
 
     async def on_text_delta(
         self,
@@ -296,10 +319,11 @@ class OutputAssembler:
     ) -> None:
         """Append a text delta to the output, with dedupe bookkeeping."""
         if isinstance(part_id, str) and part_id:
+            part_key = self._part_key(part_message_id, part_id)
             if isinstance(part_dict, dict):
                 text = part_dict.get("text")
                 if isinstance(text, str):
-                    last_len = self._part_lengths.get(part_id, 0)
+                    last_len = self._part_lengths.get(part_key, 0)
                     if len(text) > last_len:
                         self._append_text_for_message(
                             part_message_id,
@@ -308,30 +332,32 @@ class OutputAssembler:
                         )
                     elif delta_text:
                         self._append_text_for_message(part_message_id, delta_text)
-                    self._part_lengths[part_id] = len(text)
-                    self._part_accumulated_text[part_id] = text
+                    self._part_lengths[part_key] = len(text)
+                    self._part_accumulated_text[part_key] = text
                 else:
                     self._append_text_for_message(part_message_id, delta_text)
-                    self._track_part_delta(part_id, delta_text)
+                    self._track_part_delta(part_message_id, part_id, delta_text)
             else:
                 self._append_text_for_message(part_message_id, delta_text)
-                self._track_part_delta(part_id, delta_text)
+                self._track_part_delta(part_message_id, part_id, delta_text)
         elif isinstance(part_dict, dict):
             text = part_dict.get("text")
             if isinstance(text, str):
-                if self._last_full_text and text.startswith(self._last_full_text):
+                scope = self._full_text_scope(part_message_id)
+                last_full_text = self._last_full_text_by_scope.get(scope, "")
+                if last_full_text and text.startswith(last_full_text):
                     self._append_text_for_message(
                         part_message_id,
-                        text[len(self._last_full_text) :],
+                        text[len(last_full_text) :],
                         preserve_word_boundaries=False,
                     )
-                elif text != self._last_full_text:
+                elif text != last_full_text:
                     self._append_text_for_message(
                         part_message_id,
                         text,
                         preserve_word_boundaries=False,
                     )
-                self._last_full_text = text
+                self._last_full_text_by_scope[scope] = text
             else:
                 self._append_text_for_message(part_message_id, delta_text)
         else:
@@ -349,19 +375,22 @@ class OutputAssembler:
             return
         part_id = part_dict.get("id") or part_dict.get("partId")
         if isinstance(part_id, str) and part_id:
-            last_len = self._part_lengths.get(part_id, 0)
+            part_key = self._part_key(part_message_id, part_id)
+            last_len = self._part_lengths.get(part_key, 0)
             if len(text) > last_len:
                 self._append_text_for_message(part_message_id, text[last_len:])
-                self._part_lengths[part_id] = len(text)
-                self._part_accumulated_text[part_id] = text
+                self._part_lengths[part_key] = len(text)
+                self._part_accumulated_text[part_key] = text
         else:
-            if self._last_full_text and text.startswith(self._last_full_text):
+            scope = self._full_text_scope(part_message_id)
+            last_full_text = self._last_full_text_by_scope.get(scope, "")
+            if last_full_text and text.startswith(last_full_text):
                 self._append_text_for_message(
-                    part_message_id, text[len(self._last_full_text) :]
+                    part_message_id, text[len(last_full_text) :]
                 )
-            elif text != self._last_full_text:
+            elif text != last_full_text:
                 self._append_text_for_message(part_message_id, text)
-            self._last_full_text = text
+            self._last_full_text_by_scope[scope] = text
 
     def flush_pending(self) -> None:
         """Flush all pending text when no final text has been assembled yet."""
@@ -417,29 +446,44 @@ class OutputAssembler:
                 await self._part_handler("usage", usage_snapshot, None)
 
     def remember_part_type(
-        self, part_id: Optional[str], part_type: Optional[str]
+        self,
+        part_id: Optional[str],
+        part_type: Optional[str],
+        *,
+        message_id: Optional[str] = None,
     ) -> None:
-        if (
-            isinstance(part_id, str)
-            and part_id
-            and isinstance(part_type, str)
-            and part_type
-        ):
-            self._part_types[part_id] = part_type
-        elif (
-            isinstance(part_id, str)
-            and part_id
-            and not isinstance(part_type, str)
-            and part_id in self._part_types
-        ):
-            pass
-        else:
+        if not isinstance(part_id, str) or not part_id:
             return
+        part_key = self._part_key(message_id, part_id)
+        if isinstance(part_type, str) and part_type:
+            self._part_types[part_key] = part_type
+            self._remember_part_type_fallback(part_id, part_type)
 
-    def lookup_part_type(self, part_id: Optional[str]) -> Optional[str]:
-        if isinstance(part_id, str) and part_id:
-            return self._part_types.get(part_id)
+    def lookup_part_type(
+        self,
+        part_id: Optional[str],
+        *,
+        message_id: Optional[str] = None,
+    ) -> Optional[str]:
+        if not isinstance(part_id, str) or not part_id:
+            return None
+        scoped_type = self._part_types.get(self._part_key(message_id, part_id))
+        if scoped_type is not None:
+            return scoped_type
+        if message_id is None and part_id not in self._ambiguous_part_type_ids:
+            return self._part_type_fallbacks.get(part_id)
         return None
+
+    def _remember_part_type_fallback(self, part_id: str, part_type: str) -> None:
+        if part_id in self._ambiguous_part_type_ids:
+            return
+        remembered = self._part_type_fallbacks.get(part_id)
+        if remembered is None:
+            self._part_type_fallbacks[part_id] = part_type
+            return
+        if remembered != part_type:
+            self._part_type_fallbacks.pop(part_id, None)
+            self._ambiguous_part_type_ids.add(part_id)
 
     async def build_result(self) -> OutputAssemblyResult:
         """Build the final :class:`OutputAssemblyResult` after the stream loop.
@@ -461,11 +505,25 @@ class OutputAssembler:
                 and not prompt_echo_matches(text, prompt=self._prompt)
             ):
                 self._text_parts.append(text)
+                self._assistant_output.note(
+                    AssistantOutputEvent(
+                        kind="delta",
+                        text=text,
+                        scope=msg_id,
+                    )
+                )
 
         if not self._text_parts:
             recovered_text = await self._recover_text_from_messages()
             if recovered_text:
                 self._text_parts.append(recovered_text)
+                self._assistant_output.note(
+                    AssistantOutputEvent(
+                        kind="delta",
+                        text=recovered_text,
+                        scope=self._last_terminal_assistant_message_id,
+                    )
+                )
                 self._output_source = "messages_snapshot"
 
         streamed_text = self._streamed_text_for_final_message()
@@ -606,7 +664,16 @@ class OutputAssembler:
     def _flush_pending_no_id_as_assistant(self) -> None:
         if self._pending_no_id:
             self._text_parts.extend(self._pending_no_id)
+            for text in self._pending_no_id:
+                self._assistant_output.note(
+                    AssistantOutputEvent(
+                        kind="delta",
+                        text=text,
+                        scope=_NO_MESSAGE_SCOPE,
+                    )
+                )
             self._pending_no_id.clear()
+            self._last_text_message_id = _NO_MESSAGE_SCOPE
         self._no_id_role = "assistant"
 
     def _discard_pending_no_id(self) -> None:
@@ -629,6 +696,15 @@ class OutputAssembler:
                     text,
                     preserve_word_boundaries=preserve_word_boundaries,
                 )
+                self._assistant_output.note(
+                    AssistantOutputEvent(
+                        kind="delta",
+                        text=text,
+                        scope=_NO_MESSAGE_SCOPE,
+                        preserve_word_boundaries=preserve_word_boundaries,
+                    )
+                )
+                self._last_text_message_id = _NO_MESSAGE_SCOPE
             else:
                 self._append_readable_text(
                     self._pending_no_id,
@@ -652,11 +728,25 @@ class OutputAssembler:
             preserve_word_boundaries=preserve_word_boundaries,
         )
 
-    def _track_part_delta(self, part_id: str, delta_text: str) -> None:
-        accumulated = self._part_accumulated_text.get(part_id, "")
+    @staticmethod
+    def _part_key(message_id: Optional[str], part_id: str) -> str:
+        return f"{message_id or '<no-message>'}\x1f{part_id}"
+
+    @staticmethod
+    def _full_text_scope(message_id: Optional[str]) -> str:
+        return message_id or "<no-message>"
+
+    def _track_part_delta(
+        self,
+        message_id: Optional[str],
+        part_id: str,
+        delta_text: str,
+    ) -> None:
+        part_key = self._part_key(message_id, part_id)
+        accumulated = self._part_accumulated_text.get(part_key, "")
         updated = append_assistant_stream_text_readably(accumulated, delta_text)
-        self._part_accumulated_text[part_id] = updated
-        self._part_lengths[part_id] = len(updated)
+        self._part_accumulated_text[part_key] = updated
+        self._part_lengths[part_key] = len(updated)
 
     def _append_readable_text(
         self,
@@ -707,6 +797,15 @@ class OutputAssembler:
                 or not self._text_parts
             ):
                 self._text_parts.extend(self._pending_no_id)
+                for text in self._pending_no_id:
+                    self._assistant_output.note(
+                        AssistantOutputEvent(
+                            kind="delta",
+                            text=text,
+                            scope=_NO_MESSAGE_SCOPE,
+                        )
+                    )
+                self._last_text_message_id = _NO_MESSAGE_SCOPE
             self._pending_no_id.clear()
 
     def _append_assistant_text(
@@ -722,11 +821,23 @@ class OutputAssembler:
             text,
             preserve_word_boundaries=preserve_word_boundaries,
         )
-        self._append_readable_text(
-            self._text_parts,
-            text,
-            preserve_word_boundaries=preserve_word_boundaries,
+        if self._last_text_message_id not in {None, message_id} and self._text_parts:
+            self._text_parts.append(text)
+        else:
+            self._append_readable_text(
+                self._text_parts,
+                text,
+                preserve_word_boundaries=preserve_word_boundaries,
+            )
+        self._assistant_output.note(
+            AssistantOutputEvent(
+                kind="delta",
+                text=text,
+                scope=message_id,
+                preserve_word_boundaries=preserve_word_boundaries,
+            )
         )
+        self._last_text_message_id = message_id
 
     def _streamed_text_for_final_message(self) -> str:
         if self._last_terminal_assistant_message_id is not None:
@@ -734,10 +845,21 @@ class OutputAssembler:
                 self._last_terminal_assistant_message_id,
             )
             if terminal_parts:
-                return "".join(terminal_parts)
+                return self._join_text_segments(terminal_parts)
             if self._message_text_parts:
                 return ""
-        return "".join(self._text_parts)
+        return self._assistant_output.stream_text or self._join_text_segments(
+            self._text_parts
+        )
+
+    @staticmethod
+    def _join_text_segments(parts: list[str]) -> str:
+        merged = ""
+        for part in parts:
+            if not part:
+                continue
+            merged = append_assistant_stream_text_readably(merged, part)
+        return merged
 
     async def _resolve_session_model_ids(
         self,

--- a/src/codex_autorunner/agents/opencode/output_assembly.py
+++ b/src/codex_autorunner/agents/opencode/output_assembly.py
@@ -305,7 +305,7 @@ class OutputAssembler:
                 AssistantOutputEvent(
                     kind="final_message",
                     text=self._last_completed_assistant_text,
-                    scope=msg_id,
+                    scope=msg_id or _NO_MESSAGE_SCOPE,
                 )
             )
 

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -599,11 +599,18 @@ async def collect_opencode_output_from_events(
                 part_ignored = bool(part_dict.get("ignored")) if part_dict else False
                 part_message_id = extract_event_part_message_id(payload)
                 part_id = extract_event_part_id(payload)
-                assembler.remember_part_type(part_id, part_type)
+                assembler.remember_part_type(
+                    part_id,
+                    part_type,
+                    message_id=part_message_id,
+                )
                 resolved_part_type = (
                     part_type
                     if isinstance(part_type, str)
-                    else assembler.lookup_part_type(part_id)
+                    else assembler.lookup_part_type(
+                        part_id,
+                        message_id=part_message_id,
+                    )
                 )
                 if resolved_part_type == "tool" and isinstance(part_dict, dict):
                     (

--- a/src/codex_autorunner/core/orchestration/assistant_output_assembly.py
+++ b/src/codex_autorunner/core/orchestration/assistant_output_assembly.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from .stream_text_merge import (
+    AssistantOutputState,
+    append_assistant_stream_text_readably,
+)
+
+AssistantOutputEventKind = Literal[
+    "delta",
+    "snapshot",
+    "final_message",
+    "commentary",
+    "reasoning",
+]
+
+_NO_SCOPE = "<no-scope>"
+
+
+@dataclass(frozen=True)
+class AssistantOutputEvent:
+    kind: AssistantOutputEventKind
+    text: str
+    scope: Optional[str] = None
+    preserve_word_boundaries: bool = False
+
+
+class AssistantOutputAssembler:
+    """Reduce runtime-native assistant text events into canonical user output.
+
+    Runtime adapters still own protocol-specific parsing. This class owns the
+    shared invariant after parsing: only current-turn assistant answer text
+    participates in terminal output; commentary/reasoning stay out, final
+    messages outrank stream text, and scoped stream fragments do not bleed
+    across message/part boundaries.
+    """
+
+    def __init__(self) -> None:
+        self._scoped_streams: dict[str, AssistantOutputState] = {}
+        self._scope_order: list[str] = []
+        self._final_text = ""
+        self._final_scope: Optional[str] = None
+
+    def note(self, event: AssistantOutputEvent) -> None:
+        text = event.text if isinstance(event.text, str) else ""
+        if event.kind in {"commentary", "reasoning"}:
+            return
+        if event.kind == "final_message":
+            self._final_text = text if text.strip() else ""
+            self._final_scope = self._scope_key(event.scope)
+            return
+        if not text:
+            return
+        state = self._stream_state(event.scope)
+        if event.kind == "snapshot":
+            state.note_stream_snapshot(
+                text,
+                preserve_word_boundaries=event.preserve_word_boundaries,
+            )
+        else:
+            state.note_stream_delta(
+                text,
+                preserve_word_boundaries=event.preserve_word_boundaries,
+            )
+
+    @property
+    def text(self) -> str:
+        if self._final_text.strip():
+            return self._final_text.strip()
+        return self.stream_text.strip()
+
+    @property
+    def stream_text(self) -> str:
+        if self._final_scope is not None:
+            state = self._scoped_streams.get(self._final_scope)
+            return state.text if state is not None else ""
+        merged = ""
+        for scope in self._scope_order:
+            state = self._scoped_streams.get(scope)
+            if state is None or not state.text:
+                continue
+            merged = append_assistant_stream_text_readably(merged, state.text)
+        return merged
+
+    def _stream_state(self, scope: Optional[str]) -> AssistantOutputState:
+        key = self._scope_key(scope)
+        state = self._scoped_streams.get(key)
+        if state is None:
+            state = AssistantOutputState()
+            self._scoped_streams[key] = state
+            self._scope_order.append(key)
+        return state
+
+    @staticmethod
+    def _scope_key(scope: Optional[str]) -> str:
+        normalized = str(scope or "").strip()
+        return normalized or _NO_SCOPE
+
+
+def assemble_assistant_output(events: list[AssistantOutputEvent]) -> str:
+    assembler = AssistantOutputAssembler()
+    for event in events:
+        assembler.note(event)
+    return assembler.text
+
+
+__all__ = [
+    "AssistantOutputAssembler",
+    "AssistantOutputEvent",
+    "AssistantOutputEventKind",
+    "assemble_assistant_output",
+]

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -504,6 +504,11 @@ async def test_client_merges_cumulative_stream_chunks_without_duplication(
             for event in handle.snapshot_events()
             if event.kind == "output_delta"
         ] == ["fixture", "fixture reply"]
+        assert [
+            getattr(event, "assembly_kind", None)
+            for event in handle.snapshot_events()
+            if event.kind == "output_delta"
+        ] == ["delta", "snapshot"]
     finally:
         await client.close()
 
@@ -534,6 +539,11 @@ async def test_client_preserves_hermes_delta_markdown_chunks(
             for event in handle.snapshot_events()
             if event.kind == "turn_terminal"
         ] == [result.final_output]
+        assert {
+            getattr(event, "assembly_kind", None)
+            for event in handle.snapshot_events()
+            if event.kind == "output_delta"
+        } == {"delta"}
     finally:
         await client.close()
 
@@ -565,6 +575,11 @@ async def test_client_normalizes_hermes_cumulative_session_update_at_ingress(
             for event in second_events
             if event.kind == "output_delta"
         ] == ["second answer"]
+        assert [
+            getattr(event, "assembly_kind", None)
+            for event in second_events
+            if event.kind == "output_delta"
+        ] == ["snapshot"]
         assert any(
             payload.get("event") == "acp.prompt.output_normalized"
             and payload.get("classification") == "transcript_projection"

--- a/tests/agents/codex/test_codex_harness.py
+++ b/tests/agents/codex/test_codex_harness.py
@@ -110,6 +110,24 @@ async def test_codex_harness_wait_for_turn_returns_plain_text_terminal_result() 
 
 
 @pytest.mark.asyncio
+async def test_codex_harness_wait_for_turn_falls_back_to_agent_messages() -> None:
+    harness = CodexHarness(supervisor=object(), events=object())  # type: ignore[arg-type]
+    harness._turn_handles[("thread-1", "turn-1")] = _TurnHandle(  # type: ignore[attr-defined]
+        SimpleNamespace(
+            status="completed",
+            final_message="",
+            agent_messages=["first line", "second line"],
+            errors=[],
+            raw_events=[],
+        )
+    )
+
+    result = await harness.wait_for_turn(Path("."), "thread-1", "turn-1")
+
+    assert result.assistant_text == "first line\n\nsecond line"
+
+
+@pytest.mark.asyncio
 async def test_codex_harness_resume_conversation_ignores_missing_thread_failures() -> (
     None
 ):

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -261,6 +261,42 @@ async def test_hermes_supervisor_buffers_normalized_cumulative_turn_events(
 
 @pytest.mark.slow
 @pytest.mark.asyncio
+async def test_hermes_supervisor_preserves_delta_markdown_code_spacing(
+    tmp_path: Path,
+) -> None:
+    supervisor = HermesSupervisor(
+        fixture_command("official_hermes_delta_markdown_chunks")
+    )
+    try:
+        await supervisor.ensure_ready(tmp_path)
+        session = await supervisor.create_session(tmp_path, title="Markdown")
+        turn_id = await supervisor.start_turn(tmp_path, session.session_id, "markdown")
+
+        result = await asyncio.wait_for(
+            supervisor.wait_for_turn(tmp_path, session.session_id, turn_id),
+            timeout=2.0,
+        )
+
+        assert result.status == "completed"
+        assert result.assistant_text == (
+            "Processed update and orchestration are intact.\n"
+            "```\n"
+            'print("ok")\n'
+            "```"
+        )
+        assert {
+            event.get("params", {}).get("assistantOutputKind")
+            for event in result.raw_events
+            if event.get("method") == "session/update"
+            and event.get("params", {}).get("update", {}).get("sessionUpdate")
+            == "agent_message_chunk"
+        } == {"delta"}
+    finally:
+        await supervisor.close_all()
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
 async def test_hermes_supervisor_maps_session_scoped_updates_to_active_turn(
     tmp_path: Path,
 ) -> None:
@@ -361,6 +397,7 @@ async def test_hermes_supervisor_prefers_turn_stream_over_cumulative_terminal_ou
             event.get("method") == "prompt/completed"
             and event.get("params", {}).get("finalOutput")
             == "prior reply\n\nfixture reply"
+            and event.get("params", {}).get("assistantOutputKind") == "final_message"
             for event in result.raw_events
         )
     finally:

--- a/tests/agents/opencode/test_output_assembly.py
+++ b/tests/agents/opencode/test_output_assembly.py
@@ -114,6 +114,113 @@ async def test_text_delta_part_lengths_include_readable_inserted_spaces() -> Non
 
 
 @pytest.mark.anyio
+async def test_text_delta_preserves_markdown_and_code_spacing() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "a1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+
+    for delta in (
+        "Confirmed:",
+        "**",
+        "`/car/hub/read-models/chats`",
+        "returns",
+        "500",
+        "**",
+        "everything",
+        "else",
+        "is",
+        "healthy.",
+    ):
+        await asm.on_text_delta(
+            part_message_id="a1",
+            delta_text=delta,
+            part_id="p1",
+            part_dict=None,
+        )
+
+    asm.on_primary_assistant_completion(
+        {"info": {"id": "a1", "role": "assistant", "finish": "stop"}, "parts": []},
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert (
+        result.text
+        == "Confirmed: **`/car/hub/read-models/chats` returns 500** everything else is healthy."
+    )
+
+
+@pytest.mark.anyio
+async def test_text_part_tracking_scoped_by_message_id() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "a1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+    await asm.on_text_delta(
+        part_message_id="a1",
+        delta_text="",
+        part_id="text",
+        part_dict={"type": "text", "text": "Let me check."},
+    )
+
+    msg_id2, role2 = asm.on_register_message_role(
+        {"info": {"id": "a2", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id2, role2)
+    await asm.on_text_delta(
+        part_message_id="a2",
+        delta_text="",
+        part_id="text",
+        part_dict={"type": "text", "text": "Done."},
+    )
+    asm.on_primary_assistant_completion(
+        {"info": {"id": "a2", "role": "assistant", "finish": "stop"}, "parts": []},
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Done."
+
+
+@pytest.mark.anyio
+async def test_reused_part_ids_track_delta_text_per_message() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "a1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+    for delta in ("First", "message."):
+        await asm.on_text_delta(
+            part_message_id="a1",
+            delta_text=delta,
+            part_id="text",
+            part_dict=None,
+        )
+
+    msg_id2, role2 = asm.on_register_message_role(
+        {"info": {"id": "a2", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id2, role2)
+    for delta in ("Second", "message."):
+        await asm.on_text_delta(
+            part_message_id="a2",
+            delta_text=delta,
+            part_id="text",
+            part_dict=None,
+        )
+    asm.on_primary_assistant_completion(
+        {"info": {"id": "a2", "role": "assistant", "finish": "stop"}, "parts": []},
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Second message."
+
+
+@pytest.mark.anyio
 async def test_full_text_part_incremental() -> None:
     asm = OutputAssembler(session_id="s1")
     await asm.on_full_text_part(
@@ -143,6 +250,35 @@ async def test_full_text_part_no_id_incremental() -> None:
     asm.flush_pending()
     result = await asm.build_result()
     assert result.text == "Hello world"
+
+
+@pytest.mark.anyio
+async def test_full_text_part_snapshot_tracking_scoped_by_message_id() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "a1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+    await asm.on_full_text_part(
+        part_message_id="a1",
+        part_dict={"type": "text", "text": "First progress."},
+    )
+
+    msg_id2, role2 = asm.on_register_message_role(
+        {"info": {"id": "a2", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id2, role2)
+    await asm.on_full_text_part(
+        part_message_id="a2",
+        part_dict={"type": "text", "text": "Final answer."},
+    )
+    asm.on_primary_assistant_completion(
+        {"info": {"id": "a2", "role": "assistant", "finish": "stop"}, "parts": []},
+        message_role="assistant",
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Final answer."
 
 
 @pytest.mark.anyio
@@ -349,6 +485,22 @@ async def test_primary_assistant_completion_records_text() -> None:
 
 
 @pytest.mark.anyio
+async def test_roleless_primary_completion_accepts_final_answer_parts() -> None:
+    asm = OutputAssembler(session_id="s1", prompt="summarize status")
+
+    asm.on_primary_assistant_completion(
+        {
+            "info": {"id": "m1", "finish": "stop"},
+            "parts": [{"type": "text", "text": "All checks are green."}],
+        },
+        message_role=None,
+    )
+
+    result = await asm.build_result()
+    assert result.text == "All checks are green."
+
+
+@pytest.mark.anyio
 async def test_primary_assistant_completion_commentary_ignored() -> None:
     asm = OutputAssembler(session_id="s1")
 
@@ -395,6 +547,30 @@ async def test_primary_assistant_completion_non_assistant_role_ignored() -> None
 
     result = await asm.build_result()
     assert result.text == "stream text"
+
+
+@pytest.mark.anyio
+async def test_roleless_primary_completion_overrides_prior_stream_text() -> None:
+    asm = OutputAssembler(session_id="s1", prompt="release from origin main")
+
+    await asm.on_text_delta(
+        part_message_id=None,
+        delta_text="Current latest tag is `v 2.1.0`.",
+        part_id="p1",
+        part_dict=None,
+    )
+    asm.flush_pending()
+    asm.on_primary_assistant_completion(
+        {
+            "text": "Done. **v2.1.1** released.",
+            "phase": "final_answer",
+            "finish": "stop",
+        },
+        message_role=None,
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Done. **v2.1.1** released."
 
 
 @pytest.mark.anyio
@@ -682,6 +858,39 @@ async def test_part_type_memory() -> None:
     asm.remember_part_type("r1", "reasoning")
     assert asm.lookup_part_type("r1") == "reasoning"
     assert asm.lookup_part_type("unknown") is None
+
+
+@pytest.mark.anyio
+async def test_part_type_memory_scoped_by_message_id_for_reused_part_ids() -> None:
+    asm = OutputAssembler(session_id="s1")
+
+    asm.remember_part_type("shared", "reasoning", message_id="m1")
+    asm.remember_part_type("shared", "text", message_id="m2")
+
+    assert asm.lookup_part_type("shared", message_id="m1") == "reasoning"
+    assert asm.lookup_part_type("shared", message_id="m2") == "text"
+    assert asm.lookup_part_type("shared", message_id="m3") is None
+
+
+@pytest.mark.anyio
+async def test_part_type_memory_falls_back_when_delta_omits_message_id() -> None:
+    asm = OutputAssembler(session_id="s1")
+
+    asm.remember_part_type("reason-1", "reasoning", message_id="m1")
+
+    assert asm.lookup_part_type("reason-1") == "reasoning"
+
+
+@pytest.mark.anyio
+async def test_part_type_memory_omitted_message_id_fallback_rejects_ambiguous_ids() -> (
+    None
+):
+    asm = OutputAssembler(session_id="s1")
+
+    asm.remember_part_type("shared", "reasoning", message_id="m1")
+    asm.remember_part_type("shared", "text", message_id="m2")
+
+    assert asm.lookup_part_type("shared") is None
 
 
 @pytest.mark.anyio

--- a/tests/agents/opencode/test_output_assembly.py
+++ b/tests/agents/opencode/test_output_assembly.py
@@ -574,6 +574,30 @@ async def test_roleless_primary_completion_overrides_prior_stream_text() -> None
 
 
 @pytest.mark.anyio
+async def test_roleless_primary_completion_uses_no_message_stream_scope() -> None:
+    asm = OutputAssembler(session_id="s1", prompt="release from origin main")
+
+    await asm.on_text_delta(
+        part_message_id=None,
+        delta_text="Current latest tag is `v 2.1.0`.",
+        part_id="p1",
+        part_dict=None,
+    )
+    asm.flush_pending()
+    asm.on_primary_assistant_completion(
+        {
+            "text": "Done. **v2.1.1** released.",
+            "phase": "final_answer",
+            "finish": "stop",
+        },
+        message_role=None,
+    )
+
+    assert asm._assistant_output.stream_text == "Current latest tag is `v 2.1.0`."
+    assert asm._assistant_output.text == "Done. **v2.1.1** released."
+
+
+@pytest.mark.anyio
 async def test_usage_deduplication() -> None:
     seen: list[dict] = []
 

--- a/tests/core/orchestration/test_assistant_output_assembly.py
+++ b/tests/core/orchestration/test_assistant_output_assembly.py
@@ -1,0 +1,40 @@
+from codex_autorunner.core.orchestration.assistant_output_assembly import (
+    AssistantOutputAssembler,
+    AssistantOutputEvent,
+    assemble_assistant_output,
+)
+
+
+def test_final_message_wins_over_stream_and_commentary() -> None:
+    assert (
+        assemble_assistant_output(
+            [
+                AssistantOutputEvent(kind="commentary", text="Let me check."),
+                AssistantOutputEvent(kind="delta", text="damaged stream"),
+                AssistantOutputEvent(kind="final_message", text="Clean final."),
+            ]
+        )
+        == "Clean final."
+    )
+
+
+def test_scoped_stream_text_does_not_bleed_across_snapshots() -> None:
+    assembler = AssistantOutputAssembler()
+    assembler.note(
+        AssistantOutputEvent(kind="snapshot", text="First message", scope="m1")
+    )
+    assembler.note(
+        AssistantOutputEvent(kind="snapshot", text="Second message", scope="m2")
+    )
+    assembler.note(AssistantOutputEvent(kind="final_message", text="", scope="m2"))
+
+    assert assembler.stream_text == "Second message"
+
+
+def test_final_scope_uses_matching_stream_scope_when_final_text_missing() -> None:
+    assembler = AssistantOutputAssembler()
+    assembler.note(AssistantOutputEvent(kind="delta", text="progress", scope="m1"))
+    assembler.note(AssistantOutputEvent(kind="delta", text="final answer", scope="m2"))
+    assembler.note(AssistantOutputEvent(kind="final_message", text="", scope="m2"))
+
+    assert assembler.text == "final answer"


### PR DESCRIPTION
## Summary
- add a shared assistant output assembly contract for scoped deltas, snapshots, final messages, commentary, and reasoning
- wire Codex, OpenCode, and Hermes/ACP terminal output paths through the shared contract where appropriate
- harden OpenCode and Hermes/ACP against token-spacing damage, reused part ids, roleless finals, and cumulative terminal output

## Root Cause
Each runtime adapter reduced native stream events into final assistant text differently. OpenCode and Hermes/ACP could treat deltas as snapshots, mix message scopes, or prefer malformed stream text over cleaner terminal output, leaving Discord to display damaged text.

## Validation
- pre-commit aggregate lane passed
- 9608 Python tests passed
- strict mypy passed for 966 source files
- Web Hub lint/build/tests passed
- focused matrix: `tests/core/orchestration/test_assistant_output_assembly.py`, Codex harness, OpenCode, ACP client/event normalization, Hermes supervisor
