### PR TITLE
[codex] Refactor PMA prompt attention state

### DIFF
--- a/docs/ops/pma-attention-state.md
+++ b/docs/ops/pma-attention-state.md
@@ -1,0 +1,77 @@
+# PMA Attention State
+
+PMA prompt turns use an attention-state overview for the every-turn
+`<current_actionable_state>` block. The full hub snapshot remains available on
+first turns and through explicit drilldowns, but repeat turns should not expose
+snapshot plumbing, queue precedence internals, or stale idle inventory as if it
+were new work.
+
+The attention state is derived from the existing action queue and hub snapshot.
+It does not introduce a second source of truth for precedence, supersession, or
+protected-thread semantics.
+
+## Idle Overview
+
+```text
+<pma v=2 mode=overview state=idle fresh=idle actions=0>
+q:
+  none
+bg:
+  threads protected=8 reusable=1 cleanup=0 running=0 failed=0 hung=0
+  files fresh=0 stale=3
+  repos tracked=25 dirty=2
+  automation pending=0
+drill:
+  car hub snapshot --section managed_threads
+  car pma files
+  car hub snapshot --section repos
+  car pma automation list
+</pma>
+```
+
+Idle background surfaces are counts, not prompts to browse. PMA should drill
+down only when the user asks about a surface or when an action item points at
+that surface.
+
+## Action Overview
+
+```text
+<pma v=2 mode=overview state=action fresh=ok actions=2>
+q:
+  1 src=dispatch scope=run:run-123 repo=discord-1 run=run-123 fresh=ok cmd="car hub snapshot --section action_queue"
+  2 src=thread scope=thread:thread-456 repo=discord-3 thread=thread-456 fresh=ok cmd="car pma thread info --id thread-456"
+bg:
+  threads protected=8 reusable=1 cleanup=0 running=1 failed=1 hung=0
+  files fresh=0 stale=3
+  repos tracked=25 dirty=2
+  automation pending=0
+drill:
+  car hub snapshot --section action_queue
+  car hub snapshot --section managed_threads
+  car pma files
+  car hub snapshot --section repos
+  car pma automation list
+semantic_ref=4f80cce5d8d2ef8a
+</pma>
+```
+
+The command is the recommendation. Prose fields such as `why_selected`,
+`recommended_detail`, raw `basis_at`, digest previews, and state keys belong in
+drilldown/debug views, not the default PMA prompt packet.
+
+If more than three hard-action rows exist, PMA receives the total action count,
+a `+N more` queue row, and `car hub snapshot --section action_queue` as the explicit
+drilldown.
+
+## Unchanged Delta
+
+```text
+<context_unchanged />
+```
+
+When durable docs are cached and the attention overview has not changed, repeat
+turns collapse to a one-bit signal. A changed hub snapshot alone does not force
+the attention packet back into the prompt if the derived attention state is
+unchanged. The attention digest includes hidden action semantics such as
+`next_action`, `recommended_action`, `recommended_detail`, and `open_url`, so
+semantic action changes still re-emit `<current_actionable_state>`.

