### PR TITLE
Tech debt: remove dead code and unused fallback logic

### DIFF
--- a/src/codex_autorunner/adapters/discord/outbox.py
+++ b/src/codex_autorunner/adapters/discord/outbox.py
@@ -15,7 +15,6 @@ from ...core.flows.archive_helpers import flow_run_archive_root
 from ..chat.outbox_kernel import (
     ChatOutboxKernel,
     OutboxAttemptResult,
-    parse_next_attempt_at,
 )
 from .rendering import DISCORD_MAX_MESSAGE_LENGTH, chunk_discord_message
 from .state import ChannelBinding, DiscordStateStore, OutboxRecord
@@ -31,10 +30,6 @@ SendMessageFn = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
 EditMessageFn = Callable[[str, str, dict[str, Any]], Awaitable[Any]]
 DeleteMessageFn = Callable[[str, str], Awaitable[None]]
 DeliveredCallback = Callable[[OutboxRecord, Optional[str]], Awaitable[None]]
-
-
-def _parse_next_attempt_at(next_at_str: Optional[str]) -> Optional[datetime]:
-    return parse_next_attempt_at(next_at_str)
 
 
 def _extract_retry_after_seconds(exc: Exception) -> Optional[float]:

--- a/src/codex_autorunner/adapters/telegram/handlers/utils.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/utils.py
@@ -16,10 +16,6 @@ def _extract_opencode_usage_payload(
     return extract_usage(payload)
 
 
-def _flatten_opencode_tokens(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
-    return flatten_usage(payload)
-
-
 def _build_opencode_token_usage(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
     usage_payload = extract_usage(payload)
     if usage_payload is None:
@@ -68,6 +64,5 @@ def _build_opencode_token_usage(payload: dict[str, Any]) -> Optional[dict[str, A
 
 __all__ = [
     "_extract_opencode_usage_payload",
-    "_flatten_opencode_tokens",
     "_build_opencode_token_usage",
 ]

--- a/src/codex_autorunner/adapters/telegram/outbox.py
+++ b/src/codex_autorunner/adapters/telegram/outbox.py
@@ -13,7 +13,6 @@ from ...core.state import now_iso
 from ..chat.outbox_kernel import (
     ChatOutboxKernel,
     OutboxAttemptResult,
-    parse_next_attempt_at,
 )
 from .client import TelegramAPIError
 from .constants import (
@@ -61,10 +60,6 @@ def _should_delete_placeholder_on_delivery(record: OutboxRecord) -> bool:
         return True
     # Backward-compatible default for existing outbox records.
     return True
-
-
-def _parse_next_attempt_at(next_at_str: Optional[str]) -> Optional[datetime]:
-    return parse_next_attempt_at(next_at_str)
 
 
 def _coalesce_key(record: OutboxRecord) -> Optional[str]:

--- a/src/codex_autorunner/core/agent_model_defaults.py
+++ b/src/codex_autorunner/core/agent_model_defaults.py
@@ -32,9 +32,9 @@ def _state_default_model(agent: str, state: Any) -> Optional[str]:
     return None
 
 
-def normalize_agent_id(agent: object, *, default: str = "codex") -> str:
+def normalize_agent_id(agent: object) -> str:
     value = str(agent or "").strip().lower()
-    return value or default
+    return value or "codex"
 
 
 def builtin_default_model_for_agent(agent: object) -> Optional[str]:

--- a/src/codex_autorunner/core/freshness.py
+++ b/src/codex_autorunner/core/freshness.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Optional, Sequence
 
 DEFAULT_STALE_THRESHOLD_SECONDS = 30 * 60
+DEFAULT_RECENCY_BASIS = "snapshot_generated_at"
 
 
 def iso_now() -> str:
@@ -47,20 +48,21 @@ def build_freshness_payload(
     generated_at: Optional[str],
     stale_threshold_seconds: Any,
     candidates: Sequence[tuple[str, Any]],
-    fallback_basis: str = "snapshot_generated_at",
 ) -> dict[str, Any]:
     generated_at_text = normalize_iso_datetime(generated_at) or iso_now()
     generated_dt = parse_iso_datetime(generated_at_text) or datetime.now(timezone.utc)
     threshold_seconds = resolve_stale_threshold_seconds(stale_threshold_seconds)
 
-    recency_basis = fallback_basis
+    recency_basis = DEFAULT_RECENCY_BASIS
     basis_at = generated_at_text
     fallback_used = True
     for label, value in candidates:
         candidate_at = normalize_iso_datetime(value)
         if candidate_at is None:
             continue
-        recency_basis = str(label or fallback_basis).strip() or fallback_basis
+        recency_basis = (
+            str(label or DEFAULT_RECENCY_BASIS).strip() or DEFAULT_RECENCY_BASIS
+        )
         basis_at = candidate_at
         fallback_used = False
         break

--- a/src/codex_autorunner/core/managed_thread_kinds.py
+++ b/src/codex_autorunner/core/managed_thread_kinds.py
@@ -41,7 +41,6 @@ def infer_managed_thread_chat_kind(
     *,
     metadata: Any = None,
     display_name: Any = None,
-    default: ManagedThreadChatKind = MANAGED_THREAD_CHAT_KIND_PMA,
 ) -> ManagedThreadChatKind:
     metadata_map = metadata if isinstance(metadata, dict) else {}
     explicit = normalize_managed_thread_chat_kind(
@@ -52,7 +51,7 @@ def infer_managed_thread_chat_kind(
         return explicit
     if isinstance(display_name, str) and "coding agent" in display_name.strip().lower():
         return MANAGED_THREAD_CHAT_KIND_CODING_AGENT
-    return default
+    return MANAGED_THREAD_CHAT_KIND_PMA
 
 
 __all__ = [

--- a/src/codex_autorunner/core/orchestration/catalog.py
+++ b/src/codex_autorunner/core/orchestration/catalog.py
@@ -56,7 +56,6 @@ def build_agent_definition(
     *,
     repo_id: Optional[str] = None,
     workspace_root: Optional[str] = None,
-    default_model: Optional[str] = None,
     description: Optional[str] = None,
     available: bool = True,
     runtime_capabilities: Optional[Iterable[RuntimeCapability]] = None,
@@ -71,7 +70,7 @@ def build_agent_definition(
         ),
         repo_id=repo_id,
         workspace_root=workspace_root,
-        default_model=default_model,
+        default_model=None,
         description=description,
         available=available,
     )

--- a/src/codex_autorunner/core/pma/policies.py
+++ b/src/codex_autorunner/core/pma/policies.py
@@ -7,10 +7,10 @@ from ..text_utils import _normalize_optional_text
 BusyPolicy = Literal["queue", "interrupt", "reject"]
 
 
-def normalize_busy_policy(value: Any, *, default: BusyPolicy = "queue") -> BusyPolicy:
+def normalize_busy_policy(value: Any) -> BusyPolicy:
     normalized = _normalize_optional_text(value)
     if normalized is None:
-        return default
+        return "queue"
     busy_policy = normalized.lower()
     if busy_policy not in {"queue", "interrupt", "reject"}:
         raise ValueError("busy_policy must be one of: queue, interrupt, reject")

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -157,13 +157,6 @@ def _running_turn_stall_flags(
     return (True, reason)
 
 
-def _truncate_tool_name(value: Any) -> str | None:
-    text = normalize_optional_text(value)
-    if text is None:
-        return None
-    return truncate_text(text, 80)
-
-
 def _parse_inline_sse(raw_event: str) -> tuple[str, dict[str, Any]]:
     event_name = "message"
     data_lines: list[str] = []
@@ -1219,5 +1212,4 @@ __all__ = [
     "_serialize_persisted_timeline_tail_events",
     "_serialize_runtime_raw_tail_events",
     "_tail_event_from_run_event",
-    "_truncate_tool_name",
 ]

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -251,7 +251,6 @@ from .pma_rendering import _render_hub_snapshot  # noqa: E402
 from .pma_ticket_flow_state import (  # noqa: E402, F401
     TicketFlowRunState,
     TicketFlowWorkerCrash,
-    _dispatch_is_actionable,
     _latest_dispatch,
     _latest_reply_history_seq,
     _resolve_paused_dispatch_state,
@@ -280,7 +279,6 @@ __all__ = [
     "TicketFlowWorkerCrash",
     "_build_snapshot_freshness_summary",
     "_build_templates_snapshot",
-    "_dispatch_is_actionable",
     "_gather_inbox",
     "_latest_dispatch",
     "_latest_reply_history_seq",

--- a/src/codex_autorunner/core/pma_ticket_flow_state.py
+++ b/src/codex_autorunner/core/pma_ticket_flow_state.py
@@ -17,9 +17,6 @@ from .ticket_flow_operator import (
     build_ticket_flow_run_state as _build_ticket_flow_run_state,
 )
 from .ticket_flow_operator import (
-    dispatch_is_actionable as _dispatch_is_actionable_impl,
-)
-from .ticket_flow_operator import (
     get_latest_ticket_flow_run_state_with_record as _get_latest_run_state_with_record,
 )
 from .ticket_flow_operator import (
@@ -31,7 +28,6 @@ from .ticket_flow_operator import (
 from .ticket_flow_operator import (
     resolve_paused_dispatch_state as _resolve_paused_dispatch_state_impl,
 )
-from .ticket_flow_summary import build_ticket_flow_summary
 
 _logger = logging.getLogger(__name__)
 
@@ -39,8 +35,6 @@ __all__ = [
     "PMA_MAX_TEXT",
     "TicketFlowRunState",
     "TicketFlowWorkerCrash",
-    "_dispatch_is_actionable",
-    "_get_ticket_flow_summary",
     "_latest_dispatch",
     "_latest_reply_history_seq",
     "_resolve_paused_dispatch_state",
@@ -79,18 +73,10 @@ def _trim_extra(extra: Any, limit: int) -> Any:
     }
 
 
-def _get_ticket_flow_summary(repo_path: Path) -> Optional[dict[str, Any]]:
-    return build_ticket_flow_summary(repo_path, include_failure=False)
-
-
 def _latest_reply_history_seq(
     repo_root: Path, run_id: str, record_input: dict[str, Any]
 ) -> int:
     return _latest_reply_history_seq_impl(repo_root, run_id, record_input)
-
-
-def _dispatch_is_actionable(dispatch_payload: Any) -> bool:
-    return _dispatch_is_actionable_impl(dispatch_payload)
 
 
 def _resolve_paused_dispatch_state(

--- a/tests/test_hotspot_budgets.py
+++ b/tests/test_hotspot_budgets.py
@@ -600,7 +600,6 @@ HELPER_OWNERSHIP_RULES = (
     HelperOwnershipRule(
         owner_path="src/codex_autorunner/adapters/telegram/handlers/utils.py",
         helper_names=(
-            "_flatten_opencode_tokens",
             "_extract_opencode_usage_payload",
             "_build_opencode_token_usage",
         ),


### PR DESCRIPTION
## Summary

Remove mechanically proven dead code and unused fallback parameters from the production `src/codex_autorunner/` tree.

## Files changed

- `src/codex_autorunner/adapters/discord/outbox.py`: removed unused `_parse_next_attempt_at` wrapper and its now-unused `parse_next_attempt_at` import.
- `src/codex_autorunner/adapters/telegram/handlers/utils.py`: removed unused `_flatten_opencode_tokens` helper and its `__all__` export.
- `src/codex_autorunner/adapters/telegram/outbox.py`: removed unused `_parse_next_attempt_at` wrapper and its now-unused `parse_next_attempt_at` import.
- `src/codex_autorunner/core/agent_model_defaults.py`: removed the never-overridden `default` parameter from `normalize_agent_id`; the only observed fallback remains `codex`.
- `src/codex_autorunner/core/freshness.py`: removed the never-overridden `fallback_basis` parameter from `build_freshness_payload` and centralized the fixed fallback basis constant.
- `src/codex_autorunner/core/managed_thread_kinds.py`: removed the never-overridden `default` parameter from `infer_managed_thread_chat_kind`; the fixed fallback remains `pma`.
- `src/codex_autorunner/core/orchestration/catalog.py`: removed the never-passed `default_model` parameter from `build_agent_definition`; catalog definitions continue to emit `default_model=None`.
- `src/codex_autorunner/core/pma/policies.py`: removed the never-overridden `default` parameter from `normalize_busy_policy`; the fixed fallback remains `queue`.
- `src/codex_autorunner/core/pma/tail_serialization.py`: removed unused `_truncate_tool_name` helper and its `__all__` export.
- `src/codex_autorunner/core/pma_context.py`: removed unused `_dispatch_is_actionable` compatibility re-export after confirming no callers.
- `src/codex_autorunner/core/pma_ticket_flow_state.py`: removed unused `_get_ticket_flow_summary` and `_dispatch_is_actionable` wrappers, their imports, and their `__all__` exports.
- `tests/test_hotspot_budgets.py`: removed `_flatten_opencode_tokens` from the helper ownership budget alongside the production helper removal.

## Validation

- Commit hook for `7340bd33b`: aggregate lane passed, including `9597 passed` pytest, mypy, ruff, Web UI lint/build/tests.
- Commit hook for `214200beb`: core lane passed, including `9597 passed` pytest, mypy, ruff.
- Targeted checks during development:
  - `python -m ruff check ...`
  - `.venv/bin/python -m pytest tests/test_hotspot_budgets.py -k ownership`
  - `.venv/bin/python -m pytest tests/core/test_agent_model_defaults.py tests/core/test_pma_core_services.py tests/core/orchestration/test_catalog.py tests/agents/test_registry_capabilities.py tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime_payloads.py`
