### PR TITLE
[codex] Harden browser bootstrap auth

### DIFF
--- a/docs/web/security.md
+++ b/docs/web/security.md
@@ -10,6 +10,27 @@ interface and how to secure it.
 - The UI/API can run code and modify files in bound workspaces.
 - There is no built-in multi-user auth or per-endpoint role separation.
 
+## Internet-accessible surfaces
+
+Treat any internet-accessible CAR web deployment as a privileged remote-control
+surface for the host account running CAR:
+
+- Authenticated users can access terminal WebSockets, run controls, system
+  update routes, filebox uploads, contextspace and ticket mutation routes, and
+  repo/worktree management routes.
+- CAR does not provide read-only users, least-privilege roles, or per-repo
+  browser authorization. A valid browser session or bearer token is equivalent
+  to administrative access to the exposed hub.
+- The only intentionally unauthenticated web routes are the public endpoints
+  listed below. They are kept narrow for health checks, static asset loading, and
+  first browser bootstrap.
+- Public internet deployments should use HTTPS, explicit `server.allowed_hosts`,
+  explicit `server.allowed_origins`, bootstrap browser auth, and preferably an
+  additional reverse-proxy auth layer such as SSO or basic auth.
+- Do not expose a repo app or hub directly over plain HTTP on a public network.
+  Remote bootstrap is designed to fail closed unless the app receives a trusted
+  HTTPS request scheme.
+
 ## Bootstrap browser auth
 
 Remote hub deployments can use a one-time bootstrap token to create a browser
@@ -21,17 +42,23 @@ session without putting a bearer token in browser storage:
 - The browser posts the fragment token to `/auth/bootstrap/claim`; URL fragments
   are not sent in HTTP requests.
 - The bootstrap claim endpoint accepts the browser `Origin` from an HTTPS
-  reverse proxy so first login does not require pre-populating
-  `server.allowed_origins`; Host header validation still applies.
+  reverse proxy only when that origin host matches the request `Host`, so first
+  login does not require pre-populating `server.allowed_origins`; Host header
+  validation still applies.
 - A successful claim deletes the bootstrap token and sets an HttpOnly Secure
   `car_session` cookie with `SameSite=Lax`.
+- Bootstrap tokens expire after 24 hours. Restarting the hub after expiration
+  writes a fresh token.
 - Because the session cookie is `Secure`, expose remote browser deployments over
-  HTTPS, including when a reverse proxy terminates TLS in front of CAR.
+  HTTPS, including when a reverse proxy terminates TLS in front of CAR. Remote
+  bootstrap claims over plain HTTP are rejected; reverse proxies must pass a
+  trusted HTTPS request scheme to the ASGI app.
 
-To recover or rotate browser access, remove the old session file
-`.codex-autorunner/browser-sessions.json`, remove any stale
-`.codex-autorunner/bootstrap-token`, and restart the hub. CAR will write a fresh
-bootstrap token on the next authenticated or remote boot.
+To recover or rotate browser access, use `/auth/session/revoke` for the current
+browser session or `/auth/sessions/revoke-all` for all browser sessions. If the
+hub is inaccessible, remove `.codex-autorunner/browser-sessions.json`, remove
+any stale `.codex-autorunner/bootstrap-token`, and restart the hub. CAR will
+write a fresh bootstrap token on the next authenticated or remote boot.
 
 ## API bearer token
 
@@ -41,7 +68,9 @@ CAR also supports a bearer token enforced by middleware when configured:
 - Export the token in the environment before starting the server.
 - API and CLI requests can use `Authorization: Bearer <token>`.
 - WebSockets accept the token via `Sec-WebSocket-Protocol: car-token-b64.<base64url(token)>`.
-  The legacy `?token=...` query string is still accepted for backward compatibility.
+  The legacy `?token=...` query string is still accepted for backward compatibility,
+  but base-path redirects strip `token` query parameters to avoid writing bearer
+  tokens into redirect logs.
 
 ## Public endpoints
 
@@ -72,7 +101,8 @@ localhost CSRF/DNS rebinding risk:
 Config:
 
 - `server.allowed_hosts`: explicit host allowlist. Required when binding to a
-  non-loopback host.
+  non-loopback host. Do not use `*` for internet-exposed deployments; wildcard
+  hosts disable Host-header protection.
 - `server.allowed_origins`: extra allowed origins (scheme + host + port).
   Configure this for normal browser API/WebSocket use when CAR is exposed
   through a public reverse proxy.

--- a/src/codex_autorunner/core/config_validation.py
+++ b/src/codex_autorunner/core/config_validation.py
@@ -131,6 +131,14 @@ def _validate_server_security(server: Dict[str, Any]) -> None:
         raise ConfigError(
             "server.allowed_hosts must be set when binding to a non-loopback host"
         )
