### PR TITLE
[codex] Fix durable direct delivery arbitration

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_direct_delivery.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_direct_delivery.py
@@ -21,6 +21,17 @@ class ManagedThreadDirectDeliveryLease:
     claim_token: str
 
 
+class ManagedThreadDirectDeliverySendSuppressed:
+    """Active foreign claim owns delivery; direct surface send must not run."""
+
+    __slots__ = ()
+
+
+MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED = (
+    ManagedThreadDirectDeliverySendSuppressed()
+)
+
+
 def begin_managed_thread_direct_delivery(
     state_root: Path,
     *,
@@ -70,7 +81,9 @@ def complete_managed_thread_direct_delivery(
 
 
 __all__ = [
+    "MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED",
     "ManagedThreadDirectDeliveryLease",
+    "ManagedThreadDirectDeliverySendSuppressed",
     "begin_managed_thread_direct_delivery",
     "complete_managed_thread_direct_delivery",
 ]

--- a/src/codex_autorunner/adapters/chat/managed_thread_direct_delivery.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_direct_delivery.py
@@ -15,18 +15,18 @@ from ...core.orchestration.managed_thread_delivery_ledger import (
 
 
 @dataclass(frozen=True)
-class ManagedThreadDirectDeliveryReservation:
+class ManagedThreadDirectDeliveryLease:
     engine: SQLiteManagedThreadDeliveryEngine
     delivery_id: str
     claim_token: str
 
 
-def reserve_managed_thread_direct_delivery(
+def begin_managed_thread_direct_delivery(
     state_root: Path,
     *,
     delivery_id: Optional[str],
     claim_token: Optional[str] = None,
-) -> Optional[ManagedThreadDirectDeliveryReservation]:
+) -> Optional[ManagedThreadDirectDeliveryLease]:
     normalized_delivery_id = str(delivery_id or "").strip()
     if not normalized_delivery_id:
         return None
@@ -38,15 +38,15 @@ def reserve_managed_thread_direct_delivery(
     )
     if claim is None:
         return None
-    return ManagedThreadDirectDeliveryReservation(
+    return ManagedThreadDirectDeliveryLease(
         engine=engine,
         delivery_id=normalized_delivery_id,
         claim_token=claim.claim_token,
     )
 
 
-def record_managed_thread_direct_delivery(
-    reservation: ManagedThreadDirectDeliveryReservation,
+def complete_managed_thread_direct_delivery(
+    lease: ManagedThreadDirectDeliveryLease,
     *,
     delivered: bool,
     detail: Optional[str],
@@ -62,15 +62,15 @@ def record_managed_thread_direct_delivery(
         error=str(detail or "").strip() or None,
         metadata=dict(metadata or {}),
     )
-    return reservation.engine.record_attempt_result(
-        reservation.delivery_id,
-        claim_token=reservation.claim_token,
+    return lease.engine.record_attempt_result(
+        lease.delivery_id,
+        claim_token=lease.claim_token,
         result=result,
     )
 
 
 __all__ = [
-    "ManagedThreadDirectDeliveryReservation",
-    "record_managed_thread_direct_delivery",
-    "reserve_managed_thread_direct_delivery",
+    "ManagedThreadDirectDeliveryLease",
+    "begin_managed_thread_direct_delivery",
+    "complete_managed_thread_direct_delivery",
 ]

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -40,7 +40,6 @@ from ...adapters.chat.forwarding import (
     compose_inbound_message_text,
 )
 from ...adapters.chat.managed_thread_direct_delivery import (
-    MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED,
     begin_managed_thread_direct_delivery,
     complete_managed_thread_direct_delivery,
 )
@@ -184,6 +183,12 @@ _MAX_CHAT_WRAPUP_ARTIFACT_BYTES = 8 * 1024 * 1024
 _sanitize_runtime_thread_result_error = sanitize_runtime_thread_error
 
 
+@dataclass(frozen=True)
+class _DirectDeliveryBeginResult:
+    lease: Optional[Any] = None
+    suppress_send: bool = False
+
+
 def _begin_pending_discord_direct_delivery(
     service: Any,
     *,
@@ -191,9 +196,9 @@ def _begin_pending_discord_direct_delivery(
     claim_token: Optional[str],
     channel_id: str,
     session_key: str,
-) -> Optional[Any]:
+) -> _DirectDeliveryBeginResult:
     if not isinstance(delivery_id, str) or not delivery_id.strip():
-        return None
+        return _DirectDeliveryBeginResult()
     state_root = getattr(getattr(service, "_config", None), "root", None)
     if state_root is None:
         state_root = Path(".")
@@ -213,7 +218,7 @@ def _begin_pending_discord_direct_delivery(
             delivery_id=delivery_id,
             exc=exc,
         )
-        return None
+        return _DirectDeliveryBeginResult()
     if lease is None:
         log_event(
             service._logger,
@@ -223,8 +228,8 @@ def _begin_pending_discord_direct_delivery(
             session_key=session_key,
             delivery_id=delivery_id,
         )
-        return MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
-    return lease
+        return _DirectDeliveryBeginResult(suppress_send=True)
+    return _DirectDeliveryBeginResult(lease=lease)
 
 
 def _complete_pending_discord_direct_delivery(
@@ -1469,8 +1474,7 @@ async def _deliver_discord_turn_result(
         not send_final_message and not delivery_visibility_pending
     )
     visible_failure_notice = False
-    direct_delivery_begin = None
-    direct_delivery_lease = None
+    direct_delivery_begin = _DirectDeliveryBeginResult()
     durable_delivery_has_record = bool(durable_delivery_id)
     if delivery_visibility_pending and durable_delivery_has_record:
         direct_delivery_begin = _begin_pending_discord_direct_delivery(
@@ -1480,13 +1484,11 @@ async def _deliver_discord_turn_result(
             channel_id=dispatch.channel_id,
             session_key=dispatch.session_key,
         )
-        if direct_delivery_begin is not MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED:
-            direct_delivery_lease = direct_delivery_begin
     if send_final_message:
         if (
             delivery_visibility_pending
             and durable_delivery_has_record
-            and direct_delivery_begin is MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
+            and direct_delivery_begin.suppress_send
         ):
             visible_terminal_delivery = False
         else:
@@ -1499,21 +1501,31 @@ async def _deliver_discord_turn_result(
                     attachment_filename="final-response.md",
                     attachment_caption="Final response too long; attached as final-response.md.",
                 )
-            finally:
-                if direct_delivery_lease is not None:
+            except asyncio.CancelledError:
+                if direct_delivery_begin.lease is not None:
                     _complete_pending_discord_direct_delivery(
                         dispatch.service,
-                        lease=direct_delivery_lease,
+                        lease=direct_delivery_begin.lease,
                         channel_id=dispatch.channel_id,
                         session_key=dispatch.session_key,
-                        delivered=visible_terminal_delivery,
+                        delivered=False,
                     )
-                    direct_delivery_lease = None
+                raise
+            except Exception:
+                if direct_delivery_begin.lease is not None:
+                    _complete_pending_discord_direct_delivery(
+                        dispatch.service,
+                        lease=direct_delivery_begin.lease,
+                        channel_id=dispatch.channel_id,
+                        session_key=dispatch.session_key,
+                        delivered=False,
+                    )
+                raise
     if delivery_visibility_pending and durable_delivery_has_record:
-        if direct_delivery_lease is not None:
+        if direct_delivery_begin.lease is not None:
             _complete_pending_discord_direct_delivery(
                 dispatch.service,
-                lease=direct_delivery_lease,
+                lease=direct_delivery_begin.lease,
                 channel_id=dispatch.channel_id,
                 session_key=dispatch.session_key,
                 delivered=visible_terminal_delivery,

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -40,8 +40,8 @@ from ...adapters.chat.forwarding import (
     compose_inbound_message_text,
 )
 from ...adapters.chat.managed_thread_direct_delivery import (
-    record_managed_thread_direct_delivery,
-    reserve_managed_thread_direct_delivery,
+    begin_managed_thread_direct_delivery,
+    complete_managed_thread_direct_delivery,
 )
 from ...adapters.chat.models import ChatMessageEvent
 from ...adapters.chat.runtime_thread_errors import (
@@ -183,30 +183,60 @@ _MAX_CHAT_WRAPUP_ARTIFACT_BYTES = 8 * 1024 * 1024
 _sanitize_runtime_thread_result_error = sanitize_runtime_thread_error
 
 
-def _record_pending_discord_direct_delivery(
+def _begin_pending_discord_direct_delivery(
     service: Any,
     *,
     delivery_id: Optional[str],
     claim_token: Optional[str],
     channel_id: str,
     session_key: str,
-    delivered: bool,
-) -> None:
+) -> Optional[Any]:
     if not isinstance(delivery_id, str) or not delivery_id.strip():
-        return
+        return None
     state_root = getattr(getattr(service, "_config", None), "root", None)
     if state_root is None:
         state_root = Path(".")
     try:
-        reservation = reserve_managed_thread_direct_delivery(
+        lease = begin_managed_thread_direct_delivery(
             Path(state_root),
             delivery_id=delivery_id,
             claim_token=claim_token,
         )
-        if reservation is None:
-            return
-        updated = record_managed_thread_direct_delivery(
-            reservation,
+    except Exception as exc:
+        log_event(
+            service._logger,
+            logging.WARNING,
+            "discord.turn.direct_delivery_begin_failed",
+            channel_id=channel_id,
+            session_key=session_key,
+            delivery_id=delivery_id,
+            exc=exc,
+        )
+        return None
+    if lease is None:
+        log_event(
+            service._logger,
+            logging.INFO,
+            "discord.turn.direct_delivery_suppressed",
+            channel_id=channel_id,
+            session_key=session_key,
+            delivery_id=delivery_id,
+        )
+        return None
+    return lease
+
+
+def _complete_pending_discord_direct_delivery(
+    service: Any,
+    *,
+    lease: Any,
+    channel_id: str,
+    session_key: str,
+    delivered: bool,
+) -> None:
+    try:
+        updated = complete_managed_thread_direct_delivery(
+            lease,
             delivered=delivered,
             detail=(
                 "direct_discord_surface_delivery"
@@ -222,7 +252,7 @@ def _record_pending_discord_direct_delivery(
             "discord.turn.direct_delivery_record_failed",
             channel_id=channel_id,
             session_key=session_key,
-            delivery_id=delivery_id,
+            delivery_id=getattr(lease, "delivery_id", None),
             delivered=delivered,
             exc=exc,
         )
@@ -234,7 +264,7 @@ def _record_pending_discord_direct_delivery(
             "discord.turn.direct_delivery_recorded",
             channel_id=channel_id,
             session_key=session_key,
-            delivery_id=delivery_id,
+            delivery_id=getattr(lease, "delivery_id", None),
             delivered=delivered,
             delivery_state=updated.state.value,
         )
@@ -1438,24 +1468,41 @@ async def _deliver_discord_turn_result(
         not send_final_message and not delivery_visibility_pending
     )
     visible_failure_notice = False
-    if send_final_message:
-        visible_terminal_delivery = await _send_discord_turn_section(
-            dispatch.service,
-            channel_id=dispatch.channel_id,
-            text=response_text or "(No response text returned.)",
-            record_prefix=f"turn:final:{dispatch.session_key}",
-            attachment_filename="final-response.md",
-            attachment_caption="Final response too long; attached as final-response.md.",
-        )
-    if delivery_visibility_pending:
-        _record_pending_discord_direct_delivery(
+    direct_delivery_lease = None
+    durable_delivery_has_record = bool(durable_delivery_id)
+    if delivery_visibility_pending and durable_delivery_has_record:
+        direct_delivery_lease = _begin_pending_discord_direct_delivery(
             dispatch.service,
             delivery_id=durable_delivery_id,
             claim_token=durable_delivery_claim_token,
             channel_id=dispatch.channel_id,
             session_key=dispatch.session_key,
-            delivered=visible_terminal_delivery,
         )
+    if send_final_message:
+        if (
+            delivery_visibility_pending
+            and durable_delivery_has_record
+            and direct_delivery_lease is None
+        ):
+            visible_terminal_delivery = False
+        else:
+            visible_terminal_delivery = await _send_discord_turn_section(
+                dispatch.service,
+                channel_id=dispatch.channel_id,
+                text=response_text or "(No response text returned.)",
+                record_prefix=f"turn:final:{dispatch.session_key}",
+                attachment_filename="final-response.md",
+                attachment_caption="Final response too long; attached as final-response.md.",
+            )
+    if delivery_visibility_pending and durable_delivery_has_record:
+        if direct_delivery_lease is not None:
+            _complete_pending_discord_direct_delivery(
+                dispatch.service,
+                lease=direct_delivery_lease,
+                channel_id=dispatch.channel_id,
+                session_key=dispatch.session_key,
+                delivered=visible_terminal_delivery,
+            )
     if visible_terminal_delivery:
         if not preserve_progress_lease:
             # Require execution_id or managed_thread_id so listing does not fall back to

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -40,6 +40,7 @@ from ...adapters.chat.forwarding import (
     compose_inbound_message_text,
 )
 from ...adapters.chat.managed_thread_direct_delivery import (
+    MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED,
     begin_managed_thread_direct_delivery,
     complete_managed_thread_direct_delivery,
 )
@@ -222,7 +223,7 @@ def _begin_pending_discord_direct_delivery(
             session_key=session_key,
             delivery_id=delivery_id,
         )
-        return None
+        return MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
     return lease
 
 
@@ -1468,32 +1469,46 @@ async def _deliver_discord_turn_result(
         not send_final_message and not delivery_visibility_pending
     )
     visible_failure_notice = False
+    direct_delivery_begin = None
     direct_delivery_lease = None
     durable_delivery_has_record = bool(durable_delivery_id)
     if delivery_visibility_pending and durable_delivery_has_record:
-        direct_delivery_lease = _begin_pending_discord_direct_delivery(
+        direct_delivery_begin = _begin_pending_discord_direct_delivery(
             dispatch.service,
             delivery_id=durable_delivery_id,
             claim_token=durable_delivery_claim_token,
             channel_id=dispatch.channel_id,
             session_key=dispatch.session_key,
         )
+        if direct_delivery_begin is not MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED:
+            direct_delivery_lease = direct_delivery_begin
     if send_final_message:
         if (
             delivery_visibility_pending
             and durable_delivery_has_record
-            and direct_delivery_lease is None
+            and direct_delivery_begin is MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
         ):
             visible_terminal_delivery = False
         else:
-            visible_terminal_delivery = await _send_discord_turn_section(
-                dispatch.service,
-                channel_id=dispatch.channel_id,
-                text=response_text or "(No response text returned.)",
-                record_prefix=f"turn:final:{dispatch.session_key}",
-                attachment_filename="final-response.md",
-                attachment_caption="Final response too long; attached as final-response.md.",
-            )
+            try:
+                visible_terminal_delivery = await _send_discord_turn_section(
+                    dispatch.service,
+                    channel_id=dispatch.channel_id,
+                    text=response_text or "(No response text returned.)",
+                    record_prefix=f"turn:final:{dispatch.session_key}",
+                    attachment_filename="final-response.md",
+                    attachment_caption="Final response too long; attached as final-response.md.",
+                )
+            finally:
+                if direct_delivery_lease is not None:
+                    _complete_pending_discord_direct_delivery(
+                        dispatch.service,
+                        lease=direct_delivery_lease,
+                        channel_id=dispatch.channel_id,
+                        session_key=dispatch.session_key,
+                        delivered=visible_terminal_delivery,
+                    )
+                    direct_delivery_lease = None
     if delivery_visibility_pending and durable_delivery_has_record:
         if direct_delivery_lease is not None:
             _complete_pending_discord_direct_delivery(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -42,6 +42,7 @@ from .....adapters.chat.managed_thread_delivery_support import (
     managed_thread_terminal_delivery_send_key,
 )
 from .....adapters.chat.managed_thread_direct_delivery import (
+    MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED,
     begin_managed_thread_direct_delivery,
     complete_managed_thread_direct_delivery,
 )
@@ -378,7 +379,7 @@ def _begin_pending_telegram_direct_delivery(
             thread_id=thread_id,
             delivery_id=delivery_id,
         )
-        return None
+        return MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
     return lease
 
 
@@ -1516,9 +1517,9 @@ async def _run_telegram_managed_thread_turn(
             if send_failure_response and not getattr(
                 _flow, "durable_delivery_performed", False
             ):
-                direct_delivery_lease = None
+                direct_delivery_begin = None
                 if getattr(_flow, "durable_delivery_pending", False):
-                    direct_delivery_lease = _begin_pending_telegram_direct_delivery(
+                    direct_delivery_begin = _begin_pending_telegram_direct_delivery(
                         handlers,
                         delivery_id=getattr(_flow, "durable_delivery_id", None),
                         claim_token=getattr(
@@ -1531,23 +1532,33 @@ async def _run_telegram_managed_thread_turn(
                     )
                 if (
                     not getattr(_flow, "durable_delivery_pending", False)
-                    or direct_delivery_lease is not None
+                    or direct_delivery_begin
+                    is not MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
                 ):
-                    response_sent = await handlers._deliver_turn_response(
-                        chat_id=message.chat_id,
-                        thread_id=message.thread_id,
-                        reply_to=message.message_id,
-                        placeholder_id=prepared_placeholder_id,
-                        response=failure_message,
+                    direct_delivery_lease = (
+                        direct_delivery_begin
+                        if direct_delivery_begin
+                        is not MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
+                        else None
                     )
-                    if direct_delivery_lease is not None:
-                        _complete_pending_telegram_direct_delivery(
-                            handlers,
-                            lease=direct_delivery_lease,
+                    response_sent = False
+                    try:
+                        response_sent = await handlers._deliver_turn_response(
                             chat_id=message.chat_id,
                             thread_id=message.thread_id,
-                            delivered=response_sent,
+                            reply_to=message.message_id,
+                            placeholder_id=prepared_placeholder_id,
+                            response=failure_message,
                         )
+                    finally:
+                        if direct_delivery_lease is not None:
+                            _complete_pending_telegram_direct_delivery(
+                                handlers,
+                                lease=direct_delivery_lease,
+                                chat_id=message.chat_id,
+                                thread_id=message.thread_id,
+                                delivered=response_sent,
+                            )
             elif send_failure_response and prepared_placeholder_id is not None:
                 await handlers._delete_message(
                     message.chat_id,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -42,8 +42,8 @@ from .....adapters.chat.managed_thread_delivery_support import (
     managed_thread_terminal_delivery_send_key,
 )
 from .....adapters.chat.managed_thread_direct_delivery import (
-    record_managed_thread_direct_delivery,
-    reserve_managed_thread_direct_delivery,
+    begin_managed_thread_direct_delivery,
+    complete_managed_thread_direct_delivery,
 )
 from .....adapters.chat.managed_thread_lifecycle import (
     replace_surface_thread,
@@ -342,27 +342,57 @@ def _telegram_state_root(handlers: Any) -> Path:
     return Path(state_root)
 
 
-def _record_pending_telegram_direct_delivery(
+def _begin_pending_telegram_direct_delivery(
     handlers: Any,
     *,
     delivery_id: Optional[str],
     claim_token: Optional[str],
     chat_id: int,
     thread_id: Optional[int],
-    delivered: bool,
-) -> None:
+) -> Optional[Any]:
     if not isinstance(delivery_id, str) or not delivery_id.strip():
-        return
+        return None
     try:
-        reservation = reserve_managed_thread_direct_delivery(
+        lease = begin_managed_thread_direct_delivery(
             _telegram_state_root(handlers),
             delivery_id=delivery_id,
             claim_token=claim_token,
         )
-        if reservation is None:
-            return
-        updated = record_managed_thread_direct_delivery(
-            reservation,
+    except Exception as exc:
+        log_event(
+            handlers._logger,
+            logging.WARNING,
+            "telegram.response.direct_delivery_begin_failed",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            delivery_id=delivery_id,
+            exc=exc,
+        )
+        return None
+    if lease is None:
+        log_event(
+            handlers._logger,
+            logging.INFO,
+            "telegram.response.direct_delivery_suppressed",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            delivery_id=delivery_id,
+        )
+        return None
+    return lease
+
+
+def _complete_pending_telegram_direct_delivery(
+    handlers: Any,
+    *,
+    lease: Any,
+    chat_id: int,
+    thread_id: Optional[int],
+    delivered: bool,
+) -> None:
+    try:
+        updated = complete_managed_thread_direct_delivery(
+            lease,
             delivered=delivered,
             detail=(
                 "direct_telegram_surface_delivery"
@@ -378,7 +408,7 @@ def _record_pending_telegram_direct_delivery(
             "telegram.response.direct_delivery_record_failed",
             chat_id=chat_id,
             thread_id=thread_id,
-            delivery_id=delivery_id,
+            delivery_id=getattr(lease, "delivery_id", None),
             delivered=delivered,
             exc=exc,
         )
@@ -390,7 +420,7 @@ def _record_pending_telegram_direct_delivery(
             "telegram.response.direct_delivery_recorded",
             chat_id=chat_id,
             thread_id=thread_id,
-            delivery_id=delivery_id,
+            delivery_id=getattr(lease, "delivery_id", None),
             delivered=delivered,
             delivery_state=updated.state.value,
         )
@@ -1486,15 +1516,9 @@ async def _run_telegram_managed_thread_turn(
             if send_failure_response and not getattr(
                 _flow, "durable_delivery_performed", False
             ):
-                response_sent = await handlers._deliver_turn_response(
-                    chat_id=message.chat_id,
-                    thread_id=message.thread_id,
-                    reply_to=message.message_id,
-                    placeholder_id=prepared_placeholder_id,
-                    response=failure_message,
-                )
+                direct_delivery_lease = None
                 if getattr(_flow, "durable_delivery_pending", False):
-                    _record_pending_telegram_direct_delivery(
+                    direct_delivery_lease = _begin_pending_telegram_direct_delivery(
                         handlers,
                         delivery_id=getattr(_flow, "durable_delivery_id", None),
                         claim_token=getattr(
@@ -1504,8 +1528,26 @@ async def _run_telegram_managed_thread_turn(
                         ),
                         chat_id=message.chat_id,
                         thread_id=message.thread_id,
-                        delivered=response_sent,
                     )
+                if (
+                    not getattr(_flow, "durable_delivery_pending", False)
+                    or direct_delivery_lease is not None
+                ):
+                    response_sent = await handlers._deliver_turn_response(
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        reply_to=message.message_id,
+                        placeholder_id=prepared_placeholder_id,
+                        response=failure_message,
+                    )
+                    if direct_delivery_lease is not None:
+                        _complete_pending_telegram_direct_delivery(
+                            handlers,
+                            lease=direct_delivery_lease,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            delivered=response_sent,
+                        )
             elif send_failure_response and prepared_placeholder_id is not None:
                 await handlers._delete_message(
                     message.chat_id,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -42,7 +42,6 @@ from .....adapters.chat.managed_thread_delivery_support import (
     managed_thread_terminal_delivery_send_key,
 )
 from .....adapters.chat.managed_thread_direct_delivery import (
-    MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED,
     begin_managed_thread_direct_delivery,
     complete_managed_thread_direct_delivery,
 )
@@ -227,8 +226,15 @@ class _TurnRunResult:
     interrupt_status_turn_id: Optional[str] = None
     interrupt_status_fallback_text: Optional[str] = None
     durable_delivery_handled: bool = False
+    durable_delivery_pending: bool = False
     durable_delivery_id: Optional[str] = None
     durable_delivery_claim_token: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _DirectDeliveryBeginResult:
+    lease: Optional[Any] = None
+    suppress_send: bool = False
 
 
 @dataclass
@@ -350,9 +356,9 @@ def _begin_pending_telegram_direct_delivery(
     claim_token: Optional[str],
     chat_id: int,
     thread_id: Optional[int],
-) -> Optional[Any]:
+) -> _DirectDeliveryBeginResult:
     if not isinstance(delivery_id, str) or not delivery_id.strip():
-        return None
+        return _DirectDeliveryBeginResult()
     try:
         lease = begin_managed_thread_direct_delivery(
             _telegram_state_root(handlers),
@@ -369,7 +375,7 @@ def _begin_pending_telegram_direct_delivery(
             delivery_id=delivery_id,
             exc=exc,
         )
-        return None
+        return _DirectDeliveryBeginResult()
     if lease is None:
         log_event(
             handlers._logger,
@@ -379,8 +385,8 @@ def _begin_pending_telegram_direct_delivery(
             thread_id=thread_id,
             delivery_id=delivery_id,
         )
-        return MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
-    return lease
+        return _DirectDeliveryBeginResult(suppress_send=True)
+    return _DirectDeliveryBeginResult(lease=lease)
 
 
 def _complete_pending_telegram_direct_delivery(
@@ -1517,7 +1523,7 @@ async def _run_telegram_managed_thread_turn(
             if send_failure_response and not getattr(
                 _flow, "durable_delivery_performed", False
             ):
-                direct_delivery_begin = None
+                direct_delivery_begin = _DirectDeliveryBeginResult()
                 if getattr(_flow, "durable_delivery_pending", False):
                     direct_delivery_begin = _begin_pending_telegram_direct_delivery(
                         handlers,
@@ -1532,16 +1538,8 @@ async def _run_telegram_managed_thread_turn(
                     )
                 if (
                     not getattr(_flow, "durable_delivery_pending", False)
-                    or direct_delivery_begin
-                    is not MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
+                    or not direct_delivery_begin.suppress_send
                 ):
-                    direct_delivery_lease = (
-                        direct_delivery_begin
-                        if direct_delivery_begin
-                        is not MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
-                        else None
-                    )
-                    response_sent = False
                     try:
                         response_sent = await handlers._deliver_turn_response(
                             chat_id=message.chat_id,
@@ -1550,15 +1548,34 @@ async def _run_telegram_managed_thread_turn(
                             placeholder_id=prepared_placeholder_id,
                             response=failure_message,
                         )
-                    finally:
-                        if direct_delivery_lease is not None:
+                    except asyncio.CancelledError:
+                        if direct_delivery_begin.lease is not None:
                             _complete_pending_telegram_direct_delivery(
                                 handlers,
-                                lease=direct_delivery_lease,
+                                lease=direct_delivery_begin.lease,
                                 chat_id=message.chat_id,
                                 thread_id=message.thread_id,
-                                delivered=response_sent,
+                                delivered=False,
                             )
+                        raise
+                    except Exception:
+                        if direct_delivery_begin.lease is not None:
+                            _complete_pending_telegram_direct_delivery(
+                                handlers,
+                                lease=direct_delivery_begin.lease,
+                                chat_id=message.chat_id,
+                                thread_id=message.thread_id,
+                                delivered=False,
+                            )
+                        raise
+                    if direct_delivery_begin.lease is not None:
+                        _complete_pending_telegram_direct_delivery(
+                            handlers,
+                            lease=direct_delivery_begin.lease,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            delivered=response_sent,
+                        )
             elif send_failure_response and prepared_placeholder_id is not None:
                 await handlers._delete_message(
                     message.chat_id,
@@ -1697,6 +1714,7 @@ async def _run_telegram_managed_thread_turn(
             interrupt_status_turn_id=backend_turn_id or None,
             interrupt_status_fallback_text=interrupt_status_fallback_text,
             durable_delivery_handled=_delivery_handled,
+            durable_delivery_pending=getattr(_flow, "durable_delivery_pending", False),
             durable_delivery_id=getattr(_flow, "durable_delivery_id", None),
             durable_delivery_claim_token=getattr(
                 _flow,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
@@ -160,10 +160,8 @@ from .commands import (
 from .commands.execution import (
     _begin_pending_telegram_direct_delivery,
     _complete_pending_telegram_direct_delivery,
+    _DirectDeliveryBeginResult,
     _TurnRunFailure,
-)
-from ...chat.managed_thread_direct_delivery import (
-    MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED,
 )
 from .commands.shared import _RuntimeStub  # noqa: F401
 
@@ -446,9 +444,12 @@ class TelegramCommandHandlers(
                     thread_id=message.thread_id,
                 )
         else:
-            direct_delivery_begin = None
+            direct_delivery_begin = _DirectDeliveryBeginResult()
             durable_delivery_id = getattr(outcome, "durable_delivery_id", None)
-            if durable_delivery_id:
+            durable_delivery_pending = getattr(
+                outcome, "durable_delivery_pending", False
+            )
+            if durable_delivery_pending:
                 direct_delivery_begin = _begin_pending_telegram_direct_delivery(
                     self,
                     delivery_id=durable_delivery_id,
@@ -460,14 +461,9 @@ class TelegramCommandHandlers(
                     chat_id=message.chat_id,
                     thread_id=message.thread_id,
                 )
-            if (
-                durable_delivery_id
-                and direct_delivery_begin is MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
-            ):
+            if durable_delivery_pending and direct_delivery_begin.suppress_send:
                 response_sent = False
             else:
-                direct_delivery_lease = direct_delivery_begin
-                response_sent = False
                 try:
                     try:
                         response_sent = await self._deliver_turn_response(
@@ -482,7 +478,10 @@ class TelegramCommandHandlers(
                     except TypeError as exc:
                         if not any(
                             key in str(exc)
-                            for key in ("intermediate_response", "overflow_mode_override")
+                            for key in (
+                                "intermediate_response",
+                                "overflow_mode_override",
+                            )
                         ):
                             raise
                         response_sent = await self._deliver_turn_response(
@@ -492,11 +491,31 @@ class TelegramCommandHandlers(
                             placeholder_id=outcome.placeholder_id,
                             response=response_text,
                         )
-                finally:
-                    if direct_delivery_lease is not None:
+                except asyncio.CancelledError:
+                    if direct_delivery_begin.lease is not None:
                         _complete_pending_telegram_direct_delivery(
                             self,
-                            lease=direct_delivery_lease,
+                            lease=direct_delivery_begin.lease,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            delivered=False,
+                        )
+                    raise
+                except Exception:
+                    if direct_delivery_begin.lease is not None:
+                        _complete_pending_telegram_direct_delivery(
+                            self,
+                            lease=direct_delivery_begin.lease,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            delivered=False,
+                        )
+                    raise
+                else:
+                    if direct_delivery_begin.lease is not None:
+                        _complete_pending_telegram_direct_delivery(
+                            self,
+                            lease=direct_delivery_begin.lease,
                             chat_id=message.chat_id,
                             thread_id=message.thread_id,
                             delivered=response_sent,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
@@ -162,6 +162,9 @@ from .commands.execution import (
     _complete_pending_telegram_direct_delivery,
     _TurnRunFailure,
 )
+from ...chat.managed_thread_direct_delivery import (
+    MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED,
+)
 from .commands.shared import _RuntimeStub  # noqa: F401
 
 PROMPT_CONTEXT_RE = re.compile("\\bprompt\\b", re.IGNORECASE)
@@ -443,10 +446,10 @@ class TelegramCommandHandlers(
                     thread_id=message.thread_id,
                 )
         else:
-            direct_delivery_lease = None
+            direct_delivery_begin = None
             durable_delivery_id = getattr(outcome, "durable_delivery_id", None)
             if durable_delivery_id:
-                direct_delivery_lease = _begin_pending_telegram_direct_delivery(
+                direct_delivery_begin = _begin_pending_telegram_direct_delivery(
                     self,
                     delivery_id=durable_delivery_id,
                     claim_token=getattr(
@@ -457,40 +460,47 @@ class TelegramCommandHandlers(
                     chat_id=message.chat_id,
                     thread_id=message.thread_id,
                 )
-            if durable_delivery_id and direct_delivery_lease is None:
+            if (
+                durable_delivery_id
+                and direct_delivery_begin is MANAGED_THREAD_DIRECT_DELIVERY_SEND_SUPPRESSED
+            ):
                 response_sent = False
             else:
+                direct_delivery_lease = direct_delivery_begin
+                response_sent = False
                 try:
-                    response_sent = await self._deliver_turn_response(
-                        chat_id=message.chat_id,
-                        thread_id=message.thread_id,
-                        reply_to=message.message_id,
-                        placeholder_id=outcome.placeholder_id,
-                        response=response_text,
-                        intermediate_response=intermediate_response,
-                        overflow_mode_override=overflow_mode_override,
-                    )
-                except TypeError as exc:
-                    if not any(
-                        key in str(exc)
-                        for key in ("intermediate_response", "overflow_mode_override")
-                    ):
-                        raise
-                    response_sent = await self._deliver_turn_response(
-                        chat_id=message.chat_id,
-                        thread_id=message.thread_id,
-                        reply_to=message.message_id,
-                        placeholder_id=outcome.placeholder_id,
-                        response=response_text,
-                    )
-                if direct_delivery_lease is not None:
-                    _complete_pending_telegram_direct_delivery(
-                        self,
-                        lease=direct_delivery_lease,
-                        chat_id=message.chat_id,
-                        thread_id=message.thread_id,
-                        delivered=response_sent,
-                    )
+                    try:
+                        response_sent = await self._deliver_turn_response(
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            reply_to=message.message_id,
+                            placeholder_id=outcome.placeholder_id,
+                            response=response_text,
+                            intermediate_response=intermediate_response,
+                            overflow_mode_override=overflow_mode_override,
+                        )
+                    except TypeError as exc:
+                        if not any(
+                            key in str(exc)
+                            for key in ("intermediate_response", "overflow_mode_override")
+                        ):
+                            raise
+                        response_sent = await self._deliver_turn_response(
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            reply_to=message.message_id,
+                            placeholder_id=outcome.placeholder_id,
+                            response=response_text,
+                        )
+                finally:
+                    if direct_delivery_lease is not None:
+                        _complete_pending_telegram_direct_delivery(
+                            self,
+                            lease=direct_delivery_lease,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            delivered=response_sent,
+                        )
         if response_sent:
             key = await self._resolve_topic_key(message.chat_id, message.thread_id)
             log_event(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
@@ -158,7 +158,8 @@ from .commands import (
     WorkspaceCommands,
 )
 from .commands.execution import (
-    _record_pending_telegram_direct_delivery,
+    _begin_pending_telegram_direct_delivery,
+    _complete_pending_telegram_direct_delivery,
     _TurnRunFailure,
 )
 from .commands.shared import _RuntimeStub  # noqa: F401
@@ -442,33 +443,12 @@ class TelegramCommandHandlers(
                     thread_id=message.thread_id,
                 )
         else:
-            try:
-                response_sent = await self._deliver_turn_response(
-                    chat_id=message.chat_id,
-                    thread_id=message.thread_id,
-                    reply_to=message.message_id,
-                    placeholder_id=outcome.placeholder_id,
-                    response=response_text,
-                    intermediate_response=intermediate_response,
-                    overflow_mode_override=overflow_mode_override,
-                )
-            except TypeError as exc:
-                if not any(
-                    key in str(exc)
-                    for key in ("intermediate_response", "overflow_mode_override")
-                ):
-                    raise
-                response_sent = await self._deliver_turn_response(
-                    chat_id=message.chat_id,
-                    thread_id=message.thread_id,
-                    reply_to=message.message_id,
-                    placeholder_id=outcome.placeholder_id,
-                    response=response_text,
-                )
-            if response_sent:
-                _record_pending_telegram_direct_delivery(
+            direct_delivery_lease = None
+            durable_delivery_id = getattr(outcome, "durable_delivery_id", None)
+            if durable_delivery_id:
+                direct_delivery_lease = _begin_pending_telegram_direct_delivery(
                     self,
-                    delivery_id=getattr(outcome, "durable_delivery_id", None),
+                    delivery_id=durable_delivery_id,
                     claim_token=getattr(
                         outcome,
                         "durable_delivery_claim_token",
@@ -476,21 +456,41 @@ class TelegramCommandHandlers(
                     ),
                     chat_id=message.chat_id,
                     thread_id=message.thread_id,
-                    delivered=True,
                 )
-            elif getattr(outcome, "durable_delivery_id", None):
-                _record_pending_telegram_direct_delivery(
-                    self,
-                    delivery_id=getattr(outcome, "durable_delivery_id", None),
-                    claim_token=getattr(
-                        outcome,
-                        "durable_delivery_claim_token",
-                        None,
-                    ),
-                    chat_id=message.chat_id,
-                    thread_id=message.thread_id,
-                    delivered=False,
-                )
+            if durable_delivery_id and direct_delivery_lease is None:
+                response_sent = False
+            else:
+                try:
+                    response_sent = await self._deliver_turn_response(
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        reply_to=message.message_id,
+                        placeholder_id=outcome.placeholder_id,
+                        response=response_text,
+                        intermediate_response=intermediate_response,
+                        overflow_mode_override=overflow_mode_override,
+                    )
+                except TypeError as exc:
+                    if not any(
+                        key in str(exc)
+                        for key in ("intermediate_response", "overflow_mode_override")
+                    ):
+                        raise
+                    response_sent = await self._deliver_turn_response(
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        reply_to=message.message_id,
+                        placeholder_id=outcome.placeholder_id,
+                        response=response_text,
+                    )
+                if direct_delivery_lease is not None:
+                    _complete_pending_telegram_direct_delivery(
+                        self,
+                        lease=direct_delivery_lease,
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        delivered=response_sent,
+                    )
         if response_sent:
             key = await self._resolve_topic_key(message.chat_id, message.thread_id)
             log_event(

--- a/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
@@ -516,8 +516,10 @@ class SQLiteManagedThreadDeliveryEngine:
         """Return a claim suitable for direct-surface delivery bookkeeping.
 
         Validates *proposed_token* against the ledger when it still matches an
-        active lease; otherwise recovers expired claims for this adapter and
-        issues a fresh claim (same policy as :meth:`claim_delivery`).
+        active lease. A different active lease means another delivery actor owns
+        the send; direct fallback must suppress its transport call instead of
+        stealing the claim. Expired claims are recovered before issuing a fresh
+        direct-delivery claim.
         """
         current_at = now or datetime.now(timezone.utc)
         normalized_id = str(delivery_id or "").strip()
@@ -556,20 +558,21 @@ class SQLiteManagedThreadDeliveryEngine:
                     claim_expires_at=claim_expires_at,
                 )
 
-        if proposed and record.claim_token and proposed != record.claim_token:
-            if record.state in {
-                ManagedThreadDeliveryState.CLAIMED,
-                ManagedThreadDeliveryState.DELIVERING,
-            }:
-                self._ledger.patch_delivery(
-                    normalized_id,
-                    state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
-                    claim_token=None,
-                    claimed_at=None,
-                    claim_expires_at=None,
-                    next_attempt_at=current_at.isoformat(),
-                    last_error="direct_delivery_claim_token_mismatch",
-                )
+        if record.state in {
+            ManagedThreadDeliveryState.CLAIMED,
+            ManagedThreadDeliveryState.DELIVERING,
+        }:
+            decision = plan_managed_thread_delivery_recovery(
+                record,
+                now=current_at,
+                claim_ttl=self._claim_ttl,
+                max_attempts=self._max_attempts,
+            )
+            if (
+                decision.action == ManagedThreadDeliveryRecoveryAction.NOOP
+                and decision.reason == "claim_active"
+            ):
+                return None
 
         refreshed = self._ledger.get_delivery(normalized_id)
         adapter_key = refreshed.target.adapter_key if refreshed is not None else ""

--- a/tests/adapters/chat/test_managed_thread_direct_delivery.py
+++ b/tests/adapters/chat/test_managed_thread_direct_delivery.py
@@ -6,8 +6,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from codex_autorunner.adapters.chat.managed_thread_direct_delivery import (
-    record_managed_thread_direct_delivery,
-    reserve_managed_thread_direct_delivery,
+    begin_managed_thread_direct_delivery,
+    complete_managed_thread_direct_delivery,
 )
 from codex_autorunner.core.orchestration import (
     ManagedThreadDeliveryAttemptResult,
@@ -50,7 +50,9 @@ def _intent(
     )
 
 
-def test_reserve_refreshes_stale_claim_token_before_recording(tmp_path: Path) -> None:
+def test_begin_returns_none_when_another_active_claim_owns_delivery(
+    tmp_path: Path,
+) -> None:
     intent = _intent(tmp_path)
     hub_root = tmp_path / "hub"
     engine = SQLiteManagedThreadDeliveryEngine(
@@ -59,20 +61,46 @@ def test_reserve_refreshes_stale_claim_token_before_recording(tmp_path: Path) ->
         claim_ttl=timedelta(minutes=5),
     )
     engine.create_intent(intent)
+    current_at = datetime.now(timezone.utc)
     first = engine.claim_delivery(
         "delivery-1",
-        now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        now=current_at,
     )
     assert first is not None
-    reservation = reserve_managed_thread_direct_delivery(
+    lease = begin_managed_thread_direct_delivery(
         hub_root,
         delivery_id="delivery-1",
         claim_token="stale-token",
     )
-    assert reservation is not None
-    assert reservation.claim_token != "stale-token"
-    updated = record_managed_thread_direct_delivery(
-        reservation,
+    assert lease is None
+
+
+def test_begin_accepts_matching_active_claim_token_before_recording(
+    tmp_path: Path,
+) -> None:
+    intent = _intent(tmp_path)
+    hub_root = tmp_path / "hub"
+    engine = SQLiteManagedThreadDeliveryEngine(
+        hub_root,
+        durable=False,
+        claim_ttl=timedelta(minutes=5),
+    )
+    engine.create_intent(intent)
+    current_at = datetime.now(timezone.utc)
+    first = engine.claim_delivery(
+        "delivery-1",
+        now=current_at,
+    )
+    assert first is not None
+    lease = begin_managed_thread_direct_delivery(
+        hub_root,
+        delivery_id="delivery-1",
+        claim_token=first.claim_token,
+    )
+    assert lease is not None
+    assert lease.claim_token == first.claim_token
+    updated = complete_managed_thread_direct_delivery(
+        lease,
         delivered=True,
         detail="test",
         metadata={"delivery_surface": "telegram"},
@@ -100,9 +128,9 @@ def test_reserve_returns_none_when_already_direct_surface_delivered(
             outcome=ManagedThreadDeliveryOutcome.DIRECT_SURFACE_DELIVERED,
         ),
     )
-    reservation = reserve_managed_thread_direct_delivery(
+    lease = begin_managed_thread_direct_delivery(
         hub_root,
         delivery_id="delivery-1",
         claim_token=claim.claim_token,
     )
-    assert reservation is None
+    assert lease is None

--- a/tests/adapters/discord/test_message_turns_transient_progress.py
+++ b/tests/adapters/discord/test_message_turns_transient_progress.py
@@ -743,6 +743,144 @@ async def test_deliver_result_suppresses_direct_send_when_durable_claim_is_activ
 
 
 @pytest.mark.anyio
+async def test_deliver_result_sends_when_direct_delivery_begin_fails(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    def _raise_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        raise RuntimeError("ledger unavailable")
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "begin_managed_thread_direct_delivery",
+        _raise_begin,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                execution_id="exec-1",
+                send_final_message=True,
+                delivery_visibility_pending=True,
+                durable_delivery_id="delivery-1",
+                durable_delivery_claim_token="claim-token",
+            ),
+        )
+
+        assert len(rest.channel_messages) == 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_result_records_retry_when_direct_send_raises(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    engine = SQLiteManagedThreadDeliveryEngine(tmp_path)
+    finalized = support.managed_thread_turns_module.ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="fixture reply",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-1",
+    )
+    intent = support.managed_thread_turns_module.build_managed_thread_delivery_intent(
+        finalized,
+        surface=support.managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Discord",
+            surface_kind="discord",
+            surface_key="channel-1",
+        ),
+        transport_target={"channel_id": "channel-1"},
+    )
+    record = engine.create_intent(intent).record
+    claim = engine.claim_delivery(record.delivery_id)
+    assert claim is not None
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    async def _raise_send(*args: Any, **kwargs: Any) -> bool:
+        _ = args, kwargs
+        raise RuntimeError("discord send failed")
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "_send_discord_turn_section",
+        _raise_send,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="discord send failed"):
+            await support.discord_message_turns_module._deliver_discord_turn_result(
+                dispatch,
+                workspace_root=workspace,
+                turn_result=support.DiscordMessageTurnResult(
+                    final_message="done",
+                    execution_id="exec-1",
+                    send_final_message=True,
+                    delivery_visibility_pending=True,
+                    durable_delivery_id=record.delivery_id,
+                    durable_delivery_claim_token=claim.claim_token,
+                ),
+            )
+
+        current = engine._ledger.get_delivery(record.delivery_id)
+        assert current is not None
+        assert current.state is ManagedThreadDeliveryState.RETRY_SCHEDULED
+        assert current.claim_token is None
+        assert current.last_error == "direct_discord_surface_delivery_failed"
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_deliver_result_keeps_newer_pending_sibling_progress_lease(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/adapters/discord/test_message_turns_transient_progress.py
+++ b/tests/adapters/discord/test_message_turns_transient_progress.py
@@ -673,6 +673,76 @@ async def test_deliver_result_marks_pending_durable_delivery_direct_surface_deli
 
 
 @pytest.mark.anyio
+async def test_deliver_result_suppresses_direct_send_when_durable_claim_is_active(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    engine = SQLiteManagedThreadDeliveryEngine(tmp_path)
+    finalized = support.managed_thread_turns_module.ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="fixture reply",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-1",
+    )
+    intent = support.managed_thread_turns_module.build_managed_thread_delivery_intent(
+        finalized,
+        surface=support.managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Discord",
+            surface_kind="discord",
+            surface_key="channel-1",
+        ),
+        transport_target={"channel_id": "channel-1"},
+    )
+    record = engine.create_intent(intent).record
+    active_claim = engine.claim_delivery(record.delivery_id)
+    assert active_claim is not None
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                execution_id="exec-1",
+                send_final_message=True,
+                delivery_visibility_pending=True,
+                durable_delivery_id=record.delivery_id,
+                durable_delivery_claim_token="stale-direct-token",
+            ),
+        )
+
+        current = engine._ledger.get_delivery(record.delivery_id)
+        assert current is not None
+        assert current.state is ManagedThreadDeliveryState.CLAIMED
+        assert current.claim_token == active_claim.claim_token
+        assert rest.channel_messages == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_deliver_result_keeps_newer_pending_sibling_progress_lease(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/orchestration/test_managed_thread_delivery_ledger.py
+++ b/tests/core/orchestration/test_managed_thread_delivery_ledger.py
@@ -510,7 +510,9 @@ class TestEngineEnsureDirectDeliveryClaim:
         assert ensured is not None
         assert ensured.claim_token == first.claim_token
 
-    def test_reclaims_when_proposed_token_is_stale(self, tmp_path: Path) -> None:
+    def test_returns_none_when_another_active_claim_owns_delivery(
+        self, tmp_path: Path
+    ) -> None:
         engine = _engine(tmp_path)
         engine.create_intent(_intent(adapter_key="telegram"))
         first = engine.claim_delivery(
@@ -523,10 +525,7 @@ class TestEngineEnsureDirectDeliveryClaim:
             proposed_token="stale-token",
             now=datetime(2026, 4, 18, 1, 1, 0, tzinfo=timezone.utc),
         )
-        assert reclaimed is not None
-        assert reclaimed.claim_token != "stale-token"
-        assert reclaimed.claim_token != first.claim_token
-        assert reclaimed.record.state is ManagedThreadDeliveryState.CLAIMED
+        assert reclaimed is None
 
     def test_recovers_expired_claim_then_issues_fresh_token(
         self, tmp_path: Path

--- a/tests/telegram_managed_thread_support.py
+++ b/tests/telegram_managed_thread_support.py
@@ -1379,6 +1379,84 @@ async def test_handle_normal_message_marks_pending_durable_delivery_direct_surfa
 
 
 @pytest.mark.anyio
+async def test_handle_normal_message_suppresses_direct_send_when_durable_claim_is_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = TelegramTopicRecord(
+        pma_enabled=True,
+        workspace_path=None,
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+    engine = SQLiteManagedThreadDeliveryEngine(tmp_path)
+    finalized = execution_commands_module.ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="telegram managed final reply",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-1",
+    )
+    intent = build_managed_thread_delivery_intent(
+        finalized,
+        surface=execution_commands_module.ManagedThreadSurfaceInfo(
+            log_label="Telegram",
+            surface_kind="telegram",
+            surface_key="-1001:101",
+        ),
+        transport_target={"chat_id": -1001, "thread_id": 101},
+    )
+    record_entry = engine.create_intent(intent).record
+    active_claim = engine.claim_delivery(record_entry.delivery_id)
+    assert active_claim is not None
+
+    async def _fake_run_turn_and_collect_result(
+        *args: Any, **kwargs: Any
+    ) -> _TurnRunResult:
+        _ = args, kwargs
+        return _TurnRunResult(
+            record=record,
+            thread_id="backend-1",
+            turn_id="exec-1",
+            response="telegram managed final reply",
+            placeholder_id=None,
+            elapsed_seconds=None,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            durable_delivery_handled=False,
+            durable_delivery_id=record_entry.delivery_id,
+            durable_delivery_claim_token="stale-direct-token",
+        )
+
+    monkeypatch.setattr(
+        handler,
+        "_run_turn_and_collect_result",
+        _fake_run_turn_and_collect_result,
+    )
+
+    message = TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="hello",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_normal_message(message, runtime=_RuntimeStub())
+
+    current = engine._ledger.get_delivery(record_entry.delivery_id)
+    assert current is not None
+    assert current.state is ManagedThreadDeliveryState.CLAIMED
+    assert current.claim_token == active_claim.claim_token
+    assert handler._sent == []
+
+
+@pytest.mark.anyio
 async def test_pma_text_messages_route_repeated_messages_through_managed_thread_queue(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/telegram_managed_thread_support.py
+++ b/tests/telegram_managed_thread_support.py
@@ -1349,6 +1349,7 @@ async def test_handle_normal_message_marks_pending_durable_delivery_direct_surfa
             transcript_message_id=None,
             transcript_text=None,
             durable_delivery_handled=False,
+            durable_delivery_pending=True,
             durable_delivery_id=record_entry.delivery_id,
             durable_delivery_claim_token=claim.claim_token,
         )
@@ -1426,6 +1427,7 @@ async def test_handle_normal_message_suppresses_direct_send_when_durable_claim_i
             transcript_message_id=None,
             transcript_text=None,
             durable_delivery_handled=False,
+            durable_delivery_pending=True,
             durable_delivery_id=record_entry.delivery_id,
             durable_delivery_claim_token="stale-direct-token",
         )
@@ -1454,6 +1456,208 @@ async def test_handle_normal_message_suppresses_direct_send_when_durable_claim_i
     assert current.state is ManagedThreadDeliveryState.CLAIMED
     assert current.claim_token == active_claim.claim_token
     assert handler._sent == []
+
+
+@pytest.mark.anyio
+async def test_handle_normal_message_sends_direct_response_for_non_pending_durable_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = TelegramTopicRecord(
+        pma_enabled=True,
+        workspace_path=None,
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+
+    async def _fake_run_turn_and_collect_result(
+        *args: Any, **kwargs: Any
+    ) -> _TurnRunResult:
+        _ = args, kwargs
+        return _TurnRunResult(
+            record=record,
+            thread_id="backend-1",
+            turn_id="exec-1",
+            response="telegram visible fallback reply",
+            placeholder_id=None,
+            elapsed_seconds=None,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            durable_delivery_handled=False,
+            durable_delivery_pending=False,
+            durable_delivery_id="terminal-or-replayed-delivery",
+            durable_delivery_claim_token=None,
+        )
+
+    monkeypatch.setattr(
+        handler,
+        "_run_turn_and_collect_result",
+        _fake_run_turn_and_collect_result,
+    )
+
+    message = TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="hello",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_normal_message(message, runtime=_RuntimeStub())
+
+    assert "telegram visible fallback reply" in handler._sent
+
+
+@pytest.mark.anyio
+async def test_handle_normal_message_sends_when_direct_delivery_begin_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = TelegramTopicRecord(
+        pma_enabled=True,
+        workspace_path=None,
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+
+    async def _fake_run_turn_and_collect_result(
+        *args: Any, **kwargs: Any
+    ) -> _TurnRunResult:
+        _ = args, kwargs
+        return _TurnRunResult(
+            record=record,
+            thread_id="backend-1",
+            turn_id="exec-1",
+            response="telegram visible fallback reply",
+            placeholder_id=None,
+            elapsed_seconds=None,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            durable_delivery_handled=False,
+            durable_delivery_pending=True,
+            durable_delivery_id="delivery-1",
+            durable_delivery_claim_token="claim-token",
+        )
+
+    def _raise_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        raise RuntimeError("ledger unavailable")
+
+    monkeypatch.setattr(
+        handler,
+        "_run_turn_and_collect_result",
+        _fake_run_turn_and_collect_result,
+    )
+    monkeypatch.setattr(
+        execution_commands_module,
+        "begin_managed_thread_direct_delivery",
+        _raise_begin,
+    )
+
+    message = TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="hello",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_normal_message(message, runtime=_RuntimeStub())
+
+    assert "telegram visible fallback reply" in handler._sent
+
+
+@pytest.mark.anyio
+async def test_handle_normal_message_records_retry_when_direct_send_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = TelegramTopicRecord(
+        pma_enabled=True,
+        workspace_path=None,
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+    engine = SQLiteManagedThreadDeliveryEngine(tmp_path)
+    finalized = execution_commands_module.ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="telegram managed final reply",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-1",
+    )
+    intent = build_managed_thread_delivery_intent(
+        finalized,
+        surface=execution_commands_module.ManagedThreadSurfaceInfo(
+            log_label="Telegram",
+            surface_kind="telegram",
+            surface_key="-1001:101",
+        ),
+        transport_target={"chat_id": -1001, "thread_id": 101},
+    )
+    record_entry = engine.create_intent(intent).record
+    claim = engine.claim_delivery(record_entry.delivery_id)
+    assert claim is not None
+
+    async def _fake_run_turn_and_collect_result(
+        *args: Any, **kwargs: Any
+    ) -> _TurnRunResult:
+        _ = args, kwargs
+        return _TurnRunResult(
+            record=record,
+            thread_id="backend-1",
+            turn_id="exec-1",
+            response="telegram managed final reply",
+            placeholder_id=None,
+            elapsed_seconds=None,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            durable_delivery_handled=False,
+            durable_delivery_pending=True,
+            durable_delivery_id=record_entry.delivery_id,
+            durable_delivery_claim_token=claim.claim_token,
+        )
+
+    async def _raise_delivery(*args: Any, **kwargs: Any) -> bool:
+        _ = args, kwargs
+        raise RuntimeError("telegram send failed")
+
+    monkeypatch.setattr(
+        handler,
+        "_run_turn_and_collect_result",
+        _fake_run_turn_and_collect_result,
+    )
+    monkeypatch.setattr(handler, "_deliver_turn_response", _raise_delivery)
+
+    message = TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="hello",
+        date=None,
+        is_topic_message=True,
+    )
+
+    with pytest.raises(RuntimeError, match="telegram send failed"):
+        await handler._handle_normal_message(message, runtime=_RuntimeStub())
+
+    current = engine._ledger.get_delivery(record_entry.delivery_id)
+    assert current is not None
+    assert current.state is ManagedThreadDeliveryState.RETRY_SCHEDULED
+    assert current.claim_token is None
+    assert current.last_error == "direct_telegram_surface_delivery_failed"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- replace direct-delivery reservation/record-after-send with a begin/complete lease API shared by chat surfaces
- prevent direct fallback from stealing an active durable worker claim; surfaces now suppress direct sends unless the ledger grants ownership first
- update Telegram and Discord final delivery paths and add regression coverage for active-claim suppression

Fixes #1979

## Validation
- pre-commit aggregate lane passed on commit: guardrails, black, ruff, import boundaries, mypy, full Python pytest, frontend build/tests
- focused delivery regression suite passed before commit

## Notes
- First aggregate attempt hit a timing failure in tests/adapters/discord/test_dispatch_validation.py::test_autocomplete_bypasses_busy_ingressed_fifo; the test passed standalone and the full aggregate hook passed on retry.