### PR TITLE
[codex] Fix OpenCode question request id handling

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -282,6 +282,7 @@ async def collect_opencode_output_from_events(
 
     terminal_signal: Optional[str] = None
     fatal_question_tool_error: Optional[str] = None
+    pending_question_tool_without_request_id = False
     terminal_assistant_completion_seen = False
     nonterminal_assistant_checkpoint_seen = False
 
@@ -292,7 +293,7 @@ async def collect_opencode_output_from_events(
         event_session_id: Optional[str],
         source: str,
     ) -> None:
-        nonlocal fatal_question_tool_error
+        nonlocal fatal_question_tool_error, pending_question_tool_without_request_id
         questions = props.get("questions") if isinstance(props, dict) else []
         question_count = len(questions) if isinstance(questions, list) else 0
         log_event(
@@ -306,6 +307,7 @@ async def collect_opencode_output_from_events(
         )
         if not request_id:
             return
+        pending_question_tool_without_request_id = False
         dedupe_key = (event_session_id, request_id)
         if dedupe_key in seen_question_request_ids:
             return
@@ -628,12 +630,16 @@ async def collect_opencode_output_from_events(
                                 )
                             assembler.error = fatal_question_tool_error
                             break
+                        if question_status in {"completed", "complete", "success"}:
+                            pending_question_tool_without_request_id = False
                         if question_status not in {"completed", "complete", "success"}:
                             if not question_request_id:
                                 questions = question_props.get("questions")
                                 question_count = (
                                     len(questions) if isinstance(questions, list) else 0
                                 )
+                                if is_primary_session:
+                                    pending_question_tool_without_request_id = True
                                 log_event(
                                     logger,
                                     logging.INFO,
@@ -751,6 +757,8 @@ async def collect_opencode_output_from_events(
 
     result = await assembler.build_result()
     error = result.error
+    if not error and pending_question_tool_without_request_id:
+        fatal_question_tool_error = "OpenCode question tool missing request id"
     if fatal_question_tool_error:
         error = fatal_question_tool_error
         result = OutputAssemblyResult(

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -630,11 +630,19 @@ async def collect_opencode_output_from_events(
                             break
                         if question_status not in {"completed", "complete", "success"}:
                             if not question_request_id:
-                                fatal_question_tool_error = (
-                                    "OpenCode question tool missing request id"
+                                questions = question_props.get("questions")
+                                question_count = (
+                                    len(questions) if isinstance(questions, list) else 0
                                 )
-                                assembler.error = fatal_question_tool_error
-                                break
+                                log_event(
+                                    logger,
+                                    logging.INFO,
+                                    "opencode.question.tool_waiting_for_request_id",
+                                    question_count=question_count,
+                                    session_id=event_session_id,
+                                    source="tool_part",
+                                )
+                                continue
                             await _handle_question_request(
                                 question_request_id,
                                 question_props,

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -300,7 +300,7 @@ async def test_turn_runtime_collector_fails_failed_question_tool_part() -> None:
 
 
 @pytest.mark.asyncio
-async def test_turn_runtime_collector_fails_question_tool_part_missing_request_id() -> (
+async def test_turn_runtime_collector_ignores_question_tool_part_missing_request_id() -> (
     None
 ):
     async def _events():
@@ -336,7 +336,68 @@ async def test_turn_runtime_collector_fails_question_tool_part_missing_request_i
     )
 
     assert output.text == ""
-    assert output.error == "OpenCode question tool missing request id"
+    assert output.error is None
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_collector_uses_question_event_after_tool_part_without_id() -> (
+    None
+):
+    question_answers: list[tuple[str, list[list[str]]]] = []
+
+    async def _events():
+        yield SSEEvent(
+            event="message.part.updated",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "part": {
+                            "id": "prt-q1",
+                            "type": "tool",
+                            "tool": "question",
+                            "state": {
+                                "status": "pending",
+                                "input": {},
+                            },
+                        }
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="question.asked",
+            data=json.dumps(
+                {
+                    "sessionID": "session-1",
+                    "properties": {
+                        "id": "que-q1",
+                        "questions": [
+                            {
+                                "question": "Continue?",
+                                "options": [{"label": "Yes"}],
+                            }
+                        ],
+                    },
+                }
+            ),
+        )
+        yield SSEEvent(
+            event="session.status",
+            data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+        )
+
+    output = await collect_opencode_output_from_events(
+        _events(),
+        session_id="session-1",
+        question_handler=lambda request_id, props: _answer_question(request_id, props),
+        reply_question=lambda request_id, answers: _record_question_answer(
+            question_answers, request_id, answers
+        ),
+    )
+
+    assert output.error is None
+    assert question_answers == [("que-q1", [["Yes"]])]
 
 
 @pytest.mark.asyncio

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -300,7 +300,7 @@ async def test_turn_runtime_collector_fails_failed_question_tool_part() -> None:
 
 
 @pytest.mark.asyncio
-async def test_turn_runtime_collector_ignores_question_tool_part_missing_request_id() -> (
+async def test_turn_runtime_collector_fails_question_tool_part_missing_request_id() -> (
     None
 ):
     async def _events():
@@ -336,7 +336,7 @@ async def test_turn_runtime_collector_ignores_question_tool_part_missing_request
     )
 
     assert output.text == ""
-    assert output.error is None
+    assert output.error == "OpenCode question tool missing request id"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes OpenCode question-tool handling when OpenCode first emits a `question` tool part before the answerable question request id is available.

The runtime now treats a pending question tool part without a request id as progress and waits for the request-bearing `question.asked` event instead of failing the turn immediately with `OpenCode question tool missing request id`.

## Root Cause

OpenCode 1.15.12 can emit a `message.part.updated` tool part for `tool: question` with no `state.id` / `requestID` before it emits the actual `question.asked` event. CAR treated that intermediate tool update as fatal, so Discord turns failed before the request id could arrive.

## Validation

- Reproduced before the fix with real `opencode serve` 1.15.12: prompt `Ask me a question for testing...` failed with `OpenCode question tool missing request id`.
- Verified after the fix with real `opencode serve` 1.15.12: 5 consecutive question-tool runs completed, each receiving a real `que_...` request id and replying through `/question/{id}/reply`.
- Reconfirmed after formatting/type fixes with 3 more real `opencode serve` question-tool runs, all completed with real `que_...` request ids.
- `.venv/bin/python -m pytest tests/agents/opencode/test_turn_runtime.py tests/test_opencode_runtime.py -q` -> `73 passed`.
- Aggregate commit hook passed: Black, Ruff, repo-wide strict mypy, full pytest (`9612 passed`), Web UI lab, Svelte check/build, and Vitest (`894 passed`).