+    if not is_loopback_host(host) and isinstance(allowed_hosts, list):
+        has_wildcard_host = any(
+            entry.strip() == "*" for entry in allowed_hosts if isinstance(entry, str)
+        )
+        if has_wildcard_host:
+            raise ConfigError(
+                "server.allowed_hosts must not include '*' when binding to a non-loopback host"
+            )
 
 
 def _validate_browser_auth_config(cfg: Dict[str, Any]) -> None:

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -336,7 +336,7 @@ def create_hub_app(
     mount_manager.mount_initial(initial_snapshots)
 
     allowed_hosts = resolve_allowed_hosts(
-        bind_host, context.config.server_allowed_hosts
+        context.config.server_host, context.config.server_allowed_hosts
     )
     allowed_origins = context.config.server_allowed_origins
     app.state.auth_token = auth_token

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -91,6 +91,7 @@ def create_hub_app(
             build_auth_routes(
                 browser_auth_store,
                 cookie_secure=context.config.browser_auth.cookie_secure,
+                require_secure_claim=remote_bind,
             )
         )
     web_app_assets_dir = web_static_dir / "_app"
@@ -335,7 +336,7 @@ def create_hub_app(
     mount_manager.mount_initial(initial_snapshots)
 
     allowed_hosts = resolve_allowed_hosts(
-        context.config.server_host, context.config.server_allowed_hosts
+        bind_host, context.config.server_allowed_hosts
     )
     allowed_origins = context.config.server_allowed_origins
     app.state.auth_token = auth_token

--- a/src/codex_autorunner/surfaces/web/app_factory.py
+++ b/src/codex_autorunner/surfaces/web/app_factory.py
@@ -22,10 +22,14 @@ def resolve_auth_token(
 def resolve_allowed_hosts(host: str, allowed_hosts: list[str]) -> list[str]:
     cleaned = [entry.strip() for entry in allowed_hosts if entry and entry.strip()]
     if cleaned:
+        if not is_loopback_host(host) and any(entry == "*" for entry in cleaned):
+            raise ValueError(
+                "server.allowed_hosts must not include '*' when binding to a non-loopback host"
+            )
         return cleaned
     if is_loopback_host(host):
         return ["localhost", "127.0.0.1", "::1", "testserver"]
-    return []
+    return [host.strip().lower()] if host and host.strip() else []
 
 
 _STATIC_CACHE_CONTROL = "public, max-age=31536000, immutable"

--- a/src/codex_autorunner/surfaces/web/middleware.py
+++ b/src/codex_autorunner/surfaces/web/middleware.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from http.cookies import SimpleCookie
 from typing import Callable, Optional
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse
 
 from fastapi.responses import RedirectResponse, Response
 
@@ -141,7 +141,15 @@ class BasePathRouterMiddleware:
             target_path = f"{self.base_path}{path}"
             query_string = scope.get("query_string") or b""
             if query_string:
-                target_path = f"{target_path}?{query_string.decode('latin-1')}"
+                query_pairs = [
+                    (key, value)
+                    for key, value in parse_qsl(
+                        query_string.decode("latin-1"), keep_blank_values=True
+                    )
+                    if key.lower() != "token"
+                ]
+                if query_pairs:
+                    target_path = f"{target_path}?{urlencode(query_pairs)}"
             if not target_path:
                 target_path = "/"
             return await self._redirect(scope, receive, send, target_path)
@@ -445,6 +453,14 @@ class HostOriginMiddleware:
         request_origin = self._request_origin(scheme, host)
         return request_origin == normalized
 
+    def _bootstrap_proxy_origin_allowed(
+        self, origin: str | None, host: str | None
+    ) -> bool:
+        if not origin or not host:
+            return False
+        parsed = urlparse(origin.strip().lower())
+        return parsed.scheme == "https" and parsed.netloc == host.strip().lower()
+
     def _is_bootstrap_claim_path(self, scope) -> bool:
         path = scope.get("path") or ""
         root_path = scope.get("root_path") or ""
@@ -496,7 +512,11 @@ class HostOriginMiddleware:
         method = (scope.get("method") or "GET").upper()
         if method in {"POST", "PUT", "PATCH", "DELETE"} and origin:
             if not self._origin_allowed(origin, scheme, host):
-                if method == "POST" and self._is_bootstrap_claim_path(scope):
+                if (
+                    method == "POST"
+                    and self._is_bootstrap_claim_path(scope)
+                    and self._bootstrap_proxy_origin_allowed(origin, host)
+                ):
                     return await self.app(scope, receive, send)
                 return await self._reject_http(
                     scope, receive, send, 403, "Origin not allowed"

--- a/src/codex_autorunner/surfaces/web/routes/auth.py
+++ b/src/codex_autorunner/surfaces/web/routes/auth.py
@@ -102,7 +102,10 @@ def _bootstrap_html() -> str:
 
 
 def build_auth_routes(
-    store: BrowserAuthStore, cookie_secure: BrowserAuthCookieSecure = "auto"
+    store: BrowserAuthStore,
+    cookie_secure: BrowserAuthCookieSecure = "auto",
+    *,
+    require_secure_claim: bool = False,
 ) -> APIRouter:
     router = APIRouter()
 
@@ -123,6 +126,12 @@ def build_auth_routes(
     def claim_bootstrap(
         payload: BootstrapClaimRequest, request: Request
     ) -> JSONResponse:
+        secure = resolve_cookie_secure(request, cookie_secure)
+        if require_secure_claim and (request.url.scheme != "https" or not secure):
+            raise HTTPException(
+                status_code=400,
+                detail="Browser bootstrap requires HTTPS and Secure cookies",
+            )
         claim = store.claim_bootstrap_token(payload.token)
         if claim is None:
             raise HTTPException(status_code=401, detail="Invalid bootstrap token")
@@ -132,8 +141,28 @@ def build_auth_routes(
             claim.session_token,
             max_age=claim.max_age_seconds,
             httponly=True,
-            secure=resolve_cookie_secure(request, cookie_secure),
+            secure=secure,
             samesite="lax",
+            path=request.scope.get("root_path") or "/",
+        )
+        return response
+
+    @router.post("/auth/session/revoke", include_in_schema=False)
+    def revoke_current_session(request: Request) -> JSONResponse:
+        revoked = store.revoke_session_token(request.cookies.get(SESSION_COOKIE_NAME))
+        response = JSONResponse({"ok": True, "revoked": revoked})
+        response.delete_cookie(
+            SESSION_COOKIE_NAME,
+            path=request.scope.get("root_path") or "/",
+        )
+        return response
+
+    @router.post("/auth/sessions/revoke-all", include_in_schema=False)
+    def revoke_all_sessions(request: Request) -> JSONResponse:
+        revoked = store.revoke_all_sessions()
+        response = JSONResponse({"ok": True, "revoked": revoked})
+        response.delete_cookie(
+            SESSION_COOKIE_NAME,
             path=request.scope.get("root_path") or "/",
         )
         return response

--- a/src/codex_autorunner/surfaces/web/services/browser_auth.py
+++ b/src/codex_autorunner/surfaces/web/services/browser_auth.py
@@ -3,22 +3,25 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import os
 import secrets
+import stat
 import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
-from urllib.parse import urlparse
 
 from fastapi import Request
 
 from ....core.config_types import BrowserAuthCookieSecure
 
 BOOTSTRAP_TOKEN_RELATIVE_PATH = Path(".codex-autorunner/bootstrap-token")
+BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH = Path(".codex-autorunner/bootstrap-token.json")
 SESSION_STORE_RELATIVE_PATH = Path(".codex-autorunner/browser-sessions.json")
 SESSION_COOKIE_NAME = "car_session"
+BOOTSTRAP_TOKEN_MAX_AGE_SECONDS = 60 * 60 * 24
 SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
 
 
@@ -28,33 +31,95 @@ def _sha256(value: str) -> str:
 
 def _write_private_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    fd = os.open(path, flags, 0o600)
+    temp_path = path.with_name(f".{path.name}.{secrets.token_hex(12)}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(temp_path, flags, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(text)
-    finally:
+        os.replace(temp_path, path)
+    except Exception:
         try:
-            os.chmod(path, 0o600)
-        except OSError:
+            temp_path.unlink()
+        except FileNotFoundError:
             pass
+        raise
 
 
-def ensure_bootstrap_token(root: Path) -> tuple[Path, str]:
-    path = root / BOOTSTRAP_TOKEN_RELATIVE_PATH
+def _read_private_text(path: Path) -> str:
     try:
-        existing = path.read_text(encoding="utf-8").strip()
+        mode = path.lstat().st_mode
     except FileNotFoundError:
-        existing = ""
+        return ""
+    if not stat.S_ISREG(mode):
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def ensure_bootstrap_token(root: Path, now: Optional[float] = None) -> tuple[Path, str]:
+    path = root / BOOTSTRAP_TOKEN_RELATIVE_PATH
+    metadata_path = root / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH
+    observed_now = time.time() if now is None else now
+    existing = _read_private_text(path).strip()
     if existing:
+        issued_at = _read_bootstrap_issued_at(metadata_path)
+        if (
+            issued_at is not None
+            and issued_at <= observed_now + 60
+            and issued_at + BOOTSTRAP_TOKEN_MAX_AGE_SECONDS > observed_now
+        ):
+            try:
+                if not path.is_symlink():
+                    os.chmod(path, 0o600)
+            except OSError:
+                pass
+            return path, existing
         try:
-            os.chmod(path, 0o600)
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            metadata_path.unlink()
         except OSError:
             pass
-        return path, existing
     token = secrets.token_urlsafe(48)
     _write_private_text(path, f"{token}\n")
+    _write_bootstrap_metadata(metadata_path, issued_at=observed_now)
     return path, token
+
+
+def _read_bootstrap_issued_at(path: Path) -> Optional[float]:
+    try:
+        data = json.loads(_read_private_text(path))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    issued_at = data.get("issued_at")
+    if not isinstance(issued_at, (int, float)):
+        return None
+    value = float(issued_at)
+    return value if math.isfinite(value) else None
+
+
+def _write_bootstrap_metadata(path: Path, *, issued_at: float) -> None:
+    _write_private_text(
+        path,
+        json.dumps(
+            {
+                "issued_at": issued_at,
+                "expires_at": issued_at + BOOTSTRAP_TOKEN_MAX_AGE_SECONDS,
+            },
+            sort_keys=True,
+            indent=2,
+        )
+        + "\n",
+    )
 
 
 @dataclass(frozen=True)
@@ -67,16 +132,7 @@ def resolve_cookie_secure(
     request: Request, cookie_secure: BrowserAuthCookieSecure
 ) -> bool:
     if cookie_secure == "auto":
-        if request.url.scheme == "https":
-            return True
-        origin = request.headers.get("origin", "")
-        parsed_origin = urlparse(origin)
-        host = request.headers.get("host", "").strip().lower()
-        return (
-            parsed_origin.scheme.lower() == "https"
-            and bool(parsed_origin.netloc)
-            and parsed_origin.netloc.lower() == host
-        )
+        return request.url.scheme == "https"
     return bool(cookie_secure)
 
 
@@ -89,24 +145,37 @@ class BrowserAuthStore:
         self._lock = threading.Lock()
 
     def ensure_bootstrap_token(self) -> tuple[Path, str]:
-        return ensure_bootstrap_token(self.root)
+        return ensure_bootstrap_token(self.root, now=self._now())
 
     def claim_bootstrap_token(self, token: str) -> Optional[BootstrapClaim]:
         candidate = token.strip()
         if not candidate:
             return None
         with self._lock:
-            try:
-                expected = self.bootstrap_token_path.read_text(encoding="utf-8").strip()
-            except FileNotFoundError:
+            expected = _read_private_text(self.bootstrap_token_path).strip()
+            if not expected:
                 return None
-            if not expected or not hmac.compare_digest(candidate, expected):
+            issued_at = _read_bootstrap_issued_at(
+                self.root / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH
+            )
+            now = self._now()
+            if (
+                issued_at is None
+                or issued_at > now + 60
+                or issued_at + BOOTSTRAP_TOKEN_MAX_AGE_SECONDS <= now
+            ):
+                return None
+            if not hmac.compare_digest(candidate, expected):
                 return None
 
             session_token = secrets.token_urlsafe(48)
             self._add_session(session_token)
             try:
                 self.bootstrap_token_path.unlink()
+            except FileNotFoundError:
+                pass
+            try:
+                (self.root / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH).unlink()
             except FileNotFoundError:
                 pass
             return BootstrapClaim(session_token=session_token)
@@ -148,6 +217,40 @@ class BrowserAuthStore:
                 self._write_store(data)
             return valid
 
+    def revoke_session_token(self, token: Optional[str]) -> bool:
+        if not token:
+            return False
+        token_hash = _sha256(token.strip())
+        with self._lock:
+            data = self._read_store()
+            sessions = data.get("sessions")
+            if not isinstance(sessions, list):
+                return False
+            retained = [
+                entry
+                for entry in sessions
+                if not (
+                    isinstance(entry, dict)
+                    and hmac.compare_digest(
+                        str(entry.get("token_hash", "")), token_hash
+                    )
+                )
+            ]
+            if len(retained) == len(sessions):
+                return False
+            data["sessions"] = retained
+            self._write_store(data)
+            return True
+
+    def revoke_all_sessions(self) -> int:
+        with self._lock:
+            data = self._read_store()
+            sessions = data.get("sessions")
+            count = len(sessions) if isinstance(sessions, list) else 0
+            data["sessions"] = []
+            self._write_store(data)
+            return count
+
     def _add_session(self, token: str) -> None:
         data = self._read_store()
         sessions = data.get("sessions")
@@ -180,8 +283,8 @@ class BrowserAuthStore:
 
     def _read_store(self) -> dict[str, Any]:
         try:
-            data = json.loads(self.session_store_path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            data = json.loads(_read_private_text(self.session_store_path))
+        except json.JSONDecodeError:
             return {"sessions": []}
         return data if isinstance(data, dict) else {"sessions": []}
 

--- a/tests/core/test_config_validation.py
+++ b/tests/core/test_config_validation.py
@@ -135,6 +135,10 @@ class TestValidateServerSecurity:
     def test_non_loopback_with_allowed_hosts_ok(self) -> None:
         _validate_server_security({"host": "0.0.0.0", "allowed_hosts": ["example.com"]})
 
+    def test_non_loopback_with_wildcard_allowed_hosts_raises(self) -> None:
+        with pytest.raises(ConfigError, match="must not include '\\*'"):
+            _validate_server_security({"host": "0.0.0.0", "allowed_hosts": ["*"]})
+
     def test_allowed_hosts_must_be_list(self) -> None:
         with pytest.raises(ConfigError, match="must be a list of strings"):
             _validate_server_security({"allowed_hosts": "not-a-list"})

--- a/tests/surfaces/web/test_bootstrap_auth_routes.py
+++ b/tests/surfaces/web/test_bootstrap_auth_routes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import stat
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -8,6 +10,8 @@ from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.core.config import CONFIG_FILENAME
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.services.browser_auth import (
+    BOOTSTRAP_TOKEN_MAX_AGE_SECONDS,
+    BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH,
     BOOTSTRAP_TOKEN_RELATIVE_PATH,
     SESSION_COOKIE_NAME,
     SESSION_MAX_AGE_SECONDS,
@@ -30,10 +34,24 @@ def _set_browser_auth_cookie_secure(hub_root: Path, value: str) -> None:
     )
 
 
+def _set_server_allowed_hosts(hub_root: Path, *hosts: str) -> None:
+    config_path = hub_root / CONFIG_FILENAME
+    text = config_path.read_text(encoding="utf-8")
+    rendered_hosts = "\n".join(f"    - {host}" for host in hosts)
+    config_path.write_text(
+        f"{text}\nserver:\n  allowed_hosts:\n{rendered_hosts}\n",
+        encoding="utf-8",
+    )
+
+
 def test_remote_hub_bootstrap_claim_creates_http_only_session(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     seed_hub_files(hub_root, force=True)
-    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+    _set_server_allowed_hosts(hub_root, "testserver")
+    client = TestClient(
+        create_hub_app(hub_root, endpoint_host="0.0.0.0"),
+        base_url="https://testserver",
+    )
 
     assert client.get("/health").status_code == 200
     assert client.get("/hub/repos").status_code == 401
@@ -49,7 +67,7 @@ def test_remote_hub_bootstrap_claim_creates_http_only_session(tmp_path: Path) ->
     cookie = claim.headers["set-cookie"]
     assert f"{SESSION_COOKIE_NAME}=" in cookie
     assert "HttpOnly" in cookie
-    assert "Secure" not in cookie
+    assert "Secure" in cookie
     assert "SameSite=lax" in cookie
     assert not (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()
     session_token = cookie.split(f"{SESSION_COOKIE_NAME}=", 1)[1].split(";", 1)[0]
@@ -61,11 +79,49 @@ def test_remote_hub_bootstrap_claim_creates_http_only_session(tmp_path: Path) ->
     )
 
 
+def test_remote_hub_bootstrap_claim_rejects_plain_http(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    _set_server_allowed_hosts(hub_root, "testserver")
+    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+    token = _read_bootstrap_token(hub_root)
+
+    claim = client.post("/auth/bootstrap/claim", json={"token": token})
+
+    assert claim.status_code == 400
+    assert "set-cookie" not in claim.headers
+    assert _read_bootstrap_token(hub_root) == token
+
+
+def test_remote_hub_bootstrap_claim_rejects_forged_https_origin_over_http(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    _set_server_allowed_hosts(hub_root, "public.example")
+    client = TestClient(
+        create_hub_app(hub_root, endpoint_host="0.0.0.0"),
+        base_url="http://public.example",
+    )
+    token = _read_bootstrap_token(hub_root)
+
+    claim = client.post(
+        "/auth/bootstrap/claim",
+        json={"token": token},
+        headers={"origin": "https://public.example"},
+    )
+
+    assert claim.status_code == 400
+    assert "set-cookie" not in claim.headers
+    assert _read_bootstrap_token(hub_root) == token
+
+
 def test_bootstrap_cookie_secure_auto_uses_https_request_scheme(
     tmp_path: Path,
 ) -> None:
     hub_root = tmp_path / "hub"
     seed_hub_files(hub_root, force=True)
+    _set_server_allowed_hosts(hub_root, "testserver")
     client = TestClient(
         create_hub_app(hub_root, endpoint_host="0.0.0.0"),
         base_url="https://testserver",
@@ -83,13 +139,14 @@ def test_bootstrap_cookie_secure_auto_uses_https_proxy_origin(
 ) -> None:
     hub_root = tmp_path / "hub"
     seed_hub_files(hub_root, force=True)
-    config_path = hub_root / CONFIG_FILENAME
-    text = config_path.read_text(encoding="utf-8")
-    config_path.write_text(
-        f'{text}\nserver:\n  allowed_hosts:\n    - "*"\n',
-        encoding="utf-8",
+    _set_server_allowed_hosts(
+        hub_root,
+        "agent-dev-01.tailnet-name.ts.net:4173",
     )
-    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+    client = TestClient(
+        create_hub_app(hub_root, endpoint_host="0.0.0.0"),
+        base_url="https://agent-dev-01.tailnet-name.ts.net:4173",
+    )
     token = _read_bootstrap_token(hub_root)
 
     claim = client.post(
@@ -110,11 +167,9 @@ def test_bootstrap_cookie_secure_auto_ignores_mismatched_https_origin(
 ) -> None:
     hub_root = tmp_path / "hub"
     seed_hub_files(hub_root, force=True)
-    config_path = hub_root / CONFIG_FILENAME
-    text = config_path.read_text(encoding="utf-8")
-    config_path.write_text(
-        f'{text}\nserver:\n  allowed_hosts:\n    - "*"\n',
-        encoding="utf-8",
+    _set_server_allowed_hosts(
+        hub_root,
+        "agent-dev-01.tailnet-name.ts.net:4173",
     )
     client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
     token = _read_bootstrap_token(hub_root)
@@ -128,27 +183,16 @@ def test_bootstrap_cookie_secure_auto_ignores_mismatched_https_origin(
         },
     )
 
-    assert claim.status_code == 200
-    assert "Secure" not in claim.headers["set-cookie"]
+    assert claim.status_code == 403
+    assert "set-cookie" not in claim.headers
+    assert _read_bootstrap_token(hub_root) == token
 
 
-def test_bootstrap_cookie_secure_true_forces_secure_on_http(tmp_path: Path) -> None:
+def test_bootstrap_cookie_secure_true_sets_secure_cookie(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     seed_hub_files(hub_root, force=True)
     _set_browser_auth_cookie_secure(hub_root, "true")
-    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
-    token = _read_bootstrap_token(hub_root)
-
-    claim = client.post("/auth/bootstrap/claim", json={"token": token})
-
-    assert claim.status_code == 200
-    assert "Secure" in claim.headers["set-cookie"]
-
-
-def test_bootstrap_cookie_secure_false_disables_secure_on_https(tmp_path: Path) -> None:
-    hub_root = tmp_path / "hub"
-    seed_hub_files(hub_root, force=True)
-    _set_browser_auth_cookie_secure(hub_root, "false")
+    _set_server_allowed_hosts(hub_root, "testserver")
     client = TestClient(
         create_hub_app(hub_root, endpoint_host="0.0.0.0"),
         base_url="https://testserver",
@@ -158,7 +202,25 @@ def test_bootstrap_cookie_secure_false_disables_secure_on_https(tmp_path: Path) 
     claim = client.post("/auth/bootstrap/claim", json={"token": token})
 
     assert claim.status_code == 200
-    assert "Secure" not in claim.headers["set-cookie"]
+    assert "Secure" in claim.headers["set-cookie"]
+
+
+def test_remote_bootstrap_cookie_secure_false_is_rejected(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    _set_browser_auth_cookie_secure(hub_root, "false")
+    _set_server_allowed_hosts(hub_root, "testserver")
+    client = TestClient(
+        create_hub_app(hub_root, endpoint_host="0.0.0.0"),
+        base_url="https://testserver",
+    )
+    token = _read_bootstrap_token(hub_root)
+
+    claim = client.post("/auth/bootstrap/claim", json={"token": token})
+
+    assert claim.status_code == 400
+    assert "set-cookie" not in claim.headers
+    assert _read_bootstrap_token(hub_root) == token
 
 
 def test_health_reports_control_plane_schema_and_compatibility(tmp_path: Path) -> None:
@@ -185,7 +247,11 @@ def test_health_reports_control_plane_schema_and_compatibility(tmp_path: Path) -
 def test_bootstrap_token_is_single_use(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     seed_hub_files(hub_root, force=True)
-    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+    _set_server_allowed_hosts(hub_root, "testserver")
+    client = TestClient(
+        create_hub_app(hub_root, endpoint_host="0.0.0.0"),
+        base_url="https://testserver",
+    )
     token = _read_bootstrap_token(hub_root)
 
     first = client.post("/auth/bootstrap/claim", json={"token": token})
@@ -203,10 +269,13 @@ def test_remote_hub_bootstrap_claim_reaches_token_validation_from_proxy_origin(
     config_path = hub_root / ".codex-autorunner/config.yml"
     text = config_path.read_text(encoding="utf-8")
     config_path.write_text(
-        f'{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - "*"\n',
+        f"{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - 4173-glad-arch-jvr2.pad.dev\n",
         encoding="utf-8",
     )
-    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+    client = TestClient(
+        create_hub_app(hub_root, endpoint_host="0.0.0.0"),
+        base_url="https://4173-glad-arch-jvr2.pad.dev",
+    )
 
     claim = client.post(
         "/auth/bootstrap/claim",
@@ -231,11 +300,12 @@ def test_base_path_remote_hub_bootstrap_claim_reaches_token_validation_from_prox
     config_path = hub_root / ".codex-autorunner/config.yml"
     text = config_path.read_text(encoding="utf-8")
     config_path.write_text(
-        f'{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - "*"\n',
+        f"{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - 4173-glad-arch-jvr2.pad.dev\n",
         encoding="utf-8",
     )
     client = TestClient(
-        create_hub_app(hub_root, base_path="/car", endpoint_host="0.0.0.0")
+        create_hub_app(hub_root, base_path="/car", endpoint_host="0.0.0.0"),
+        base_url="https://4173-glad-arch-jvr2.pad.dev",
     )
 
     claim = client.post(
@@ -259,7 +329,10 @@ def test_bearer_token_auth_still_works_with_bootstrap_routes(
     seed_hub_files(hub_root, force=True)
     config_path = hub_root / ".codex-autorunner/config.yml"
     text = config_path.read_text(encoding="utf-8")
-    config_path.write_text(f"{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n")
+    config_path.write_text(
+        f"{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - testserver\n",
+        encoding="utf-8",
+    )
     monkeypatch.setenv("CAR_TEST_TOKEN", "api-secret")
     client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
 
@@ -289,3 +362,74 @@ def test_browser_session_validation_enforces_server_side_expiry(
     assert store.validate_session_token(token) is False
     data = store._read_store()
     assert data["sessions"] == []
+
+
+def test_bootstrap_token_files_are_private(tmp_path: Path) -> None:
+    store = BrowserAuthStore(tmp_path)
+
+    token_path, _ = store.ensure_bootstrap_token()
+    metadata_path = tmp_path / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH
+
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(metadata_path.stat().st_mode) == 0o600
+
+
+def test_bootstrap_token_expires_and_rotates(tmp_path: Path) -> None:
+    now = 1_000.0
+    store = BrowserAuthStore(tmp_path, now=lambda: now)
+    token_path, token = store.ensure_bootstrap_token()
+    metadata_path = tmp_path / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH
+    metadata_path.write_text(
+        json.dumps({"issued_at": now - BOOTSTRAP_TOKEN_MAX_AGE_SECONDS - 1}),
+        encoding="utf-8",
+    )
+
+    assert store.claim_bootstrap_token(token) is None
+
+    _, rotated = store.ensure_bootstrap_token()
+    assert rotated != token
+    assert token_path.read_text(encoding="utf-8").strip() == rotated
+
+
+def test_bootstrap_token_rejects_non_finite_metadata(tmp_path: Path) -> None:
+    store = BrowserAuthStore(tmp_path)
+    _, token = store.ensure_bootstrap_token()
+    metadata_path = tmp_path / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH
+    metadata_path.write_text('{"issued_at": NaN}', encoding="utf-8")
+
+    assert store.claim_bootstrap_token(token) is None
+
+
+def test_bootstrap_token_rejects_far_future_metadata(tmp_path: Path) -> None:
+    now = 1_000.0
+    store = BrowserAuthStore(tmp_path, now=lambda: now)
+    _, token = store.ensure_bootstrap_token()
+    metadata_path = tmp_path / BOOTSTRAP_TOKEN_METADATA_RELATIVE_PATH
+    metadata_path.write_text(json.dumps({"issued_at": now + 120}), encoding="utf-8")
+
+    assert store.claim_bootstrap_token(token) is None
+
+
+def test_auth_files_replace_symlinks_without_following(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.write_text("do-not-overwrite", encoding="utf-8")
+    token_path = tmp_path / BOOTSTRAP_TOKEN_RELATIVE_PATH
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.symlink_to(target)
+
+    store = BrowserAuthStore(tmp_path)
+    store.ensure_bootstrap_token()
+
+    assert target.read_text(encoding="utf-8") == "do-not-overwrite"
+    assert not token_path.is_symlink()
+
+
+def test_browser_session_can_be_revoked(tmp_path: Path) -> None:
+    store = BrowserAuthStore(tmp_path)
+    _, bootstrap_token = store.ensure_bootstrap_token()
+    claim = store.claim_bootstrap_token(bootstrap_token)
+    assert claim is not None
+
+    assert store.validate_session_token(claim.session_token) is True
+    assert store.revoke_session_token(claim.session_token) is True
+    assert store.validate_session_token(claim.session_token) is False

--- a/tests/test_base_path.py
+++ b/tests/test_base_path.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from codex_autorunner.server import BasePathRouterMiddleware
+from codex_autorunner.surfaces.web.app_factory import resolve_allowed_hosts
 
 
 def _build_app():
@@ -32,6 +33,23 @@ def test_redirects_preserve_query_string():
     resp = client.get("/api/ping?foo=bar&nested=1", follow_redirects=False)
     assert resp.status_code == 308
     assert resp.headers["location"] == "/car/api/ping?foo=bar&nested=1"
+
+
+def test_redirects_drop_token_query_string():
+    app = BasePathRouterMiddleware(_build_app(), "/car")
+    client = TestClient(app)
+    resp = client.get("/api/ping?foo=bar&token=secret&nested=1", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/car/api/ping?foo=bar&nested=1"
+
+
+def test_resolve_allowed_hosts_rejects_wildcard_for_effective_remote_bind():
+    try:
+        resolve_allowed_hosts("0.0.0.0", ["*"])
+    except ValueError as exc:
+        assert "must not include '*'" in str(exc)
+    else:
+        raise AssertionError("wildcard allowed_hosts should fail for remote bind")
 
 
 def test_strips_base_and_sets_root_path():

--- a/tests/test_origin_middleware.py
+++ b/tests/test_origin_middleware.py
@@ -128,6 +128,35 @@ def test_origin_rejects_prefixed_bootstrap_claim_without_configured_base_path():
     assert messages[0]["status"] == 403
 
 
+def test_origin_rejects_bootstrap_claim_from_mismatched_origin():
+    called = False
+
+    async def dummy_app(scope, receive, send):
+        nonlocal called
+        called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    middleware = HostOriginMiddleware(dummy_app, ["4173-glad-arch-jvr2.pad.dev"], [])
+    scope = {
+        "type": "http",
+        "path": "/auth/bootstrap/claim",
+        "root_path": "",
+        "headers": [
+            (b"host", b"4173-glad-arch-jvr2.pad.dev"),
+            (b"origin", b"https://different.example"),
+        ],
+        "method": "POST",
+        "scheme": "http",
+        "http_version": "1.1",
+        "query_string": b"",
+    }
+
+    messages = anyio.run(_http_call, middleware, scope)
+    assert called is False
+    assert messages[0]["status"] == 403
+
+
 def test_origin_allows_no_origin_post():
     called = False
 


### PR DESCRIPTION
## Summary

- harden remote browser bootstrap so claims require an actual HTTPS ASGI scheme and Secure cookies
- add bootstrap token expiry metadata, symlink-safe auth file writes, finite timestamp validation, and browser session revocation routes
- strip legacy WebSocket token query params from base-path redirects and reject wildcard allowed_hosts for effective non-loopback binds
- document the security posture for internet-accessible CAR web surfaces

## Validation

- aggregate pre-commit lane passed: Black, Ruff, import boundaries, hub contracts, mypy, full pytest suite (9635 passed), web UI lab, web lint, web build, web tests, SPA shell check
- focused checks passed before commit: `pytest tests/surfaces/web/test_bootstrap_auth_routes.py tests/test_origin_middleware.py tests/test_base_path.py tests/test_auth_middleware.py tests/core/test_config_validation.py`
- final subagent audit sweep found no actionable findings in the bootstrap auth surface

## Operational notes

- remote bootstrap now fails closed unless CAR receives a trusted HTTPS request scheme
- TLS-terminating proxies must propagate HTTPS scheme correctly
- public deployments should use explicit host/origin allowlists and preferably an additional reverse-proxy auth layer