### PR TITLE
[codex] Harden OpenCode review subagents

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -178,11 +178,11 @@ repo_defaults:
     enabled: true
     agent: opencode
     # Model for parent coordinator agent
-    model: zai-coding-plan/glm-5
-    # Agent ID to use for subtasks (bucket reviews, pruning agents)
-    subagent_agent: subagent
+    model: zai-coding-plan/glm-5.1
+    # Read-only OpenCode agent ID to use for review subtasks
+    subagent_agent: car-read-explore
     # Model to use for subagents (default to model if not specified)
-    subagent_model: zai-coding-plan/glm-4.7-flashx
+    subagent_model: zai-coding-plan/glm-5.1
     reasoning: null
     max_wallclock_seconds: null
 
@@ -202,10 +202,10 @@ agents:
   opencode:
     binary: opencode
     # Optional: map subagent agent IDs to models
-    # Example: subagent_models: { subagent: zai-coding-plan/glm-4.7-flashx }
+    # Example: subagent_models: { car-read-explore: zai-coding-plan/glm-5.1 }
     # This allows different models for parent vs subagent sessions
     subagent_models:
-      subagent: zai-coding-plan/glm-4.7-flashx
+      car-read-explore: zai-coding-plan/glm-5.1
     # Optional: override the default serve command derived from binary.
     # serve_command:
     #   - /absolute/path/to/opencode

--- a/docs/adding-an-agent.md
+++ b/docs/adding-an-agent.md
@@ -236,18 +236,18 @@ CAR can run review coordinators on one model while spawning cheaper/faster subag
 agents:
   opencode:
     subagent_models:
-      subagent: zai-coding-plan/glm-4.7-flashx
+      car-read-explore: zai-coding-plan/glm-5.1
 
 repo_defaults:
   review:
