### PR TITLE
[codex] Teach PMA to use PR-mode worktrees

### DIFF
--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1137,6 +1137,7 @@ async def _execute_discord_thread_message(
                 prompt_text,
                 hub_root=dispatch.service._config.root,
                 prompt_state_key=dispatch.session_key,
+                user_input_texts=[dispatch.text],
             )
             prompt_text = prompt_variants.new_session_prompt
             existing_session_prompt_text = prompt_variants.existing_session_prompt

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -3319,6 +3319,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         *,
         record: "TelegramTopicRecord",
         message: TelegramMessage,
+        user_input_texts: list[str | None] | None = None,
     ) -> Optional[tuple[str, str]]:
         hub_root = getattr(self, "_hub_root", None)
         if hub_root is None:
@@ -3361,6 +3362,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 message_text,
                 hub_root=hub_root,
                 prompt_state_key=prompt_state_key,
+                user_input_texts=user_input_texts,
             )
             return (
                 prompt_variants.new_session_prompt,
@@ -3614,10 +3616,14 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 user_message_prompt = (
                     f"{pma_context_prefix.strip()}\n\n{user_message_prompt}"
                 )
+            raw_user_input = (
+                text_override if text_override is not None else (message.text or "")
+            )
             pma_prompt_variants = await self._prepare_pma_prompt(
                 user_message_prompt,
                 record=record,
                 message=message,
+                user_input_texts=[raw_user_input],
             )
             if pma_prompt_variants is None:
                 return await self._maybe_send_failure(

--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -306,7 +306,7 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 - Managed threads are the default for straightforward work in one repo: exploratory work, reviews, bug fixes, focused refactors, and single-feature PRs that fit in one clear prompt.
 - Reuse an existing relevant managed thread before spawning a new one.
 - For work that should open a PR, use PR mode instead of a reused thread:
-  `car pma thread spawn --agent codex --repo <base_or_worktree_repo_id> --pr --name <label> --path <hub_root>`.
+  `car pma thread spawn --agent <agent_id> --repo <base_or_worktree_repo_id> --pr --name <label> --path <hub_root>`.
   PR mode resolves hub worktrees back to their upstream/base repo, creates a
   fresh hub-owned worktree from `origin/<default-branch>` (or `--pr-base-ref`),
   runs configured worktree setup commands, and fails instead of falling back to
@@ -318,8 +318,8 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 - For hub-scoped PMA CLI commands, include `--path <hub_root>` so they resolve the
   intended hub config instead of relying on the current working directory.
 - CLI primitives:
-  - `car pma thread spawn --agent codex --repo <repo_id> --name <label> --path <hub_root>`
-  - `car pma thread spawn --agent codex --repo <repo_id> --pr --name <label> --path <hub_root>`
+  - `car pma thread spawn --agent <agent_id> --repo <repo_id> --name <label> --path <hub_root>`
+  - `car pma thread spawn --agent <agent_id> --repo <repo_id> --pr --name <label> --path <hub_root>`
   - `car pma thread send --id <managed_thread_id> --message "..." --path <hub_root>`
   - `car pma thread send --id <managed_thread_id> --message-file prompt.md --path <hub_root>`
   - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>` only when you intentionally want synchronous foreground babysitting
@@ -471,7 +471,7 @@ Canonical worktree creation:
   `car hub worktree create <base_repo_id> <branch> [--start-point <ref>]`
   (defaults to `origin/<default-branch>` when `--start-point` is omitted)
 - PMA PR work:
-  `car pma thread spawn --agent codex --repo <base_or_worktree_repo_id> --pr --path <hub_root>`
+  `car pma thread spawn --agent <agent_id> --repo <base_or_worktree_repo_id> --pr --path <hub_root>`
   creates a fresh PR-isolated worktree from the upstream/base repo and runs the
   base repo's configured worktree setup commands.
 

--- a/src/codex_autorunner/core/context_awareness.py
+++ b/src/codex_autorunner/core/context_awareness.py
@@ -27,7 +27,21 @@ ROLE_ADDENDUM_END = "</role addendum>"
 PROMPT_WRITING_HINT = (
     "If the user asks to write a prompt, put the prompt in a ```code block```."
 )
+WORKTREE_PR_HINT = (
+    "For PMA-managed implementation work that should produce a PR, spawn a "
+    "PR-mode managed thread: "
+    "`car pma thread spawn --agent <agent_id> --repo <repo_id> --pr --name <label> "
+    "--path <hub_root>`. This keeps lifecycle/progress visible and provisions a "
+    "fresh hub-owned worktree from `origin/<default-branch>` by default. Do not "
+    "use raw `git worktree add ... main` for PMA-managed PR work. If a standalone "
+    "hub worktree is explicitly required outside managed-thread creation, use "
+    "`car hub worktree create <base_repo_id> <branch> --path <hub_root>`."
+)
 _PROMPT_CONTEXT_RE = re.compile(r"\bprompt\b", re.IGNORECASE)
+_WORKTREE_PR_CONTEXT_RE = re.compile(
+    r"\b(?:worktree|worktrees|branch|branches|pr|prs|pull\s+request|pull\s+requests)\b",
+    re.IGNORECASE,
+)
 _FILE_CONTEXT_SIGNAL_RE = re.compile(
     r"(?:<file\s+path=|Inbound Discord attachments:|PMA File Inbox:)",
     re.IGNORECASE,
@@ -79,6 +93,47 @@ def maybe_inject_prompt_writing_hint(
         return prompt_text, False
     return append_capsules_to_prompt(
         prompt_text, (build_prompt_writing_capsule(PROMPT_WRITING_HINT),)
+    )
+
+
+def has_user_worktree_pr_hint_request(
+    user_input_texts: Sequence[str | None] | None,
+) -> bool:
+    """Return True when raw user text mentions PR/worktree/branch coordination."""
+    if not user_input_texts:
+        return False
+    for text in user_input_texts:
+        if not isinstance(text, str):
+            continue
+        if _WORKTREE_PR_CONTEXT_RE.search(text):
+            return True
+    return False
+
+
+def maybe_inject_worktree_pr_hint(
+    prompt_text: str,
+    *,
+    hint_text: str = WORKTREE_PR_HINT,
+    user_input_texts: Sequence[str | None] | None = None,
+) -> tuple[str, bool]:
+    """Inject PMA worktree/PR creation guidance only from raw user signals."""
+    if not prompt_text or not prompt_text.strip():
+        return prompt_text, False
+    if "worktree.pr_mode" in prompt_text or "PR-mode managed thread" in prompt_text:
+        return prompt_text, False
+    if not has_user_worktree_pr_hint_request(user_input_texts):
+        return prompt_text, False
+    from .surface_context_capsules import build_model_only_text_capsule
+
+    return append_capsules_to_prompt(
+        prompt_text,
+        (
+            build_model_only_text_capsule(
+                capsule_id="worktree.pr_mode",
+                text=hint_text,
+                reason="worktree_pr_keyword_detected",
+            ),
+        ),
     )
 
 

--- a/src/codex_autorunner/core/pma/queue_prompts.py
+++ b/src/codex_autorunner/core/pma/queue_prompts.py
@@ -86,6 +86,7 @@ def build_queue_execution_prompt(
         hub_root=inputs.hub_root,
         prompt_state_key=inputs.prompt_state_key,
         force_full_base_prompt=force_full_base_prompt,
+        user_input_texts=[inputs.message],
     )
     if inputs.github_context_injector is None:
         return built

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional, cast
 
 from .config_contract import ConfigError
+from .context_awareness import maybe_inject_worktree_pr_hint
 from .hub import HubSupervisor
 from .managed_thread_snapshot import (
     snapshot_managed_threads as _snapshot_managed_threads,
@@ -95,6 +96,10 @@ def format_pma_prompt(
     force_full_context: bool = False,
     force_full_base_prompt: bool = False,
 ) -> str:
+    message, _ = maybe_inject_worktree_pr_hint(
+        message,
+        user_input_texts=[message],
+    )
     limits = PmaPromptRenderLimits.from_snapshot(snapshot)
     snapshot_text = _render_hub_snapshot(
         snapshot,

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, cast
@@ -95,10 +96,11 @@ def format_pma_prompt(
     prompt_state_key: Optional[str] = None,
     force_full_context: bool = False,
     force_full_base_prompt: bool = False,
+    user_input_texts: Sequence[str | None] | None = None,
 ) -> str:
     message, _ = maybe_inject_worktree_pr_hint(
         message,
-        user_input_texts=[message],
+        user_input_texts=user_input_texts,
     )
     limits = PmaPromptRenderLimits.from_snapshot(snapshot)
     snapshot_text = _render_hub_snapshot(
@@ -180,6 +182,7 @@ def format_pma_prompt_variants(
     *,
     prompt_state_key: Optional[str] = None,
     force_full_context: bool = False,
+    user_input_texts: Sequence[str | None] | None = None,
 ) -> PmaPromptVariants:
     """Build prompt variants for fresh-session bootstrap and existing sessions.
 
@@ -196,6 +199,7 @@ def format_pma_prompt_variants(
         hub_root=hub_root,
         prompt_state_key=prompt_state_key,
         force_full_context=force_full_context,
+        user_input_texts=user_input_texts,
     )
     existing_session_prompt = new_session_prompt
     if hub_root is not None and prompt_state_key and not force_full_context:
@@ -205,6 +209,7 @@ def format_pma_prompt_variants(
             message,
             hub_root=hub_root,
             prompt_state_key=prompt_state_key,
+            user_input_texts=user_input_texts,
         )
     return PmaPromptVariants(
         new_session_prompt=new_session_prompt,

--- a/src/codex_autorunner/core/pma_prompt_builder.py
+++ b/src/codex_autorunner/core/pma_prompt_builder.py
@@ -59,13 +59,16 @@ First-turn routine:
     - For hub-scoped PMA CLI commands, include `--path <hub_root>` so they resolve the intended hub config instead of relying on the current working directory.
     - Do not launch runtime CLIs directly (`codex`, `opencode`, etc.) for PMA-managed work when a managed thread fits. Use CAR managed threads so lifecycle, progress, subscriptions, and wake-ups stay visible to PMA.
     - If no suitable thread exists, spawn one, run work, and keep it compact:
-      - `car pma thread spawn --agent codex --repo <repo_id> --name <label> --path <hub_root>`
+      - Exploratory or non-PR work: `car pma thread spawn --agent <agent_id> --repo <repo_id> --name <label> --path <hub_root>`
+      - Implementation work that should produce a PR: `car pma thread spawn --agent <agent_id> --repo <repo_id> --pr --name <label> --path <hub_root>`
       - `car pma thread send --id <managed_thread_id> --message "..." --path <hub_root>`
       - `car pma thread send --id <managed_thread_id> --message-file prompt.md --path <hub_root>`
       - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>` only when you intentionally want synchronous foreground babysitting
       - `car pma thread status --id <managed_thread_id> --path <hub_root>`
       - `car pma thread compact --id <id> --summary "..." --path <hub_root>`
       - `car pma thread retire --id <id> --path <hub_root>`
+    - PR mode creates a fresh hub-owned worktree from `origin/<default-branch>` by default, runs configured worktree setup commands, and keeps lifecycle/progress/subscriptions visible to PMA.
+    - Do not use raw `git worktree add ... main` for PMA-managed PR work. If a standalone hub worktree is explicitly required outside managed-thread creation, use `car hub worktree create <base_repo_id> <branch> --path <hub_root>`.
     - Do not write ticket files as scaffolding for managed-thread work. If the task fits in one clear prompt, stay in a managed thread.
     - Use tickets/ticket_flow when the work needs ordered multi-step structure: cross-repo changes, 3+ planned tickets, explicit acceptance-criteria tracking, or pause/resume/review handoffs.
 4) BRANCH C - PMA File Inbox (fresh uploads vs stale leftovers):

--- a/src/codex_autorunner/docs/managed-threads.md
+++ b/src/codex_autorunner/docs/managed-threads.md
@@ -6,7 +6,8 @@ Default to managed threads for work that fits in one clear prompt and one manage
 
 Common operations:
 
-- Spawn: `car pma thread spawn --agent codex --repo <repo_id> --path <hub_root>`
+- Spawn exploratory or non-PR work: `car pma thread spawn --agent <agent_id> --repo <repo_id> --path <hub_root>`
+- Spawn implementation work that should produce a PR: `car pma thread spawn --agent <agent_id> --repo <repo_id> --pr --path <hub_root>`
 - Send: `car pma thread send --id <thread_id> --message "..." --path <hub_root>`
 - Watch intentionally: `car pma thread send --id <thread_id> --message "..." --watch --path <hub_root>`
 - Status: `car pma thread status --id <thread_id> --path <hub_root>`
@@ -14,6 +15,9 @@ Common operations:
 - Retire: `car pma thread retire --id <thread_id> --path <hub_root>`
 
 Reuse a relevant active managed thread before spawning a new one.
+
+PR mode creates a fresh hub-owned worktree from `origin/<default-branch>` by
+default and keeps lifecycle, progress, and subscriptions visible to PMA.
 
 ## Bound Chat Generations
 

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -503,6 +503,42 @@ def test_format_pma_prompt_load_failure_still_includes_fastpath(
     assert "<pma_fastpath>" in result
 
 
+def test_format_pma_prompt_fastpath_prefers_pr_mode_managed_threads(
+    tmp_path: Path,
+) -> None:
+    result = _format_seeded_pma_prompt(tmp_path)
+
+    assert (
+        "car pma thread spawn --agent <agent_id> --repo <repo_id> --pr "
+        "--name <label> --path <hub_root>"
+    ) in result
+    assert "origin/<default-branch>" in result
+    assert "Do not use raw `git worktree add ... main`" in result
+    assert "car pma thread spawn --agent codex" not in result
+
+
+def test_format_pma_prompt_injects_worktree_pr_hint_from_user_message(
+    tmp_path: Path,
+) -> None:
+    result = _format_seeded_pma_prompt(
+        tmp_path,
+        message="Please create a worktree and open a PR for this fix.",
+    )
+
+    assert "car pma thread spawn --agent <agent_id>" in result
+    assert "car hub worktree create <base_repo_id> <branch> --path <hub_root>" in result
+    assert "Do not use raw `git worktree add ... main`" in result
+    assert result.count("car hub worktree create <base_repo_id> <branch>") == 2
+
+
+def test_format_pma_prompt_does_not_inject_worktree_pr_hint_without_user_signal(
+    tmp_path: Path,
+) -> None:
+    result = _format_seeded_pma_prompt(tmp_path, message="Please summarize status.")
+
+    assert result.count("car hub worktree create <base_repo_id> <branch>") == 1
+
+
 def test_truncation_applied_to_long_agents(tmp_path: Path) -> None:
     """Test that long AGENTS.md content is truncated."""
     seed_hub_files(tmp_path, force=True)

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -111,6 +111,7 @@ def _format_seeded_pma_prompt(
         _STUB_SNAPSHOT if snapshot is None else snapshot,
         message,
         hub_root=hub_root if include_workspace_docs else None,
+        user_input_texts=[message],
         **prompt_kwargs,
     )
 

--- a/tests/test_context_awareness.py
+++ b/tests/test_context_awareness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from codex_autorunner.core.context_awareness import (
     CAR_AWARENESS_BLOCK,
     maybe_inject_filebox_hint,
+    maybe_inject_worktree_pr_hint,
 )
 
 
@@ -21,6 +22,28 @@ def test_filebox_hint_not_injected_from_car_context_keyword_only() -> None:
     prompt, injected = maybe_inject_filebox_hint(
         CAR_AWARENESS_BLOCK,
         hint_text="<injected context>\nInbox: /tmp/inbox\n</injected context>",
+    )
+
+    assert injected is False
+    assert prompt == CAR_AWARENESS_BLOCK
+
+
+def test_worktree_pr_hint_injected_for_raw_user_keyword() -> None:
+    prompt, injected = maybe_inject_worktree_pr_hint(
+        "please create a worktree for this PR",
+        user_input_texts=["please create a worktree for this PR"],
+    )
+
+    assert injected is True
+    assert "car pma thread spawn --agent <agent_id>" in prompt
+    assert "--pr --name <label> --path <hub_root>" in prompt
+    assert "git worktree add ... main" in prompt
+
+
+def test_worktree_pr_hint_not_injected_from_existing_context_only() -> None:
+    prompt, injected = maybe_inject_worktree_pr_hint(
+        CAR_AWARENESS_BLOCK,
+        user_input_texts=["please summarize"],
     )
 
     assert injected is False


### PR DESCRIPTION
## Summary
- Teach PMA fastpath and generated docs to prefer PR-mode managed threads for implementation work that should produce a PR.
- Add a raw-user-keyword JIT worktree/PR context capsule that points PMA to `car pma thread spawn --agent <agent_id> --repo <repo_id> --pr ...` and away from raw `git worktree add ... main`.
- Cover the fastpath and JIT injection/non-injection paths with focused tests.

Fixes #1990.

## Validation
- `.venv/bin/python -m pytest -q tests/test_context_awareness.py tests/pma_context_support.py -q`
- `.venv/bin/python -m ruff check src/codex_autorunner/core/context_awareness.py src/codex_autorunner/core/pma_context.py tests/test_context_awareness.py tests/pma_context_support.py`
- pre-commit aggregate lane: guardrails, ruff, mypy, 9652 pytest tests, Web UI lab/lint/build/tests, SPA shell check

## Review
- Subagent reviewer found no issues.