--- a/src/codex_autorunner/core/pma_attention.py
+++ b/src/codex_autorunner/core/pma_attention.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from typing import Any, Mapping, Sequence
+
+from .pma_file_inbox import (
+    PMA_FILE_NEXT_ACTION_PROCESS,
+    PMA_FILE_NEXT_ACTION_REVIEW_STALE,
+    _extract_entry_freshness,
+)
+
+PMA_ATTENTION_SCHEMA_VERSION = 2
+PMA_ATTENTION_MAX_ACTIONS = 3
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _quote(value: Any) -> str:
+    text = _text(value)
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _freshness_status(payload: Any) -> str:
+    if not isinstance(payload, Mapping):
+        return "unknown"
+    if payload.get("is_stale") is True:
+        return "stale"
+    if payload.get("is_stale") is False:
+        return "ok"
+    status = _text(payload.get("status")).lower()
+    return status or "unknown"
+
+
+def _stable_digest_payload(value: Any) -> str:
+    try:
+        payload = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        payload = str(value)
+    return sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _item_semantic_payload(item: Mapping[str, Any]) -> dict[str, Any]:
+    freshness = _extract_entry_freshness(item)
+    supersession = item.get("supersession") or {}
+    return {
+        "id": _text(item.get("action_queue_id")),
+        "src": _action_source(item),
+        "scope": _scope_key(item),
+        "status": _text(supersession.get("status")),
+        "repo": _text(item.get("repo_id")),
+        "run": _text(item.get("run_id")),
+        "thread": _text(item.get("managed_thread_id") or item.get("thread_id")),
+        "file": _text(item.get("name")) if item.get("item_type") == "pma_file" else "",
+        "next_action": _text(item.get("next_action")),
+        "recommended_action": _text(item.get("recommended_action")),
+        "recommended_detail": _text(item.get("recommended_detail")),
+        "open_url": _text(item.get("open_url")),
+        "cmd": _build_command(item),
+        "fresh": _freshness_status(freshness),
+    }
+
+
+def _attention_freshness(snapshot: Mapping[str, Any], actions: Sequence[dict]) -> str:
+    if any(action.get("fresh") == "stale" for action in actions):
+        return "risk"
+    if actions:
+        return "ok"
+
+    freshness = snapshot.get("freshness") or {}
+    stale_sections = (
+        freshness.get("stale_sections") if isinstance(freshness, Mapping) else []
+    )
+    if stale_sections:
+        return "idle"
+    return "ok"
+
+
+def _scope_key(item: Mapping[str, Any]) -> str:
+    scope = item.get("scope") or {}
+    if isinstance(scope, Mapping):
+        value = _text(scope.get("key"))
+        if value:
+            return value
+    for key in ("run_id", "managed_thread_id", "thread_id", "name", "repo_id"):
+        value = _text(item.get(key))
+        if value:
+            return value
+    return _text(item.get("action_queue_id")) or "unknown"
+
+
+def _is_low_signal_inventory(item: Mapping[str, Any]) -> bool:
+    if bool(item.get("likely_false_positive")):
+        return True
+    item_type = _text(item.get("item_type")).lower()
+    if item_type in {"managed_thread_followup_summary", "pma_file_summary"}:
+        return True
+    operator_need = _text(item.get("operator_need")).lower()
+    return operator_need in {"optional", "cleanup", "protected", "review"}
+
+
+def _is_hard_attention_item(item: Mapping[str, Any]) -> bool:
+    if _is_low_signal_inventory(item):
+        return False
+    item_type = _text(item.get("item_type")).lower()
+    queue_source = _text(item.get("queue_source")).lower()
+    followup_state = _text(item.get("followup_state")).lower()
+    operator_need = _text(item.get("operator_need")).lower()
+
+    if queue_source == "ticket_flow_inbox":
+        return True
+    if item_type == "automation_wakeup":
+        return True
+    if item_type == "pma_file":
+        return _text(item.get("next_action")) == PMA_FILE_NEXT_ACTION_PROCESS
+    if item_type == "managed_thread_followup":
+        return followup_state in {"attention_required", "awaiting_followup"}
+    return operator_need in {"urgent", "normal"}
+
+
+def _build_command(item: Mapping[str, Any]) -> str:
+    item_type = _text(item.get("item_type")).lower()
+    queue_source = _text(item.get("queue_source")).lower()
+    repo_id = _text(item.get("repo_id"))
+    run_id = _text(item.get("run_id"))
+    thread_id = _text(item.get("managed_thread_id") or item.get("thread_id"))
+    file_name = _text(item.get("name"))
+    action_queue_id = _text(item.get("action_queue_id"))
+
+    if queue_source == "ticket_flow_inbox" and repo_id and run_id:
+        return "car hub snapshot --section action_queue"
+    if item_type == "managed_thread_followup" and thread_id:
+        return f"car pma thread info --id {thread_id}"
+    if item_type == "pma_file" and file_name:
+        return "car pma files"
+    if item_type == "automation_wakeup":
+        return "car pma automation list"
+    if action_queue_id:
+        return "car hub snapshot --section action_queue"
+    return "car hub snapshot --section action_queue"
+
+
+def _action_source(item: Mapping[str, Any]) -> str:
+    queue_source = _text(item.get("queue_source"))
+    return {
+        "ticket_flow_inbox": "dispatch",
+        "managed_thread_followup": "thread",
+        "pma_file_inbox": "file",
+        "automation_wakeup": "automation",
+    }.get(queue_source, queue_source or "unknown")
+
+
+def _project_action(item: Mapping[str, Any]) -> dict[str, Any]:
+    semantic = _item_semantic_payload(item)
+    return {
+        "id": semantic["id"],
+        "src": semantic["src"],
+        "scope": semantic["scope"],
+        "status": semantic["status"] or "non_primary",
+        "repo": semantic["repo"],
+        "run": semantic["run"],
+        "thread": semantic["thread"],
+        "file": semantic["file"],
+        "cmd": semantic["cmd"],
+        "fresh": semantic["fresh"],
+    }
+
+
+def _surface_counts_from_threads(
+    threads: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    counts = {
+        "protected": 0,
+        "reusable": 0,
+        "cleanup": 0,
+        "running": 0,
+        "failed": 0,
+        "hung": 0,
+    }
+    for thread in threads:
+        status = _text(
+            thread.get("operator_status")
+            or thread.get("normalized_status")
+            or thread.get("status")
+        ).lower()
+        reason = _text(
+            thread.get("status_reason_code") or thread.get("status_reason")
+        ).lower()
+        if bool(thread.get("chat_bound")) or bool(thread.get("cleanup_protected")):
+            counts["protected"] += 1
+        if status in {"completed", "reusable", "idle"} and not bool(
+            thread.get("chat_bound") or thread.get("cleanup_protected")
+        ):
+            counts["reusable"] += 1
+        if status == "running":
+            counts["running"] += 1
+        if status in {"failed", "attention_required"}:
+            counts["failed"] += 1
+        if "hung" in reason:
+            counts["hung"] += 1
+    return counts
+
+
+def _overlay_thread_summary_counts(
+    counts: dict[str, int], action_queue: Sequence[Mapping[str, Any]]
+) -> dict[str, int]:
+    projected = dict(counts)
+    for item in action_queue:
+        if _text(item.get("item_type")) != "managed_thread_followup_summary":
+            continue
+        followup_state = _text(item.get("followup_state"))
+        thread_count = int(item.get("thread_count") or 0)
+        if followup_state == "protected_chat_bound":
+            projected["protected"] = max(projected["protected"], thread_count)
+        elif followup_state == "reusable":
+            projected["reusable"] = max(projected["reusable"], thread_count)
+        elif followup_state == "idle_archive_candidate":
+            projected["cleanup"] = max(projected["cleanup"], thread_count)
+    return projected
+
+
+def _surface_counts_from_files(
+    pma_files_detail: Mapping[str, Sequence[Mapping[str, Any]]],
+    action_queue: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    fresh = 0
+    stale = 0
+    for entry in pma_files_detail.get("inbox") or []:
+        next_action = _text(entry.get("next_action"))
+        freshness = _extract_entry_freshness(entry)
+        if next_action == PMA_FILE_NEXT_ACTION_REVIEW_STALE or (
+            isinstance(freshness, Mapping) and freshness.get("is_stale") is True
+        ):
+            stale += 1
+        else:
+            fresh += 1
+
+    for item in action_queue:
+        item_type = _text(item.get("item_type"))
+        if item_type == "pma_file_summary":
+            stale = max(stale, int(item.get("file_count") or 0))
+        elif (
+            item_type == "pma_file"
+            and _text(item.get("next_action")) == PMA_FILE_NEXT_ACTION_PROCESS
+        ):
+            fresh = max(fresh, 1)
+    return {"fresh": fresh, "stale": stale}
+
+
+def _surface_counts_from_repos(repos: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    dirty = 0
+    for repo in repos:
+        if bool(repo.get("dirty")) or bool(repo.get("has_unpushed_commits")):
+            dirty += 1
+            continue
+        status = _text(repo.get("status")).lower()
+        if status in {"dirty", "needs_push", "unpushed"}:
+            dirty += 1
+    return {"tracked": len(repos), "dirty": dirty}
+
+
+def _surface_counts_from_automation(automation: Mapping[str, Any]) -> dict[str, int]:
+    wakeups = automation.get("wakeups") if isinstance(automation, Mapping) else {}
+    pending = (
+        int((wakeups or {}).get("pending_count") or 0)
+        if isinstance(wakeups, Mapping)
+        else 0
+    )
+    return {"pending": pending}
+
+
+def _fallback_action_queue(snapshot: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    items: list[Mapping[str, Any]] = []
+    for entry in snapshot.get("inbox") or []:
+        if not isinstance(entry, Mapping):
+            continue
+        copied = dict(entry)
+        repo_id = _text(copied.get("repo_id"))
+        run_id = _text(copied.get("run_id"))
+        copied.setdefault("queue_source", "ticket_flow_inbox")
+        copied.setdefault("item_type", copied.get("item_type") or "run_dispatch")
+        copied.setdefault(
+            "action_queue_id",
+            f"ticket_flow_inbox:{repo_id or '-'}:{run_id or '-'}",
+        )
+        copied.setdefault("supersession", {"status": "primary", "superseded": False})
+        copied.setdefault(
+            "scope",
+            {"kind": "run", "key": f"run:{run_id}" if run_id else f"repo:{repo_id}"},
+        )
+        items.append(copied)
+
+    pma_files_detail = snapshot.get("pma_files_detail") or {}
+    if isinstance(pma_files_detail, Mapping):
+        for entry in pma_files_detail.get("inbox") or []:
+            if not isinstance(entry, Mapping):
+                continue
+            if _text(entry.get("next_action")) != PMA_FILE_NEXT_ACTION_PROCESS:
+                continue
+            copied = dict(entry)
+            name = _text(copied.get("name"))
+            copied.setdefault("queue_source", "pma_file_inbox")
+            copied.setdefault("item_type", "pma_file")
+            copied.setdefault("action_queue_id", f"pma_file_inbox:{name or '-'}")
+            copied.setdefault(
+                "supersession", {"status": "non_primary", "superseded": False}
+            )
+            copied.setdefault(
+                "scope", {"kind": "filebox", "key": f"filebox:inbox:{name or '-'}"}
+            )
+            items.append(copied)
+    return items
+
+
+def build_pma_attention_state(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    action_queue = [
+        item for item in snapshot.get("action_queue") or [] if isinstance(item, Mapping)
+    ]
+    if not action_queue:
+        action_queue = list(_fallback_action_queue(snapshot))
+    hard_items = [
+        item
+        for item in action_queue
+        if _is_hard_attention_item(item)
+        and not bool((item.get("supersession") or {}).get("superseded"))
+    ]
+    visible_hard_items = hard_items[:PMA_ATTENTION_MAX_ACTIONS]
+    actions = [_project_action(item) for item in visible_hard_items]
+    thread_counts = _overlay_thread_summary_counts(
+        _surface_counts_from_threads(
+            [
+                item
+                for item in snapshot.get("managed_threads") or []
+                if isinstance(item, Mapping)
+            ]
+        ),
+        action_queue,
+    )
+    pma_files_detail = snapshot.get("pma_files_detail") or {}
+    if not isinstance(pma_files_detail, Mapping):
+        pma_files_detail = {}
+    repos = [item for item in snapshot.get("repos") or [] if isinstance(item, Mapping)]
+    automation = snapshot.get("automation") or {}
+    if not isinstance(automation, Mapping):
+        automation = {}
+
+    state = "action" if actions else "idle"
+    if isinstance(snapshot.get("availability"), Mapping):
+        state = "degraded"
+    drilldowns = [
+        "car hub snapshot --section managed_threads",
+        "car pma files",
+        "car hub snapshot --section repos",
+        "car pma automation list",
+    ]
+    if len(hard_items) > PMA_ATTENTION_MAX_ACTIONS:
+        drilldowns.insert(0, "car hub snapshot --section action_queue")
+
+    return {
+        "version": PMA_ATTENTION_SCHEMA_VERSION,
+        "state": state,
+        "fresh": _attention_freshness(snapshot, actions),
+        "action_count": len(hard_items),
+        "omitted_action_count": max(0, len(hard_items) - len(actions)),
+        "semantic_ref": _stable_digest_payload(
+            [_item_semantic_payload(item) for item in hard_items]
+        ),
+        "actions": actions,
+        "background": {
+            "threads": thread_counts,
+            "files": _surface_counts_from_files(pma_files_detail, action_queue),
+            "repos": _surface_counts_from_repos(repos),
+            "automation": _surface_counts_from_automation(automation),
+        },
+        "drilldowns": drilldowns,
+    }
+
+
+def render_pma_attention_state(attention: Mapping[str, Any], *, mode: str) -> str:
+    version = int(attention.get("version") or PMA_ATTENTION_SCHEMA_VERSION)
+    state = _text(attention.get("state")) or "idle"
+    fresh = _text(attention.get("fresh")) or "unknown"
+    actions = [
+        item for item in attention.get("actions") or [] if isinstance(item, Mapping)
+    ]
+    action_count = int(attention.get("action_count") or len(actions))
+    omitted_action_count = int(attention.get("omitted_action_count") or 0)
+    lines = [
+        f"<pma v={version} mode={mode} state={state} fresh={fresh} actions={action_count}>"
+    ]
+    lines.append("q:")
+    if actions:
+        for index, action in enumerate(actions, start=1):
+            parts = [
+                str(index),
+                f"src={_text(action.get('src')) or 'unknown'}",
+                f"scope={_text(action.get('scope')) or 'unknown'}",
+            ]
+            for key in ("repo", "run", "thread", "file"):
+                value = _text(action.get(key))
+                if value:
+                    parts.append(f"{key}={value}")
+            parts.append(f"fresh={_text(action.get('fresh')) or 'unknown'}")
+            parts.append(f"cmd={_quote(action.get('cmd'))}")
+            lines.append("  " + " ".join(parts))
+        if omitted_action_count:
+            lines.append(
+                f"  +{omitted_action_count} more cmd="
+                f"{_quote('car hub snapshot --section action_queue')}"
+            )
+    else:
+        lines.append("  none")
+
+    background = attention.get("background") or {}
+    lines.append("bg:")
+    for surface in ("threads", "files", "repos", "automation"):
+        counts = background.get(surface) if isinstance(background, Mapping) else {}
+        if not isinstance(counts, Mapping):
+            counts = {}
+        parts = [f"{key}={int(value or 0)}" for key, value in counts.items()]
+        if parts:
+            lines.append(f"  {surface} " + " ".join(parts))
+
+    drilldowns = [
+        _text(command)
+        for command in attention.get("drilldowns") or []
+        if _text(command)
+    ]
+    if drilldowns:
+        lines.append("drill:")
+        for command in drilldowns:
+            lines.append(f"  {command}")
+    semantic_ref = _text(attention.get("semantic_ref"))
+    if semantic_ref:
+        lines.append(f"semantic_ref={semantic_ref}")
+    lines.append("</pma>")
+    return "\n".join(lines)

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -238,6 +238,10 @@ async def build_hub_snapshot(
 
 
 from .pma_action_queue import build_pma_action_queue  # noqa: E402
+from .pma_attention import (  # noqa: E402
+    build_pma_attention_state,
+    render_pma_attention_state,
+)
 from .pma_inbox import _gather_inbox  # noqa: E402
 from .pma_prompt_state import (  # noqa: E402, F401
     PMA_PROMPT_TURN_SECTION,
@@ -299,6 +303,7 @@ __all__ = [
     "build_hub_snapshot",
     "build_hub_snapshot_payload",
     "build_pma_action_queue",
+    "build_pma_attention_state",
     "build_ticket_flow_run_state",
     "clear_pma_prompt_state_sessions",
     "default_pma_prompt_state_path",
@@ -312,4 +317,5 @@ __all__ = [
     "load_pma_prompt",
     "load_pma_workspace_docs",
     "maybe_auto_prune_active_context",
+    "render_pma_attention_state",
 ]

--- a/src/codex_autorunner/core/pma_prompt_builder.py
+++ b/src/codex_autorunner/core/pma_prompt_builder.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence, TypedDict
 
+from .pma_attention import build_pma_attention_state, render_pma_attention_state
 from .pma_context_shared import PMA_MAX_MESSAGES, PMA_MAX_REPOS, PMA_MAX_TEXT
 from .pma_prompt_state import (
     PMA_PROMPT_SECTION_ORDER,
+    PMA_PROMPT_TURN_SECTION,
     _digest_preview,
     _digest_text,
 )
@@ -284,31 +286,22 @@ def _render_pma_actionable_state(
     *,
     render_hub_snapshot: Any,
     limits: PmaPromptRenderLimits,
+    mode: str = "overview",
 ) -> str:
-    actionable_snapshot: dict[str, Any] = {}
-    if snapshot.get("availability") is not None:
-        actionable_snapshot["availability"] = snapshot.get("availability")
-    if snapshot.get("generated_at") is not None:
-        actionable_snapshot["generated_at"] = snapshot.get("generated_at")
-    if snapshot.get("freshness") is not None:
-        actionable_snapshot["freshness"] = snapshot.get("freshness")
-
-    action_queue = snapshot.get("action_queue") or []
-    if action_queue:
-        actionable_snapshot["action_queue"] = action_queue
-    else:
-        for key in ("inbox", "managed_threads", "pma_files_detail", "automation"):
-            value = snapshot.get(key)
-            if value:
-                actionable_snapshot[key] = value
-
-    rendered = render_hub_snapshot(
-        actionable_snapshot,
-        max_repos=limits.max_repos,
-        max_messages=limits.max_messages,
-        max_text_chars=limits.max_text_chars,
+    del render_hub_snapshot, limits
+    rendered = render_pma_attention_state(
+        build_pma_attention_state(snapshot),
+        mode=mode,
     ).strip()
     return rendered or "No current PMA actions."
+
+
+def _attention_semantic_ref_from_content(content: Any) -> str:
+    text = str(content or "")
+    for line in text.splitlines():
+        if line.startswith("semantic_ref="):
+            return line.split("=", 1)[1].strip()
+    return ""
 
 
 def _render_prompt_delta_header(
@@ -421,6 +414,63 @@ def _render_prompt_delta_header(
     return "\n".join(lines) + "\n\n"
 
 
+def _is_context_unchanged_delta(
+    *,
+    sections: Mapping[str, Mapping[str, str]],
+    prior_sections: Optional[Mapping[str, Any]],
+) -> bool:
+    prior_section_map = prior_sections if isinstance(prior_sections, Mapping) else {}
+    turn_prior = prior_section_map.get(PMA_PROMPT_TURN_SECTION)
+    turn_digest = str((sections.get(PMA_PROMPT_TURN_SECTION) or {}).get("digest") or "")
+    turn_previous_digest = (
+        str(turn_prior.get("digest") or "") if isinstance(turn_prior, Mapping) else ""
+    )
+    turn_payload = turn_prior.get("payload") if isinstance(turn_prior, Mapping) else {}
+    turn_previous_content = (
+        str(turn_payload.get("content") or "")
+        if isinstance(turn_payload, Mapping)
+        else ""
+    )
+    turn_semantic_ref = _attention_semantic_ref_from_content(
+        (sections.get(PMA_PROMPT_TURN_SECTION) or {}).get("content")
+    )
+    turn_previous_semantic_ref = _attention_semantic_ref_from_content(
+        turn_previous_content
+    )
+    if (
+        turn_semantic_ref
+        and turn_previous_semantic_ref
+        and turn_semantic_ref != turn_previous_semantic_ref
+    ):
+        return False
+    turn_decision = (
+        str(turn_prior.get("decision") or "") if isinstance(turn_prior, Mapping) else ""
+    )
+    turn_unchanged = turn_decision == "skip_duplicate" or bool(
+        turn_digest and turn_previous_digest == turn_digest
+    )
+    if not turn_unchanged:
+        return False
+
+    changed_sections: list[str] = []
+    for name in PMA_PROMPT_SECTION_ORDER:
+        section = sections.get(name) or {}
+        current_digest = str(section.get("digest") or "")
+        previous = prior_section_map.get(name)
+        previous_digest = (
+            str(previous.get("digest") or "") if isinstance(previous, Mapping) else ""
+        )
+        decision = (
+            str(previous.get("decision") or "") if isinstance(previous, Mapping) else ""
+        )
+        if decision == "skip_duplicate" or (
+            current_digest and previous_digest == current_digest
+        ):
+            continue
+        changed_sections.append(name)
+    return not changed_sections or changed_sections == ["hub_snapshot"]
+
+
 def render_pma_prompt(
     *,
     base_prompt: str,
@@ -448,23 +498,35 @@ def render_pma_prompt(
         prompt += _render_pma_workspace_docs(pma_docs)
     if not use_delta:
         prompt += f"{PMA_FASTPATH}\n\n"
+    context_unchanged = False
     if prompt_state_key:
-        prompt += _render_prompt_delta_header(
-            sections=sections,
-            prior_sections=prior_sections,
-            prompt_state_key=prompt_state_key,
-            current_mode="delta" if use_delta else "full",
-            reason=delta_reason,
-            prior_updated_at=prior_updated_at,
+        context_unchanged = bool(
+            use_delta
+            and _is_context_unchanged_delta(
+                sections=sections,
+                prior_sections=prior_sections,
+            )
         )
-    prompt += (
-        "<current_actionable_state>\n"
-        f"{actionable_state_text}\n"
-        "</current_actionable_state>\n\n"
-    )
+        if context_unchanged:
+            prompt += "<context_unchanged />\n\n"
+        else:
+            prompt += _render_prompt_delta_header(
+                sections=sections,
+                prior_sections=prior_sections,
+                prompt_state_key=prompt_state_key,
+                current_mode="delta" if use_delta else "full",
+                reason=delta_reason,
+                prior_updated_at=prior_updated_at,
+            )
+    if not context_unchanged:
+        prompt += (
+            "<current_actionable_state>\n"
+            f"{actionable_state_text}\n"
+            "</current_actionable_state>\n\n"
+        )
     if not use_delta:
         prompt += f"<hub_snapshot>\n{snapshot_text}\n</hub_snapshot>\n\n"
-    elif prompt_state_key:
+    elif prompt_state_key and not context_unchanged:
         prompt += (
             "<hub_snapshot_ref "
             f"digest='{_digest_preview(str((sections.get('hub_snapshot') or {}).get('digest') or ''))}' "

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -2094,18 +2094,9 @@ class TestIssue975DeltaPmaPromptAssembly:
         assert "Ops guide: `.codex-autorunner/pma/docs/ABOUT_CAR.md`." not in result2
         assert "<pma_fastpath>" not in result2
         assert "\n<hub_snapshot>\n" not in result2
-        assert "<hub_snapshot_ref " in result2
-        assert "- cached=" in result2
-        assert "PMA_PROMPT_MD" in result2
-        assert "PMA_DISCOVERABILITY" in result2
-        assert "PMA_FASTPATH" in result2
-        assert "AGENTS_MD" in result2
-        assert "ACTIVE_CONTEXT_MD" in result2
-        assert "CONTEXT_LOG_TAIL_MD" in result2
-        assert "HUB_SNAPSHOT" in result2
-        assert "- changed=none" in result2
-        assert "PMA Action Queue:" in result2
-        assert "recommended_action=reply_and_resume" in result2
+        assert "<context_unchanged />" in result2
+        assert "<current_actionable_state>" not in result2
+        assert "<hub_snapshot_ref " not in result2
 
     def test_format_pma_prompt_force_full_base_prompt_reinjects_prompt_md_on_delta_turn(
         self, tmp_path: Path
@@ -2161,8 +2152,7 @@ class TestIssue975DeltaPmaPromptAssembly:
         assert "<hub_snapshot>" in variants.new_session_prompt
         assert "<pma_workspace_docs>" not in variants.existing_session_prompt
         assert "\n<hub_snapshot>\n" not in variants.existing_session_prompt
-        assert "<hub_snapshot_ref " in variants.existing_session_prompt
-        assert "- cached=" in variants.existing_session_prompt
+        assert "<context_unchanged />" in variants.existing_session_prompt
 
     def test_format_pma_prompt_delta_surfaces_only_changed_docs(
         self, tmp_path: Path
@@ -2281,12 +2271,9 @@ class TestIssue975DeltaPmaPromptAssembly:
         assert "Ops guide: `.codex-autorunner/pma/docs/ABOUT_CAR.md`." not in result
         assert "<pma_workspace_docs>" not in result
         assert "<pma_fastpath>" not in result
-        assert "- changed=HUB_SNAPSHOT[pma.hub_snapshot@1:" in result
-        assert "(see <current_actionable_state>)" in result
+        assert "<context_unchanged />" in result
         assert "\n<hub_snapshot>\n" not in result
-        assert "<hub_snapshot_ref " in result
-        assert "PMA Action Queue:" in result
-        assert "recommended_action=inspect_thread_result" in result
+        assert "<hub_snapshot_ref " not in result
 
     def test_format_pma_prompt_force_full_context_refresh(self, tmp_path: Path) -> None:
         seed_hub_files(tmp_path, force=True)
@@ -2428,16 +2415,8 @@ class TestIssue975DeltaPmaPromptAssembly:
             prompt_state_key="pma.test-header-sections",
         )
 
-        assert "- cached=" in result
-        assert "PMA_PROMPT_MD" in result
-        assert "PMA_DISCOVERABILITY" in result
-        assert "PMA_FASTPATH" in result
-        assert "AGENTS_MD" in result
-        assert "ACTIVE_CONTEXT_MD" in result
-        assert "CONTEXT_LOG_TAIL_MD" in result
-        assert "HUB_SNAPSHOT" in result
-        assert "- changed=none" in result
-        assert "state_key='pma.test-header-sections'" in result
+        assert "<context_unchanged />" in result
+        assert "state_key='pma.test-header-sections'" not in result
 
     def test_format_pma_prompt_compacted_context_stays_within_budget(
         self, tmp_path: Path

--- a/tests/test_pma_attention.py
+++ b/tests/test_pma_attention.py
@@ -1,0 +1,256 @@
+from pathlib import Path
+
+from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.core.pma_attention import (
+    build_pma_attention_state,
+    render_pma_attention_state,
+)
+from codex_autorunner.core.pma_context import format_pma_prompt
+
+
+def test_attention_state_renders_idle_overview_without_queue_prose() -> None:
+    snapshot = {
+        "generated_at": "2026-05-31T10:00:00Z",
+        "repos": [{"id": "repo-1", "status": "clean"}],
+        "managed_threads": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+        "action_queue": [
+            {
+                "item_type": "managed_thread_followup_summary",
+                "queue_source": "managed_thread_followup",
+                "action_queue_id": "managed_thread_followup_summary:protected_chat_bound",
+                "name": "Protected chat-bound threads (8)",
+                "thread_count": 8,
+                "followup_state": "protected_chat_bound",
+                "operator_need": "protected",
+                "why_selected": "Collapsed protected threads into inventory.",
+                "recommended_detail": "Show protected threads.",
+                "supersession": {"status": "non_primary", "superseded": False},
+            },
+            {
+                "item_type": "pma_file_summary",
+                "queue_source": "pma_file_inbox",
+                "action_queue_id": "pma_file_inbox_summary:stale_uploaded_files",
+                "name": "Stale uploaded files (3)",
+                "file_count": 3,
+                "next_action": "review_stale_uploaded_file",
+                "why_selected": "Collapsed stale files into inventory.",
+                "supersession": {"status": "non_primary", "superseded": False},
+                "likely_false_positive": True,
+            },
+        ],
+        "freshness": {"stale_sections": ["managed_threads", "pma_file_inbox"]},
+    }
+
+    rendered = render_pma_attention_state(
+        build_pma_attention_state(snapshot),
+        mode="overview",
+    )
+
+    assert "<pma v=2 mode=overview state=idle fresh=idle actions=0>" in rendered
+    assert "q:\n  none" in rendered
+    assert "threads protected=8" in rendered
+    assert "files fresh=0 stale=3" in rendered
+    assert "car hub snapshot --section managed_threads" in rendered
+    assert "why_selected" not in rendered
+    assert "recommended_detail" not in rendered
+    assert "precedence" not in rendered
+
+
+def test_attention_state_combines_recommendation_and_drilldown_command() -> None:
+    snapshot = {
+        "repos": [],
+        "managed_threads": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+        "action_queue": [
+            {
+                "item_type": "run_dispatch",
+                "queue_source": "ticket_flow_inbox",
+                "action_queue_id": "ticket_flow_inbox:discord-1:run-123:3",
+                "repo_id": "discord-1",
+                "run_id": "run-123",
+                "recommended_action": "reply_and_resume",
+                "supersession": {"status": "primary", "superseded": False},
+                "freshness": {"is_stale": False},
+                "scope": {"kind": "run", "key": "run:run-123"},
+            }
+        ],
+    }
+
+    rendered = render_pma_attention_state(
+        build_pma_attention_state(snapshot),
+        mode="overview",
+    )
+
+    assert "<pma v=2 mode=overview state=action fresh=ok actions=1>" in rendered
+    assert "src=dispatch" in rendered
+    assert "repo=discord-1" in rendered
+    assert "run=run-123" in rendered
+    assert 'cmd="car hub snapshot --section action_queue"' in rendered
+    assert "recommended_action" not in rendered
+
+
+def test_attention_state_uses_required_thread_info_id_option() -> None:
+    snapshot = {
+        "repos": [],
+        "managed_threads": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+        "action_queue": [
+            {
+                "item_type": "managed_thread_followup",
+                "queue_source": "managed_thread_followup",
+                "action_queue_id": "managed_thread_followup:thread-123",
+                "managed_thread_id": "thread-123",
+                "followup_state": "attention_required",
+                "supersession": {"status": "primary", "superseded": False},
+                "freshness": {"is_stale": False},
+                "scope": {"kind": "thread", "key": "thread:thread-123"},
+            }
+        ],
+    }
+
+    rendered = render_pma_attention_state(
+        build_pma_attention_state(snapshot),
+        mode="overview",
+    )
+
+    assert 'cmd="car pma thread info --id thread-123"' in rendered
+    assert "car pma thread info thread-123" not in rendered
+
+
+def test_attention_state_falls_back_to_raw_inbox_when_queue_is_absent() -> None:
+    snapshot = {
+        "inbox": [
+            {
+                "item_type": "run_dispatch",
+                "repo_id": "discord-2",
+                "run_id": "run-raw",
+                "next_action": "reply_and_resume",
+                "canonical_state_v1": {"freshness": {"is_stale": False}},
+            }
+        ],
+        "repos": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+    }
+
+    rendered = render_pma_attention_state(
+        build_pma_attention_state(snapshot),
+        mode="overview",
+    )
+
+    assert "state=action" in rendered
+    assert "src=dispatch" in rendered
+    assert 'cmd="car hub snapshot --section action_queue"' in rendered
+
+
+def test_attention_state_exposes_action_overflow() -> None:
+    action_queue = []
+    for index in range(4):
+        action_queue.append(
+            {
+                "item_type": "run_dispatch",
+                "queue_source": "ticket_flow_inbox",
+                "action_queue_id": f"ticket_flow_inbox:repo-{index}:run-{index}:1",
+                "repo_id": f"repo-{index}",
+                "run_id": f"run-{index}",
+                "supersession": {"status": "non_primary", "superseded": False},
+                "freshness": {"is_stale": False},
+            }
+        )
+    snapshot = {
+        "repos": [],
+        "managed_threads": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+        "action_queue": action_queue,
+    }
+
+    rendered = render_pma_attention_state(
+        build_pma_attention_state(snapshot),
+        mode="overview",
+    )
+
+    assert "actions=4" in rendered
+    assert '+1 more cmd="car hub snapshot --section action_queue"' in rendered
+    assert "car hub snapshot --section action_queue" in rendered
+
+
+def test_prompt_delta_does_not_collapse_when_action_semantics_change(
+    tmp_path: Path,
+) -> None:
+    seed_hub_files(tmp_path, force=True)
+    base_queue_item = {
+        "item_type": "run_dispatch",
+        "queue_source": "ticket_flow_inbox",
+        "action_queue_id": "ticket_flow_inbox:discord-1:run-123:3",
+        "repo_id": "discord-1",
+        "run_id": "run-123",
+        "recommended_action": "reply_and_resume",
+        "recommended_detail": "Answer the dispatch.",
+        "supersession": {"status": "primary", "superseded": False},
+        "freshness": {"is_stale": False},
+    }
+    snapshot1 = {
+        "generated_at": "2026-05-31T10:00:00Z",
+        "repos": [],
+        "managed_threads": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+        "action_queue": [base_queue_item],
+    }
+    changed_queue_item = dict(base_queue_item)
+    changed_queue_item["recommended_action"] = "inspect_and_resume"
+    changed_queue_item["recommended_detail"] = "Inspect the new blocker."
+    snapshot2 = dict(snapshot1)
+    snapshot2["generated_at"] = "2026-05-31T10:05:00Z"
+    snapshot2["action_queue"] = [changed_queue_item]
+
+    _ = format_pma_prompt(
+        "Base prompt",
+        snapshot1,
+        "Turn 1",
+        hub_root=tmp_path,
+        prompt_state_key="pma.attention.changed-semantics",
+    )
+    result = format_pma_prompt(
+        "Base prompt",
+        snapshot2,
+        "Turn 2",
+        hub_root=tmp_path,
+        prompt_state_key="pma.attention.changed-semantics",
+    )
+
+    assert "<context_unchanged />" not in result
+    assert "<current_actionable_state>" in result
+    assert "semantic_ref=" in result
+
+
+def test_prompt_delta_collapses_when_attention_is_unchanged(tmp_path: Path) -> None:
+    seed_hub_files(tmp_path, force=True)
+    snapshot1 = {
+        "generated_at": "2026-05-31T10:00:00Z",
+        "repos": [],
+        "managed_threads": [],
+        "pma_files_detail": {"inbox": [], "outbox": []},
+        "action_queue": [],
+    }
+    snapshot2 = dict(snapshot1)
+    snapshot2["generated_at"] = "2026-05-31T10:05:00Z"
+
+    _ = format_pma_prompt(
+        "Base prompt",
+        snapshot1,
+        "Turn 1",
+        hub_root=tmp_path,
+        prompt_state_key="pma.attention.same",
+    )
+    result = format_pma_prompt(
+        "Base prompt",
+        snapshot2,
+        "Turn 2",
+        hub_root=tmp_path,
+        prompt_state_key="pma.attention.same",
+    )
+
+    assert "<context_unchanged />" in result
+    assert "<current_actionable_state>" not in result
+    assert "<hub_snapshot_ref " not in result
+    assert "<user_message>\nTurn 2\n</user_message>" in result


### PR DESCRIPTION
## Summary
- Adds a PMA attention-state projection for the every-turn `<current_actionable_state>` packet.
- Replaces verbose action queue rendering with compact `q/bg/drill` overview rows and existing valid drilldown commands.
- Collapses stable repeat turns to `<context_unchanged />` while preserving hidden semantic-change safety through `semantic_ref`.
- Documents the new packet shapes in `docs/ops/pma-attention-state.md`.

## Example structures

Idle overview:
```text
<pma v=2 mode=overview state=idle fresh=idle actions=0>
q:
  none
bg:
  threads protected=8 reusable=1 cleanup=0 running=0 failed=0 hung=0
  files fresh=0 stale=3
  repos tracked=25 dirty=2
  automation pending=0
drill:
  car hub snapshot --section managed_threads
  car pma files
  car hub snapshot --section repos
  car pma automation list
</pma>
```

Action overview:
```text
<pma v=2 mode=overview state=action fresh=ok actions=2>
q:
  1 src=dispatch scope=run:run-123 repo=discord-1 run=run-123 fresh=ok cmd="car hub snapshot --section action_queue"
  2 src=thread scope=thread:thread-456 repo=discord-3 thread=thread-456 fresh=ok cmd="car pma thread info thread-456"
bg:
  threads protected=8 reusable=1 cleanup=0 running=1 failed=1 hung=0
  files fresh=0 stale=3
  repos tracked=25 dirty=2
  automation pending=0
semantic_ref=4f80cce5d8d2ef8a
</pma>
```

Unchanged delta:
```text
<context_unchanged />
```

## Review
- Subagent review found two issues: hidden semantic changes could be suppressed, and hard-action overflow was not visible.
- Fixed by adding hashed `semantic_ref` comparison and explicit `actions=<total>` / `+N more` overflow rows.
- Subagent re-review reported no blocking issues.

## Validation
- Commit hook aggregate lane passed:
  - guardrails, black, ruff, import boundaries, contract checks
  - CLI command hint validation
  - mypy strict repo-wide
  - pytest: 9641 passed
  - Web UI lab fast check
  - Web frontend lint/build/tests: 894 passed, 2 skipped
- Additional focused checks before commit:
  - `.venv/bin/python -m pytest tests/test_pma_attention.py tests/test_pma_context.py tests/test_pma_context_snapshot.py tests/core/test_pma_core_services.py tests/test_pma_context_issue975.py`
  - `.venv/bin/python scripts/check_cli_command_hints.py`

Fixes #1982