-    subagent_agent: subagent
-    subagent_model: zai-coding-plan/glm-4.7-flashx
+    subagent_agent: car-read-explore
+    subagent_model: zai-coding-plan/glm-5.1
 ```
 
 How it works:
-1. CAR ensures `.opencode/agent/subagent.md` exists with the FlashX model before starting review.
-2. The review coordinator runs on the full GLM-4.7 model.
-3. The coordinator spawns subagents via the `task` tool with `agent="subagent"`, inheriting the configured model.
+1. CAR ensures `.opencode/agent/car-read-explore.md` exists with the configured read-only model before starting review.
+2. The review coordinator runs on the configured parent review model.
+3. The coordinator spawns subagents via the `task` tool with `agent="car-read-explore"`, inheriting the configured read-only model.
 
 If you are adding an agent directly to the CAR codebase, register it in:
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,11 @@
+# CAR Agent Integration Notes
+
+These notes describe how CAR uses external agent runtimes. They are not upstream
+runtime manuals; keep them short and update them when CAR relies on runtime
+behavior that is easy to forget.
+
+- [OpenCode](opencode.md)
+- [Codex](codex.md)
+- [Hermes](hermes.md)
+
+For adding a new runtime, see [Adding an Agent](../adding-an-agent.md).

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -1,0 +1,8 @@
+# Codex in CAR
+
+CAR uses Codex through its app-server/runtime integration. Codex is the reference
+runtime for durable managed-thread behavior and rich turn events.
+
+Keep CAR-specific Codex notes here when CAR depends on behavior that is not
+obvious from the code, such as app-server lifecycle assumptions, event semantics,
+or timeout policy. Detailed upstream/API notes belong under `docs/codex/`.

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -1,0 +1,10 @@
+# Hermes in CAR
+
+CAR uses Hermes through the ACP-style runtime path. Hermes support should stay
+behind the same protocol boundaries as Codex and OpenCode: runtime-specific code
+belongs in the agent adapter, while surfaces consume canonical CAR turn events.
+
+For the current architecture and caveats, see:
+
+- [Hermes ACP operations](../ops/hermes-acp.md)
+- [Hermes ACP architecture](../architecture/hermes-acp-v1.md)

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -1,0 +1,67 @@
+# OpenCode in CAR
+
+CAR uses OpenCode through `opencode serve` and the HTTP/SSE API in
+`src/codex_autorunner/agents/opencode/`.
+
+## Runtime Shape
+
+- `OpenCodeSupervisor` owns the server process and client handles.
+- `OpenCodeClient` calls `/session`, `/session/{id}/prompt_async`, `/session/{id}/abort`,
+  `/session/status`, and the event stream.
+- `OpenCodeHarness` adapts OpenCode sessions to CAR managed-thread turns.
+- `run_opencode_prompt` is used by review flows that run a temporary OpenCode
+  session and dispose it afterwards.
+
+## Agent Files
+
+CAR writes generated OpenCode agents under `.opencode/agent/<agent-id>.md`.
+OpenCode 1.15.13 also reads `.opencode/agents/`, but CAR writes the singular
+path.
+
+Generated files are marked with:
+
+```yaml
+car_managed: codex-autorunner
+```
+
+CAR may update marked files and old minimal CAR-generated files. User-authored
+agent files with custom frontmatter/body are left unchanged.
+
+## Review Task Policy
+
+OpenCode Task subagents are a reliability fault boundary. CAR review now uses:
+
+- a primary coordinator agent with `permission.task` denying `*` and allowing
+  only the configured read-only review subagent
+- a read-only subagent with write-like permissions denied: `edit`, `write`,
+  `bash`, and `todowrite`
+
+The parent coordinator still owns scratchpad/final report writing. Subagents
+should return analysis to the coordinator; they should not edit files or write
+artifacts directly.
+
+Use `scripts/probe_opencode_agent_policy.py` to verify the installed OpenCode
+binary parses these permissions as expected.
+
+## Timeouts and Stalls
+
+CAR has its own OpenCode stream stall handling:
+
+- `opencode.session_stall_timeout_seconds` configures CAR-side stream stall
+  behavior.
+- Busy `session.status` heartbeats do not count as meaningful progress.
+- The stream lifecycle reconnects, polls session status, and can abort the
+  primary session on timeout.
+
+OpenCode provider options such as provider `timeout` and `chunkTimeout` are
+OpenCode configuration, not CAR HTTP client timeouts. Verify exact OpenCode
+provider config shape before generating or documenting repo defaults for them.
+
+## Known Reliability Boundaries
+
+- CAR can abort the primary OpenCode session.
+- CAR observes descendant sessions for progress, but it does not currently have
+  a proven API contract for killing one Task child while allowing the parent to
+  continue.
+- Rescue should be implemented only after descendant-session telemetry and abort
+  cascade behavior are verified.

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -34,7 +34,7 @@ OpenCode Task subagents are a reliability fault boundary. CAR review now uses:
 - a primary coordinator agent with `permission.task` denying `*` and allowing
   only the configured read-only review subagent
 - a read-only subagent with write-like permissions denied: `edit`, `write`,
-  `bash`, and `todowrite`
+  `bash`, `task`, and `todowrite`
 
 The parent coordinator still owns scratchpad/final report writing. Subagents
 should return analysis to the coordinator; they should not edit files or write

--- a/scripts/opencode_lifecycle_soak.py
+++ b/scripts/opencode_lifecycle_soak.py
@@ -318,7 +318,7 @@ async def _one_shot_phase(
                 supervisor,
                 OpenCodeRunConfig(
                     agent="opencode",
-                    model="zai-coding-plan/glm-4.7-flashx",
+                    model="zai-coding-plan/glm-5.1",
                     reasoning=None,
                     prompt="Reply with exactly OK.",
                     workspace_root=str(repo_root),

--- a/scripts/probe_opencode_agent_policy.py
+++ b/scripts/probe_opencode_agent_policy.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Probe local OpenCode agent permission behavior used by CAR.
+
+This script uses CAR's generator, then verifies the result with the real
+``opencode agent list`` command. It checks that the installed OpenCode build
+parses CAR-style agent frontmatter into the permission rules CAR relies on for
+read-only Task subagents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+def _write_agent(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _run_opencode_agent_list(workspace: Path) -> str:
+    opencode = shutil.which("opencode")
+    if opencode is None:
+        raise RuntimeError("opencode binary not found on PATH")
+    result = subprocess.run(
+        [opencode, "agent", "list"],
+        cwd=workspace,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def _require(output: str, needle: str) -> None:
+    if needle not in output:
+        raise AssertionError(f"expected OpenCode agent list output to contain: {needle}")
+
+
+async def probe(workspace: Path) -> None:
+    from codex_autorunner.agents.opencode.agent_config import ensure_agent_config
+
+    agent_dir = workspace / ".opencode" / "agent"
+    await ensure_agent_config(
+        workspace_root=workspace,
+        agent_id="car-review-coordinator",
+        model="zai-coding-plan/glm-5.1",
+        title="CAR review coordinator",
+        description="CAR OpenCode review coordinator",
+        mode="primary",
+        permission={"task": {"*": "deny", "car-read-explore": "allow"}},
+        body="Coordinate review work. Use Task only for read-only review subagents.\n",
+    )
+    await ensure_agent_config(
+        workspace_root=workspace,
+        agent_id="car-read-explore",
+        model="zai-coding-plan/glm-5.1",
+        title="CAR read-only review explorer",
+        description="Read-only CAR review subagent",
+        mode="subagent",
+        permission={
+            "edit": "deny",
+            "write": "deny",
+            "bash": "deny",
+            "todowrite": "deny",
+        },
+        body="Read repository files and return findings to the coordinator.\n",
+    )
+    _write_agent(
+        agent_dir / "car-write-helper.md",
+        """---
+agent: car-write-helper
+title: "CAR write helper"
+description: "Write-capable helper that should not be task-allowlisted"
+model: zai-coding-plan/glm-5.1
+mode: subagent
+permission:
+  "*": allow
+---
+Write-capable helper.
+""",
+    )
+
+    output = _run_opencode_agent_list(workspace)
+    for needle in (
+        "car-review-coordinator (primary)",
+        '"permission": "task"',
+        '"pattern": "*"',
+        '"action": "deny"',
+        '"pattern": "car-read-explore"',
+        '"action": "allow"',
+        "car-read-explore (subagent)",
+        '"permission": "edit"',
+        '"permission": "write"',
+        '"permission": "bash"',
+        '"permission": "todowrite"',
+        "car-write-helper (subagent)",
+    ):
+        _require(output, needle)
+    if '"pattern": "car-write-helper"' in output:
+        raise AssertionError("write helper was unexpectedly allowlisted for task")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the temporary workspace for inspection",
+    )
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        asyncio.run(probe(workspace))
+        if args.keep:
+            kept = Path(tempfile.mkdtemp(prefix="car-opencode-agent-policy-"))
+            shutil.copytree(workspace, kept, dirs_exist_ok=True)
+            print(f"kept probe workspace: {kept}")
+    print("local OpenCode agent policy probe passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe_opencode_agent_policy.py
+++ b/scripts/probe_opencode_agent_policy.py
@@ -71,6 +71,7 @@ async def probe(workspace: Path) -> None:
             "edit": "deny",
             "write": "deny",
             "bash": "deny",
+            "task": "deny",
             "todowrite": "deny",
         },
         body="Read repository files and return findings to the coordinator.\n",
@@ -102,6 +103,7 @@ Write-capable helper.
         '"permission": "edit"',
         '"permission": "write"',
         '"permission": "bash"',
+        '"permission": "task"',
         '"permission": "todowrite"',
         "car-write-helper (subagent)",
     ):

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
@@ -950,7 +950,7 @@ class GitHubCommands(TelegramCommandSupportMixin):
                 turn_ref = await harness.start_review(
                     setup.workspace_root,
                     setup.review_session_id,
-                    prompt=setup.review_args,
+                    prompt=canonical_review_prompt,
                     model=record.model,
                     reasoning=None,
                     approval_mode=setup.approval_mode,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
@@ -895,10 +895,13 @@ class GitHubCommands(TelegramCommandSupportMixin):
                 topic_key = await self._resolve_topic_key(
                     message.chat_id, message.thread_id
                 )
+                canonical_review_prompt = (
+                    setup.review_args.strip() or "Review uncommitted changes."
+                )
                 message_request = MessageRequest(
                     target_id=setup.review_session_id,
                     target_kind="thread",
-                    message_text=setup.review_args,
+                    message_text=canonical_review_prompt,
                     kind="review",
                     busy_policy="reject",
                     model=record.model,

--- a/src/codex_autorunner/agents/opencode/agent_config.py
+++ b/src/codex_autorunner/agents/opencode/agent_config.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 logger = logging.getLogger(__name__)
+
+_CAR_MANAGED_KEY = "car_managed"
+_CAR_MANAGED_VALUE = "codex-autorunner"
+_LEGACY_CAR_KEYS = {"agent", "title", "description", "model"}
 
 
 async def ensure_agent_config(
@@ -14,15 +18,25 @@ async def ensure_agent_config(
     model: Optional[str],
     title: Optional[str] = None,
     description: Optional[str] = None,
+    mode: Optional[str] = None,
+    permission: Optional[Mapping[str, Any]] = None,
+    steps: Optional[int] = None,
+    body: Optional[str] = None,
+    car_managed: bool = True,
 ) -> None:
     """Ensure .opencode/agent/<agent_id>.md exists with frontmatter config.
 
     Args:
         workspace_root: Path to the workspace root
         agent_id: Agent ID (e.g., "subagent")
-        model: Model ID in format "providerID/modelID" (e.g., "zai-coding-plan/glm-4.7-flashx")
+        model: Model ID in format "providerID/modelID" (e.g., "zai-coding-plan/glm-5.1")
         title: Optional title for the agent
         description: Optional description for the agent
+        mode: Optional OpenCode agent mode ("primary" or "subagent")
+        permission: Optional OpenCode permission policy frontmatter
+        steps: Optional max step count for the OpenCode agent
+        body: Optional instruction body after frontmatter
+        car_managed: Whether to mark the file as CAR-owned for future updates
     """
     if model is None:
         logger.debug(f"Skipping agent config for {agent_id}: no model configured")
@@ -34,21 +48,52 @@ async def ensure_agent_config(
     # Check if file already exists and has the correct model
     if agent_file.exists():
         existing_content = agent_file.read_text(encoding="utf-8")
-        existing_model = _extract_model_from_frontmatter(existing_content)
-        if existing_model == model:
+        if not _can_update_existing_agent_config(existing_content):
+            logger.info(
+                "OpenCode agent config is user-managed, leaving unchanged: %s",
+                agent_file,
+            )
+            return
+        content = _build_agent_md(
+            agent_id=agent_id,
+            model=model,
+            title=title or agent_id,
+            description=description or f"Subagent for {agent_id} tasks",
+            mode=mode,
+            permission=permission,
+            steps=steps,
+            body=body,
+            car_managed=car_managed,
+        )
+        if existing_content == content:
             logger.debug(f"Agent config already exists for {agent_id}: {agent_file}")
             return
+        if (
+            permission is None
+            and mode is None
+            and steps is None
+            and body is None
+            and _extract_model_from_frontmatter(existing_content) == model
+        ):
+            logger.debug(
+                f"Agent config model already matches for {agent_id}: {agent_file}"
+            )
+            return
+    else:
+        content = _build_agent_md(
+            agent_id=agent_id,
+            model=model,
+            title=title or agent_id,
+            description=description or f"Subagent for {agent_id} tasks",
+            mode=mode,
+            permission=permission,
+            steps=steps,
+            body=body,
+            car_managed=car_managed,
+        )
 
     # Create agent directory if needed
     await asyncio.to_thread(agent_dir.mkdir, parents=True, exist_ok=True)
-
-    # Build agent markdown with frontmatter
-    content = _build_agent_md(
-        agent_id=agent_id,
-        model=model,
-        title=title or agent_id,
-        description=description or f"Subagent for {agent_id} tasks",
-    )
 
     # Write atomically
     await asyncio.to_thread(agent_file.write_text, content, encoding="utf-8")
@@ -60,6 +105,11 @@ def _build_agent_md(
     model: str,
     title: str,
     description: str,
+    mode: Optional[str] = None,
+    permission: Optional[Mapping[str, Any]] = None,
+    steps: Optional[int] = None,
+    body: Optional[str] = None,
+    car_managed: bool = False,
 ) -> str:
     """Generate markdown with YAML frontmatter.
 
@@ -69,17 +119,32 @@ def _build_agent_md(
     title: "<title>"
     description: "<description>"
     model: <providerID>/<modelID>
+    mode: <primary|subagent>
     ---
 
     <Optional agent instructions go here>
     """
-    return f"""---
-agent: {agent_id}
-title: "{title}"
-description: "{description}"
-model: {model}
----
-"""
+    lines = [
+        "---",
+        f"agent: {_yaml_scalar(agent_id)}",
+        f"title: {_yaml_scalar(title)}",
+        f"description: {_yaml_scalar(description)}",
+        f"model: {_yaml_scalar(model)}",
+    ]
+    if mode:
+        lines.append(f"mode: {_yaml_scalar(mode)}")
+    if isinstance(steps, int) and steps > 0:
+        lines.append(f"steps: {steps}")
+    if car_managed:
+        lines.append(f"{_CAR_MANAGED_KEY}: {_yaml_scalar(_CAR_MANAGED_VALUE)}")
+    if permission:
+        lines.append("permission:")
+        lines.extend(_yaml_mapping_lines(permission, indent=2))
+    lines.append("---")
+    content = "\n".join(lines) + "\n"
+    if body:
+        content += body.rstrip() + "\n"
+    return content
 
 
 def _extract_model_from_frontmatter(content: str) -> Optional[str]:
@@ -99,6 +164,67 @@ def _extract_model_from_frontmatter(content: str) -> Optional[str]:
             return model if model else None
 
     return None
+
+
+def _can_update_existing_agent_config(content: str) -> bool:
+    fields, body = _parse_frontmatter_fields(content)
+    if not fields:
+        return False
+    if fields.get(_CAR_MANAGED_KEY) == _CAR_MANAGED_VALUE:
+        return True
+    # Files produced by older CAR versions contained only simple frontmatter and
+    # no body. Treat those as migratable while preserving user-authored agents.
+    return _looks_like_legacy_car_agent(fields, body)
+
+
+def _looks_like_legacy_car_agent(fields: dict[str, str], body: str) -> bool:
+    description = fields.get("description", "")
+    return (
+        not body.strip()
+        and set(fields).issubset(_LEGACY_CAR_KEYS)
+        and set(fields).issuperset(_LEGACY_CAR_KEYS)
+        and description.startswith("Subagent for ")
+    )
+
+
+def _parse_frontmatter_fields(content: str) -> tuple[dict[str, str], str]:
+    lines = content.splitlines()
+    if not lines or not lines[0].startswith("---"):
+        return {}, content
+    fields: dict[str, str] = {}
+    body_start = len(lines)
+    for index, line in enumerate(lines[1:], start=1):
+        if line.startswith("---"):
+            body_start = index + 1
+            break
+        if ":" not in line or line.startswith(" "):
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip('"')
+    body = "\n".join(lines[body_start:])
+    return fields, body
+
+
+def _yaml_scalar(value: str) -> str:
+    if not value:
+        return '""'
+    if all(ch.isalnum() or ch in "-_./" for ch in value):
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _yaml_mapping_lines(mapping: Mapping[str, Any], *, indent: int) -> list[str]:
+    lines: list[str] = []
+    prefix = " " * indent
+    for key, value in mapping.items():
+        key_text = _yaml_scalar(str(key))
+        if isinstance(value, Mapping):
+            lines.append(f"{prefix}{key_text}:")
+            lines.extend(_yaml_mapping_lines(value, indent=indent + 2))
+        else:
+            lines.append(f"{prefix}{key_text}: {_yaml_scalar(str(value))}")
+    return lines
 
 
 __all__ = ["ensure_agent_config"]

--- a/src/codex_autorunner/agents/opencode/run_prompt.py
+++ b/src/codex_autorunner/agents/opencode/run_prompt.py
@@ -46,6 +46,13 @@ class OpenCodeRunConfig:
     permission_policy: str = PERMISSION_ALLOW
 
 
+def _runtime_agent_for_prompt(agent: str) -> Optional[str]:
+    normalized = (agent or "").strip()
+    if not normalized or normalized == "opencode":
+        return None
+    return normalized
+
+
 async def _create_session(
     client: Any,
     workspace_root: str,
@@ -260,6 +267,7 @@ async def _run_turn(
         client.prompt_async(
             session_id,
             message=config.prompt,
+            agent=_runtime_agent_for_prompt(config.agent),
             model=model_payload,
             variant=config.reasoning,
         )

--- a/src/codex_autorunner/agents/opencode/supervisor.py
+++ b/src/codex_autorunner/agents/opencode/supervisor.py
@@ -373,6 +373,13 @@ class OpenCodeSupervisor:
         workspace_root: Path,
         agent_id: str,
         model: Optional[str] = None,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        mode: Optional[str] = None,
+        permission: Optional[dict[str, object]] = None,
+        steps: Optional[int] = None,
+        body: Optional[str] = None,
     ) -> None:
         """Ensure subagent agent config file exists with correct model.
 
@@ -392,8 +399,12 @@ class OpenCodeSupervisor:
             workspace_root=workspace_root,
             agent_id=agent_id,
             model=model,
-            title=agent_id,
-            description=f"Subagent for {agent_id} tasks",
+            title=title or agent_id,
+            description=description or f"Subagent for {agent_id} tasks",
+            mode=mode,
+            permission=permission,
+            steps=steps,
+            body=body,
         )
 
     async def _close_handle(self, handle: OpenCodeHandle, *, reason: str) -> None:

--- a/src/codex_autorunner/core/config_defaults.py
+++ b/src/codex_autorunner/core/config_defaults.py
@@ -25,7 +25,7 @@ def _default_agents_section() -> Dict[str, Any]:
         "opencode": {
             "binary": "opencode",
             "subagent_models": {
-                "subagent": "zai-coding-plan/glm-4.7-flashx",
+                "car-read-explore": "zai-coding-plan/glm-5.1",
             },
         },
         "hermes": {
@@ -498,8 +498,8 @@ DEFAULT_REPO_CONFIG: Dict[str, Any] = {
         "enabled": True,
         "agent": "opencode",
         "model": "zai-coding-plan/glm-5.1",
-        "subagent_agent": "subagent",
-        "subagent_model": "zai-coding-plan/glm-4.7-flashx",
+        "subagent_agent": "car-read-explore",
+        "subagent_model": "zai-coding-plan/glm-5.1",
         "reasoning": None,
         "max_wallclock_seconds": None,
     },

--- a/src/codex_autorunner/flows/review/service.py
+++ b/src/codex_autorunner/flows/review/service.py
@@ -52,6 +52,7 @@ OPENCODE_REVIEW_READ_PERMISSION: dict[str, object] = {
     "edit": "deny",
     "write": "deny",
     "bash": "deny",
+    "task": "deny",
     "todowrite": "deny",
 }
 REVIEW_PROMPT = """# Multi-Agent Code Review Prompt (Coordinator + Subagents)

--- a/src/codex_autorunner/flows/review/service.py
+++ b/src/codex_autorunner/flows/review/service.py
@@ -46,6 +46,14 @@ from .models import (
 REVIEW_STATE_VERSION = 1
 REVIEW_TIMEOUT_SECONDS = 3600
 REVIEW_INTERRUPT_GRACE_SECONDS = 10
+OPENCODE_REVIEW_COORDINATOR_AGENT = "car-review-coordinator"
+OPENCODE_REVIEW_READ_SUBAGENT = "car-read-explore"
+OPENCODE_REVIEW_READ_PERMISSION: dict[str, object] = {
+    "edit": "deny",
+    "write": "deny",
+    "bash": "deny",
+    "todowrite": "deny",
+}
 REVIEW_PROMPT = """# Multi-Agent Code Review Prompt (Coordinator + Subagents)
 
 You are coordinating a multi-agent, high-signal code review.
@@ -145,9 +153,10 @@ For each bucket:
 
 For each bucket, launch a subagent using the template below.
 
-**IMPORTANT**: Use the "subagent" agent type. Do NOT specify model in the prompt.
-- The subagent agent is pre-configured with GLM-4.7-FlashX
-- This avoids concurrency throttling while maintaining full GLM-4.7 for the coordinator
+**IMPORTANT**: Use only the configured read-only subagent agent type. Do NOT specify model in the prompt.
+- The subagent agent is pre-configured by CAR for read-only exploration
+- Do not ask subagents to write files, edit code, run shell commands, or commit changes
+- This keeps Task tool work isolated to analysis while the coordinator owns report writing
 
 Subagent prompt template:
 
@@ -214,7 +223,10 @@ Then:
 
 ### 5) Launch 2–3 Independent Pruning Agents
 
-Each pruning agent must read `{{scratchpad_dir}}/FINDINGS_RAW.md` first, then produce a pruned list.
+Each pruning agent must use the configured read-only subagent agent type. It must
+read `{{scratchpad_dir}}/FINDINGS_RAW.md` first, then produce a pruned list.
+Do not ask pruning agents to write files directly; the coordinator records their
+outputs.
 
 Pruning criteria:
 
@@ -314,12 +326,14 @@ Prepare scratchpad files under {{scratchpad_dir}} (see list above).
 
 ## Phase 2: Parallel Bucket Reviews (Subagents)
 
-Launch subagents by review dimension:
+Launch read-only subagents by review dimension:
 * Spec compliance agent: requirement → evidence mapping.
 * Risk & regression agent: likely failure modes introduced by recent changes.
 * Optional: Test adequacy agent if tests are in-scope.
 
-Each subagent must read AUTORUNNER_CONTEXT.md and BUCKETS.md first and write findings back to the scratchpad.
+Each subagent must read AUTORUNNER_CONTEXT.md and BUCKETS.md first and return
+findings to the coordinator. Do not ask subagents to edit code, write files, run
+shell commands, or commit changes.
 
 ## Phase 3: Aggregate (Coordinator)
 
@@ -327,7 +341,10 @@ Collect subagent outputs into FINDINGS_RAW.md. Deduplicate and normalize to the 
 
 ## Phase 4: Prune (Independent Agents)
 
-Run 2–3 pruning passes (PRUNE_A.md, PRUNE_B.md, optional PRUNE_C.md) to drop speculative or low-impact items. Keep credible security issues, regressions, data loss/corruption risks, and systemic failures.
+Run 2–3 read-only pruning passes (PRUNE_A.md, PRUNE_B.md, optional PRUNE_C.md)
+to drop speculative or low-impact items. Keep credible security issues,
+regressions, data loss/corruption risks, and systemic failures. The coordinator
+writes the pruning outputs.
 
 ## Phase 5: Final Synthesis (Coordinator)
 
@@ -922,17 +939,54 @@ class ReviewService:
             repo_config = self._repo_config()
             review_cfg = repo_config.raw.get("review") or {}
 
-            subagent_agent_id = review_cfg.get("subagent_agent")
-            subagent_model = review_cfg.get("subagent_model")
+            subagent_agent_id = (
+                review_cfg.get("subagent_agent") or OPENCODE_REVIEW_READ_SUBAGENT
+            )
+            subagent_model = review_cfg.get("subagent_model") or state.model
+            coordinator_agent_id = (
+                review_cfg.get("coordinator_agent") or OPENCODE_REVIEW_COORDINATOR_AGENT
+            )
+            coordinator_model = state.model
             if subagent_agent_id:
                 await self._opencode_supervisor.ensure_subagent_config(
                     workspace_root=self.ctx.repo_root,
                     agent_id=subagent_agent_id,
                     model=subagent_model,
+                    title="CAR read-only review explorer",
+                    description="Read-only CAR review subagent",
+                    mode="subagent",
+                    permission=OPENCODE_REVIEW_READ_PERMISSION,
+                    body=(
+                        "Read repository files and return findings to the coordinator. "
+                        "Do not edit files, write scratchpad artifacts, run shell commands, "
+                        "or commit changes.\n"
+                    ),
                 )
+            runtime_agent_id = agent_id
+            if coordinator_agent_id and coordinator_model:
+                await self._opencode_supervisor.ensure_subagent_config(
+                    workspace_root=self.ctx.repo_root,
+                    agent_id=coordinator_agent_id,
+                    model=coordinator_model,
+                    title="CAR review coordinator",
+                    description="CAR OpenCode review coordinator",
+                    mode="primary",
+                    permission={
+                        "task": {
+                            "*": "deny",
+                            str(subagent_agent_id): "allow",
+                        }
+                    },
+                    body=(
+                        "Coordinate CAR review work. Use Task only for configured "
+                        "read-only review subagents; keep writing and synthesis in the "
+                        "coordinator session.\n"
+                    ),
+                )
+                runtime_agent_id = coordinator_agent_id
 
             config = OpenCodeRunConfig(
-                agent=agent_id,
+                agent=runtime_agent_id,
                 model=state.model,
                 reasoning=state.reasoning,
                 prompt=prompt,

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -9,7 +9,7 @@
     "opencode": {
       "binary": "opencode",
       "subagent_models": {
-        "subagent": "zai-coding-plan/glm-4.7-flashx"
+        "car-read-explore": "zai-coding-plan/glm-5.1"
       }
     }
   },
@@ -394,8 +394,8 @@
       "max_wallclock_seconds": null,
       "model": "zai-coding-plan/glm-5.1",
       "reasoning": null,
-      "subagent_agent": "subagent",
-      "subagent_model": "zai-coding-plan/glm-4.7-flashx"
+      "subagent_agent": "car-read-explore",
+      "subagent_model": "zai-coding-plan/glm-5.1"
     },
     "runner": {
       "max_wallclock_seconds": null,

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -9,7 +9,7 @@
     "opencode": {
       "binary": "opencode",
       "subagent_models": {
-        "subagent": "zai-coding-plan/glm-4.7-flashx"
+        "car-read-explore": "zai-coding-plan/glm-5.1"
       }
     }
   },
@@ -305,8 +305,8 @@
     "max_wallclock_seconds": null,
     "model": "zai-coding-plan/glm-5.1",
     "reasoning": null,
-    "subagent_agent": "subagent",
-    "subagent_model": "zai-coding-plan/glm-4.7-flashx"
+    "subagent_agent": "car-read-explore",
+    "subagent_model": "zai-coding-plan/glm-5.1"
   },
   "runner": {
     "max_wallclock_seconds": null,

--- a/tests/test_opencode_agent_config.py
+++ b/tests/test_opencode_agent_config.py
@@ -15,17 +15,36 @@ def test_build_agent_md():
     """Test agent markdown generation with frontmatter."""
     result = _build_agent_md(
         agent_id="subagent",
-        model="zai-coding-plan/glm-4.7-flashx",
+        model="zai-coding-plan/glm-5.1",
         title="Subagent",
         description="Subagent for subagent tasks",
     )
 
     assert result.startswith("---")
     assert "agent: subagent" in result
-    assert 'title: "Subagent"' in result
+    assert "title: Subagent" in result
     assert 'description: "Subagent for subagent tasks"' in result
-    assert "model: zai-coding-plan/glm-4.7-flashx" in result
+    assert "model: zai-coding-plan/glm-5.1" in result
     assert result.endswith("---\n")
+
+
+def test_build_agent_md_with_permissions_and_body():
+    """Test richer OpenCode frontmatter used by CAR review agents."""
+    result = _build_agent_md(
+        agent_id="car-review-coordinator",
+        model="zai-coding-plan/glm-5.1",
+        title="CAR review coordinator",
+        description="CAR OpenCode review coordinator",
+        mode="primary",
+        permission={"task": {"*": "deny", "car-read-explore": "allow"}},
+        body="Use only read-only subagents.\n",
+        car_managed=True,
+    )
+
+    assert "mode: primary" in result
+    assert "car_managed: codex-autorunner" in result
+    assert 'permission:\n  task:\n    "*": deny\n    car-read-explore: allow' in result
+    assert result.endswith("Use only read-only subagents.\n")
 
 
 def test_extract_model_from_frontmatter():
@@ -34,12 +53,12 @@ def test_extract_model_from_frontmatter():
 agent: subagent
 title: "Subagent"
 description: "Subagent for subagent tasks"
-model: zai-coding-plan/glm-4.7-flashx
+model: zai-coding-plan/glm-5.1
 ---
 Some content here
 """
     result = _extract_model_from_frontmatter(content)
-    assert result == "zai-coding-plan/glm-4.7-flashx"
+    assert result == "zai-coding-plan/glm-5.1"
 
 
 def test_extract_model_from_frontmatter_no_model():
@@ -74,7 +93,7 @@ async def test_ensure_agent_config_creates_file(tmp_path: Path):
     await ensure_agent_config(
         workspace_root=tmp_path,
         agent_id="subagent",
-        model="zai-coding-plan/glm-4.7-flashx",
+        model="zai-coding-plan/glm-5.1",
         title="Subagent",
         description="Subagent for subagent tasks",
     )
@@ -84,7 +103,7 @@ async def test_ensure_agent_config_creates_file(tmp_path: Path):
 
     content = agent_file.read_text(encoding="utf-8")
     assert "agent: subagent" in content
-    assert "model: zai-coding-plan/glm-4.7-flashx" in content
+    assert "model: zai-coding-plan/glm-5.1" in content
 
 
 @pytest.mark.anyio
@@ -114,7 +133,7 @@ async def test_ensure_agent_config_skips_if_model_unchanged(tmp_path: Path):
 agent: subagent
 title: "Subagent"
 description: "Subagent for subagent tasks"
-model: zai-coding-plan/glm-4.7-flashx
+model: zai-coding-plan/glm-5.1
 ---
 """
     agent_file.write_text(existing_content, encoding="utf-8")
@@ -122,7 +141,7 @@ model: zai-coding-plan/glm-4.7-flashx
     await ensure_agent_config(
         workspace_root=tmp_path,
         agent_id="subagent",
-        model="zai-coding-plan/glm-4.7-flashx",
+        model="zai-coding-plan/glm-5.1",
         title="Subagent",
         description="Subagent for subagent tasks",
     )
@@ -150,14 +169,107 @@ model: zai-coding-plan/glm-4.7
     await ensure_agent_config(
         workspace_root=tmp_path,
         agent_id="subagent",
-        model="zai-coding-plan/glm-4.7-flashx",
+        model="zai-coding-plan/glm-5.1",
         title="Subagent",
         description="Subagent for subagent tasks",
     )
 
     content = agent_file.read_text(encoding="utf-8")
-    assert "model: zai-coding-plan/glm-4.7-flashx" in content
-    assert content.count("model: zai-coding-plan/glm-4.7-flashx") == 1
+    assert "model: zai-coding-plan/glm-5.1" in content
+    assert content.count("model: zai-coding-plan/glm-5.1") == 1
+
+
+@pytest.mark.anyio
+async def test_ensure_agent_config_does_not_overwrite_user_authored_agent(
+    tmp_path: Path,
+):
+    agent_dir = tmp_path / ".opencode" / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    agent_file = agent_dir / "subagent.md"
+
+    existing_content = """---
+agent: subagent
+title: "User Subagent"
+model: user/model
+permission:
+  bash: allow
+---
+User-written body.
+"""
+    agent_file.write_text(existing_content, encoding="utf-8")
+
+    await ensure_agent_config(
+        workspace_root=tmp_path,
+        agent_id="subagent",
+        model="zai-coding-plan/glm-5.1",
+        mode="subagent",
+        permission={"bash": "deny"},
+    )
+
+    assert agent_file.read_text(encoding="utf-8") == existing_content
+
+
+@pytest.mark.anyio
+async def test_ensure_agent_config_does_not_treat_any_minimal_agent_as_legacy(
+    tmp_path: Path,
+):
+    agent_dir = tmp_path / ".opencode" / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    agent_file = agent_dir / "subagent.md"
+
+    existing_content = """---
+agent: subagent
+title: "User Subagent"
+model: user/model
+---
+"""
+    agent_file.write_text(existing_content, encoding="utf-8")
+
+    await ensure_agent_config(
+        workspace_root=tmp_path,
+        agent_id="subagent",
+        model="new/model",
+        mode="subagent",
+        permission={"bash": "deny"},
+    )
+
+    assert agent_file.read_text(encoding="utf-8") == existing_content
+
+
+@pytest.mark.anyio
+async def test_ensure_agent_config_migrates_legacy_car_generated_agent(
+    tmp_path: Path,
+):
+    agent_dir = tmp_path / ".opencode" / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    agent_file = agent_dir / "subagent.md"
+
+    agent_file.write_text(
+        """---
+agent: subagent
+title: "Subagent"
+description: "Subagent for subagent tasks"
+model: old/model
+---
+""",
+        encoding="utf-8",
+    )
+
+    await ensure_agent_config(
+        workspace_root=tmp_path,
+        agent_id="subagent",
+        model="new/model",
+        mode="subagent",
+        permission={"edit": "deny", "bash": "deny"},
+        body="Read-only.\n",
+    )
+
+    content = agent_file.read_text(encoding="utf-8")
+    assert "model: new/model" in content
+    assert "mode: subagent" in content
+    assert "car_managed: codex-autorunner" in content
+    assert "edit: deny" in content
+    assert content.endswith("Read-only.\n")
 
 
 def test_supervisor_ensure_subagent_config():
@@ -165,12 +277,12 @@ def test_supervisor_ensure_subagent_config():
     supervisor = OpenCodeSupervisor(
         command=["opencode", "serve"],
         subagent_models={
-            "subagent": "zai-coding-plan/glm-4.7-flashx",
+            "subagent": "zai-coding-plan/glm-5.1",
             "other": "zai-coding-plan/glm-4.7",
         },
     )
 
     assert supervisor._subagent_models == {
-        "subagent": "zai-coding-plan/glm-4.7-flashx",
+        "subagent": "zai-coding-plan/glm-5.1",
         "other": "zai-coding-plan/glm-4.7",
     }

--- a/tests/test_opencode_run_prompt.py
+++ b/tests/test_opencode_run_prompt.py
@@ -16,6 +16,7 @@ class _ClientStub:
     def __init__(self, session_id: str) -> None:
         self._session_id = session_id
         self.dispose_calls: list[str] = []
+        self.prompt_calls: list[dict[str, Any]] = []
 
     async def create_session(
         self, *, directory: Optional[str] = None
@@ -24,6 +25,7 @@ class _ClientStub:
         return {"sessionId": self._session_id}
 
     async def prompt_async(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.prompt_calls.append(dict(_kwargs))
         return {}
 
     async def abort(self, _session_id: str) -> None:
@@ -93,6 +95,7 @@ async def test_run_opencode_prompt_disposes_temporary_session_after_completion(
     assert result.turn_id == "session-1:turn"
     assert result.output_text == "done"
     assert client.dispose_calls == ["session-1"]
+    assert client.prompt_calls[0].get("agent") is None
     assert supervisor.started == [tmp_path]
     assert supervisor.finished == [tmp_path]
 
@@ -140,6 +143,42 @@ async def test_run_opencode_prompt_restarts_after_empty_pre_prompt_stream(
     assert client.dispose_calls == ["session-late-output"]
     assert supervisor.started == [tmp_path]
     assert supervisor.finished == [tmp_path]
+
+
+@pytest.mark.anyio
+async def test_run_opencode_prompt_passes_runtime_agent_when_configured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from codex_autorunner.agents.opencode import run_prompt as run_prompt_module
+
+    client = _ClientStub("session-agent")
+    supervisor = _SupervisorStub(client)
+
+    async def _fake_collect(*_args: Any, **_kwargs: Any) -> OpenCodeTurnOutput:
+        ready_event = _kwargs.get("ready_event")
+        if ready_event is not None:
+            ready_event.set()
+        return OpenCodeTurnOutput(text="done")
+
+    async def _fake_missing_env(*_args: Any, **_kwargs: Any) -> list[str]:
+        return []
+
+    monkeypatch.setattr(run_prompt_module, "collect_opencode_output", _fake_collect)
+    monkeypatch.setattr(run_prompt_module, "opencode_missing_env", _fake_missing_env)
+
+    await run_opencode_prompt(
+        supervisor,  # type: ignore[arg-type]
+        OpenCodeRunConfig(
+            agent="car-review-coordinator",
+            model=None,
+            reasoning=None,
+            prompt="hello",
+            workspace_root=str(tmp_path),
+            timeout_seconds=5,
+        ),
+    )
+
+    assert client.prompt_calls[0].get("agent") == "car-review-coordinator"
 
 
 @pytest.mark.anyio

--- a/tests/test_opencode_supervisor_factory.py
+++ b/tests/test_opencode_supervisor_factory.py
@@ -80,7 +80,11 @@ def test_build_opencode_supervisor_from_repo_config(
     assert captured["session_stall_timeout_seconds"] == 55
     assert captured["max_text_chars"] == 9999
     assert captured["base_env"] is env
-    assert captured["subagent_models"] == {"subagent": "model-x", "helper": "model-y"}
+    assert captured["subagent_models"] == {
+        "car-read-explore": "zai-coding-plan/glm-5.1",
+        "subagent": "model-x",
+        "helper": "model-y",
+    }
 
 
 def test_build_opencode_supervisor_from_repo_config_wraps_for_docker_destination(

--- a/tests/test_review_service.py
+++ b/tests/test_review_service.py
@@ -45,6 +45,10 @@ def test_review_module_imports() -> None:
     assert ReviewStatus is not None
 
 
+def test_opencode_read_review_subagent_denies_nested_task() -> None:
+    assert review_service_module.OPENCODE_REVIEW_READ_PERMISSION["task"] == "deny"
+
+
 def test_review_status_recovers_interrupted_state(repo) -> None:
     service = _build_service(repo)
     service._save_state(

--- a/tests/test_telegram_review_opencode.py
+++ b/tests/test_telegram_review_opencode.py
@@ -508,6 +508,7 @@ async def test_telegram_review_opencode_tracks_thinking_and_tool_progress_via_ha
     monkeypatch.setattr(
         github_commands, "opencode_missing_env", _fake_opencode_missing_env
     )
+    start_review_prompts: list[str] = []
 
     class _FakeHarness:
         def __init__(self, _supervisor: object) -> None:
@@ -524,10 +525,10 @@ async def test_telegram_review_opencode_tracks_thinking_and_tool_progress_via_ha
             approval_mode: Optional[str],
             sandbox_policy: Optional[object],
         ) -> SimpleNamespace:
+            start_review_prompts.append(prompt)
             _ = (
                 workspace_root,
                 conversation_id,
-                prompt,
                 model,
                 reasoning,
                 approval_mode,
@@ -615,6 +616,7 @@ async def test_telegram_review_opencode_tracks_thinking_and_tool_progress_via_ha
 
     await handler._handle_review(_message(), "", runtime)
 
+    assert start_review_prompts == ["Review uncommitted changes."]
     assert handler._turn_progress_trackers
     progress_traces = [
         (


### PR DESCRIPTION
## Summary

- generate dedicated CAR-managed OpenCode review coordinator and read-only Task subagent configs
- constrain OpenCode review Task usage to `car-read-explore` and preserve user-authored agent files
- pass configured OpenCode runtime agent IDs through `prompt_async`
- document CAR-specific agent runtime notes and add a real OpenCode policy probe
- switch OpenCode review/subagent defaults to `zai-coding-plan/glm-5.1`, which local dogfood showed is reliable for Task output

Fixes #1987.

## Validation

- final subagent review: no remaining clear PR-blocking issues
- `./scripts/check.sh` passed aggregate lane: `9649 passed`, web UI build/tests passed, chat-apps aggregate checks passed
- `.venv/bin/python scripts/probe_opencode_agent_policy.py` passed with real local OpenCode
- real local OpenCode `1.15.13` dogfood: allowed `car-read-explore` read `README.md` and returned `READ_SUBAGENT_OK`; non-allowlisted `car-write-helper` returned `WRITE_SUBAGENT_DENIED_OK`

## Notes

The first commit attempt saw the hook runner terminate `scripts/check.sh` with SIGTERM before reporting a failure. Running `./scripts/check.sh` directly completed successfully afterward.