### PR TITLE
[codex] Extend detail route URL projection

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
@@ -39,6 +39,23 @@ describe('read model loaders', () => {
     expect(client.chatIndex).not.toHaveBeenCalled();
   });
 
+  it('returns cached data immediately and refreshes in the background when requested non-blocking', async () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot(chatIndexSnapshot());
+    const client = mockClient({
+      chatIndex: vi.fn().mockResolvedValue(ok(chatIndexSnapshot([chatIndexRow('chat-2', 'Fresh Chat')])))
+    });
+    const { ensureChatIndexLoaded } = await importLoaders(true);
+
+    const result = await ensureChatIndexLoaded({}, { store, client, blocking: false, refresh: true });
+
+    expect(result).toEqual({ status: 'cache-hit', tags: ['entity:chat:index'] });
+    expect(client.chatIndex).toHaveBeenCalledWith({});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(store.snapshot().chats['chat-2']?.title).toBe('Fresh Chat');
+  });
+
   it('fetches a cache miss through the snapshot client and hydrates the store', async () => {
     const store = new ReadModelEntityStore();
     const snapshot = chatDetailSnapshot('chat-1');
@@ -268,7 +285,7 @@ function cursor(sequence: number, source = 'test'): ProjectionCursor {
   return { value: `${source}:${sequence}`, sequence, source, issuedAt: now };
 }
 
-function chatIndexSnapshot(): ChatIndexSnapshot {
+function chatIndexSnapshot(rows: ChatIndexSnapshot['rows'] = [chatIndexRow('chat-1', 'Chat One')]): ChatIndexSnapshot {
   return {
     contractVersion: READ_MODEL_CONTRACT_VERSION,
     kind: 'chat.index.snapshot',
@@ -277,26 +294,30 @@ function chatIndexSnapshot(): ChatIndexSnapshot {
     filter: 'all',
     query: null,
     facetRequest: emptyFacetRequest,
-    rows: [{
-      chatId: 'chat-1',
-      surface: 'pma',
-      title: 'Chat One',
-      status: 'idle',
-      unreadCount: 0,
-      lastActivityAt: now,
-      repoId: 'repo-1',
-      worktreeId: null,
-      ticketId: null,
-      runId: null,
-      agent: 'codex',
-      chatKind: 'pma',
-      model: 'gpt-5.5',
-      groupId: null
-    }],
+    rows,
     groups: [],
     counters: { total: 1, waiting: 0, running: 0, unread: 0, archived: 0 },
     facetCounts: emptyFacetCounts,
     repair: repair('/hub/read-models/chats')
+  };
+}
+
+function chatIndexRow(chatId: string, title: string): ChatIndexSnapshot['rows'][number] {
+  return {
+    chatId,
+    surface: 'pma',
+    title,
+    status: 'idle',
+    unreadCount: 0,
+    lastActivityAt: now,
+    repoId: 'repo-1',
+    worktreeId: null,
+    ticketId: null,
+    runId: null,
+    agent: 'codex',
+    chatKind: 'pma',
+    model: 'gpt-5.5',
+    groupId: null
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
@@ -240,9 +240,16 @@ async function ensureSnapshotLoaded({
   const state = store.snapshot();
   const cached = isCached(state);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
-  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
+  if (options.blocking === false) {
+    if (cached) {
+      void fetchAndApply(client, store).catch(() => undefined);
+      return { status: 'cache-hit', tags };
+    }
+    return { status: 'cold', tags };
+  }
+
   const result = await fetchAndApply(client, store);
   if (!result.ok) return { status: 'error', tags, error: result.error };
   return { status: 'fetched', tags };

--- a/src/codex_autorunner/web_frontend/src/lib/routes/chatUrlProjection.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/chatUrlProjection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  pushChatDetailProjection,
+  replaceChatDetailProjection,
+  replaceChatListFiltersProjection
+} from './chatUrlProjection';
+import type { ChatListFilters } from './chatListFiltersUrl';
+
+const filters: ChatListFilters = {
+  status: 'waiting',
+  category: 'ticket_run',
+  transport: null,
+  scopeKind: null,
+  search: 'queue'
+};
+
+describe('chatUrlProjection', () => {
+  it('projects chat list filters with replaceState instead of navigation', () => {
+    const history = mockHistory();
+
+    const target = replaceChatListFiltersProjection(filters, {
+      chatId: 'chat-1',
+      url: new URL('http://localhost/chats/chat-1?tab=activity&draft=old'),
+      history,
+      withHref: (path) => `/base${path}`
+    });
+
+    expect(target).toBe('/base/chats/chat-1?tab=activity&filter=waiting&search=queue&category=ticket_run');
+    expect(history.replaceState).toHaveBeenCalledWith({ preserved: true }, '', target);
+    expect(history.pushState).not.toHaveBeenCalled();
+  });
+
+  it('strips transient detail hooks when replacing or pushing committed chat detail URLs', () => {
+    const history = mockHistory();
+    const url = new URL('http://localhost/chats?chat=old&detail=chat%3Aold&draft=x&new=agent&kind=agent&tab=activity');
+
+    expect(replaceChatDetailProjection('chat-2', { url, history, withHref: (path) => path })).toBe(
+      '/chats/chat-2?tab=activity'
+    );
+    expect(pushChatDetailProjection('chat-3', { url, history, withHref: (path) => path })).toBe(
+      '/chats/chat-3?tab=activity'
+    );
+    expect(history.replaceState).toHaveBeenCalledWith({ preserved: true }, '', '/chats/chat-2?tab=activity');
+    expect(history.pushState).toHaveBeenCalledWith({ preserved: true }, '', '/chats/chat-3?tab=activity');
+  });
+});
+
+function mockHistory(): Pick<History, 'pushState' | 'replaceState' | 'state'> {
+  return {
+    state: { preserved: true },
+    pushState: vi.fn(),
+    replaceState: vi.fn()
+  };
+}

--- a/src/codex_autorunner/web_frontend/src/lib/routes/chatUrlProjection.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/chatUrlProjection.ts
@@ -1,0 +1,68 @@
+import { withRuntimeBasePath as defaultHref } from '$lib/runtime/basePath';
+import { chatRoute } from '$lib/viewModels/routes';
+import {
+  buildChatsListHref,
+  type ChatListFilters
+} from './chatListFiltersUrl';
+
+export type ChatUrlProjectionRuntime = {
+  url?: URL;
+  history?: Pick<History, 'pushState' | 'replaceState' | 'state'>;
+  withHref?: (path: string) => string;
+};
+
+const CHAT_DETAIL_QUERY_KEYS = ['chat', 'detail', 'draft', 'new', 'kind'] as const;
+
+export function replaceChatListFiltersProjection(
+  filters: ChatListFilters,
+  options: ChatUrlProjectionRuntime & { chatId?: string | null } = {}
+): string {
+  const target = buildChatsListHref(filters, {
+    chatId: options.chatId ?? null,
+    preserveParams: currentProjectionUrl(options).searchParams,
+    withHref: options.withHref ?? defaultHref
+  });
+  replaceProjectionUrl(target, options);
+  return target;
+}
+
+export function replaceChatDetailProjection(
+  detailId: string,
+  options: ChatUrlProjectionRuntime = {}
+): string {
+  const target = buildChatDetailProjectionTarget(detailId, options);
+  replaceProjectionUrl(target, options);
+  return target;
+}
+
+export function pushChatDetailProjection(
+  detailId: string,
+  options: ChatUrlProjectionRuntime = {}
+): string {
+  const target = buildChatDetailProjectionTarget(detailId, options);
+  const history = options.history ?? browserHistory();
+  history?.pushState(history.state, '', target);
+  return target;
+}
+
+function buildChatDetailProjectionTarget(detailId: string, options: ChatUrlProjectionRuntime): string {
+  const params = new URLSearchParams(currentProjectionUrl(options).searchParams);
+  for (const key of CHAT_DETAIL_QUERY_KEYS) params.delete(key);
+  const raw = chatRoute(detailId, { searchParams: params });
+  return (options.withHref ?? defaultHref)(raw);
+}
+
+function replaceProjectionUrl(target: string, options: ChatUrlProjectionRuntime): void {
+  const history = options.history ?? browserHistory();
+  history?.replaceState(history.state, '', target);
+}
+
+function currentProjectionUrl(options: ChatUrlProjectionRuntime): URL {
+  if (options.url) return options.url;
+  if (typeof window !== 'undefined') return new URL(window.location.href);
+  return new URL('http://localhost/chats');
+}
+
+function browserHistory(): ChatUrlProjectionRuntime['history'] {
+  return typeof history !== 'undefined' ? history : undefined;
+}

--- a/src/codex_autorunner/web_frontend/src/lib/routes/loadReadModelRoute.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/loadReadModelRoute.ts
@@ -9,6 +9,7 @@ export function readModelLoaderOptions(options: LoadReadModelRouteOptions): Read
   return {
     ...options.loaderOptions,
     depends: options.depends,
+    refresh: options.loaderOptions?.refresh ?? true,
     blocking: options.loaderOptions?.blocking ?? false
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -215,8 +215,12 @@
    *  declared which scope this chat belongs to. */
   let scopeLocked = $state(false);
   function readChatListFiltersFromRoute(): ChatListFilters {
+    return readChatListFiltersFromUrl(page.url);
+  }
+
+  function readChatListFiltersFromUrl(url: URL): ChatListFilters {
     try {
-      return parseChatListFiltersFromSearchParams(currentBrowserUrl().searchParams);
+      return parseChatListFiltersFromSearchParams(url.searchParams);
     } catch {
       return DEFAULT_CHAT_LIST_FILTERS;
     }
@@ -1101,9 +1105,10 @@
 
   $effect(() => {
     try {
-      const fromUrl = readChatListFiltersFromRoute();
+      const browserUrl = currentBrowserUrl();
+      const fromUrl = readChatListFiltersFromUrl(browserUrl);
       if (chatListFiltersEqual(chatListFilters, fromUrl)) return;
-      replaceChatListFiltersProjection(chatListFilters, { chatId: activeChatId, url: currentBrowserUrl() });
+      replaceChatListFiltersProjection(chatListFilters, { chatId: activeChatId, url: browserUrl });
     } catch {
       // No SvelteKit page context during SSR-only renders.
     }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -216,7 +216,7 @@
   let scopeLocked = $state(false);
   function readChatListFiltersFromRoute(): ChatListFilters {
     try {
-      return parseChatListFiltersFromSearchParams(page.url.searchParams);
+      return parseChatListFiltersFromSearchParams(currentBrowserUrl().searchParams);
     } catch {
       return DEFAULT_CHAT_LIST_FILTERS;
     }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -81,6 +81,11 @@
     type ChatListFilters
   } from '$lib/routes/chatListFiltersUrl';
   import {
+    pushChatDetailProjection,
+    replaceChatDetailProjection,
+    replaceChatListFiltersProjection
+  } from '$lib/routes/chatUrlProjection';
+  import {
     buildChatFilterSummaryChips,
     formatChatListResultSummary,
     selectChatFacetCountsForWindow,
@@ -93,8 +98,7 @@
     repoTicketRoute,
     worktreeContextspaceRoute,
     worktreeRoute,
-    worktreeTicketRoute,
-    chatRoute
+    worktreeTicketRoute
   } from '$lib/viewModels/routes';
   import type {
     ChatSummary,
@@ -1099,11 +1103,7 @@
     try {
       const fromUrl = readChatListFiltersFromRoute();
       if (chatListFiltersEqual(chatListFilters, fromUrl)) return;
-      void goto(chatsHubHref(activeChatId), {
-        replaceState: true,
-        keepFocus: true,
-        noScroll: true
-      });
+      replaceChatListFiltersProjection(chatListFilters, { chatId: activeChatId, url: currentBrowserUrl() });
     } catch {
       // No SvelteKit page context during SSR-only renders.
     }
@@ -1472,10 +1472,7 @@
   }
 
   async function replaceDetailUrl(detailId: string): Promise<void> {
-    const params = new URLSearchParams(page.url.searchParams);
-    for (const key of ['chat', 'detail', 'draft', 'new', 'kind']) params.delete(key);
-    const target = chatRoute(detailId, { searchParams: params });
-    history.replaceState(history.state, '', href(target));
+    replaceChatDetailProjection(detailId, { url: page.url });
   }
 
   async function syncCommittedDetailUrl(detailId: string, options: { mode?: 'push' | 'replace' } = {}): Promise<void> {
@@ -1484,10 +1481,7 @@
       await replaceDetailUrl(detailId);
       return;
     }
-    const params = new URLSearchParams(currentBrowserUrl().searchParams);
-    for (const key of ['chat', 'detail', 'draft', 'new', 'kind']) params.delete(key);
-    const target = chatRoute(detailId, { searchParams: params });
-    history.pushState(history.state, '', href(target));
+    pushChatDetailProjection(detailId, { url: currentBrowserUrl() });
   }
 
   async function refreshActive(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -103,9 +103,21 @@ describe('/chats page', () => {
     )?.[0];
 
     expect(syncCommittedBody).toContain('await replaceDetailUrl(detailId);');
-    expect(source).toContain("history.replaceState(history.state, '', href(target));");
+    expect(source).toContain('replaceChatDetailProjection(detailId');
+    expect(source).toContain('pushChatDetailProjection(detailId');
     expect(syncCommittedBody).not.toContain('goto(');
     expect(syncCommittedBody).not.toContain('pendingCommittedDetailUrlChatId');
+  });
+
+  it('projects chat filter URLs without SvelteKit navigation', () => {
+    const source = chatDetailPageSource();
+    const filterSyncBody = source.match(
+      /\$effect\(\(\) => \{\n    try \{\n      const fromUrl = readChatListFiltersFromRoute[\s\S]*?\n  \}\);/
+    )?.[0];
+
+    expect(filterSyncBody).toBeTruthy();
+    expect(filterSyncBody).toContain('replaceChatListFiltersProjection(chatListFilters');
+    expect(filterSyncBody).not.toContain('goto(');
   });
 
   it('pushes the selected chat URL and lets the updated route activate the detail controller', () => {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -112,11 +112,14 @@ describe('/chats page', () => {
   it('projects chat filter URLs without SvelteKit navigation', () => {
     const source = chatDetailPageSource();
     const filterSyncBody = source.match(
-      /\$effect\(\(\) => \{\n    try \{\n      const fromUrl = readChatListFiltersFromRoute[\s\S]*?\n  \}\);/
+      /\$effect\(\(\) => \{\n    try \{\n      const browserUrl = currentBrowserUrl[\s\S]*?\n  \}\);/
     )?.[0];
 
     expect(filterSyncBody).toBeTruthy();
+    expect(filterSyncBody).toContain('const fromUrl = readChatListFiltersFromUrl(browserUrl);');
     expect(filterSyncBody).toContain('replaceChatListFiltersProjection(chatListFilters');
+    expect(filterSyncBody).toContain('url: browserUrl');
+    expect(filterSyncBody).not.toContain('readChatListFiltersFromRoute()');
     expect(filterSyncBody).not.toContain('goto(');
   });
 

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/load.test.ts
@@ -14,7 +14,7 @@ import { importRouteLoader } from '$lib/test/importRouteLoader';
 const now = '2026-05-11T12:00:00Z';
 
 describe('/repos/[repoId] route load', () => {
-  it('returns a cache hit when the repo detail is already in the store', async () => {
+  it('returns cached repo detail immediately and refreshes in the background', async () => {
     const store = new ReadModelEntityStore();
     store.applyRepoDetailSnapshot(repoDetailSnapshot('repo-1'));
     const client = mockClient();
@@ -23,7 +23,7 @@ describe('/repos/[repoId] route load', () => {
     const result = await loadRepoDetailRoute({ repoId: 'repo-1', loaderOptions: { store, client } });
 
     expect(result.result).toEqual({ status: 'cache-hit', tags: ['entity:repo:repo-1'] });
-    expect(client.repoDetail).not.toHaveBeenCalled();
+    expect(client.repoDetail).toHaveBeenCalledWith('repo-1');
   });
 
   it('returns cold on a missing repo detail so navigation can commit immediately', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/load.test.ts
@@ -51,7 +51,7 @@ describe('/repos/[repoId]/tickets/[ticketId] route load', () => {
       status: 'cache-hit',
       tags: ['entity:ticket:t-1', 'entity:repo:repo-1']
     });
-    expect(client.ticketDetail).not.toHaveBeenCalled();
+    expect(client.ticketDetail).toHaveBeenCalledWith('t-1', { kind: 'repo', id: 'repo-1' });
   });
 
   it('returns cold without blocking when ticket detail is missing', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/load.test.ts
@@ -60,7 +60,7 @@ describe('/repos/[repoId]/tickets route load', () => {
     });
 
     expect(result.result).toEqual({ status: 'cache-hit', tags: ['entity:repo:repo-1'] });
-    expect(client.repoDetail).not.toHaveBeenCalled();
+    expect(client.repoDetail).toHaveBeenCalledWith('repo-1');
   });
 
   it('returns errors from blocking repo detail fetches', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/load.test.ts
@@ -50,7 +50,7 @@ describe('/tickets/[ticketId] route load', () => {
     expect(client.ticketDetail).toHaveBeenCalledWith('t-1', { kind: 'repo', id: 'repo-right' });
   });
 
-  it('returns cache hit when ticket index is already loaded', async () => {
+  it('returns cached ticket index immediately and refreshes in the background', async () => {
     const store = new ReadModelEntityStore();
     store.replaceScopedTicketSummaries('all', [ticketSummary('t-1', 'Cached')]);
     const client = mockClient();
@@ -59,6 +59,7 @@ describe('/tickets/[ticketId] route load', () => {
     const result = await loadTicketDetailRoute({ ticketId: 't-1', loaderOptions: { store, client } });
 
     expect(result.indexResult).toEqual({ status: 'cache-hit', tags: ['entity:ticket:index'] });
+    expect(client.ticketIndex).toHaveBeenCalled();
   });
 
   it('returns cold and defers detail lookup when the ticket index is missing', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/load.test.ts
@@ -55,7 +55,7 @@ describe('/tickets route load', () => {
     const result = await loadTicketIndexRoute({ loaderOptions: { store, client } });
 
     expect(result.result).toEqual({ status: 'cache-hit', tags: ['entity:ticket:index'] });
-    expect(client.ticketIndex).not.toHaveBeenCalled();
+    expect(client.ticketIndex).toHaveBeenCalled();
   });
 
   it('returns cold when not in the browser', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/load.test.ts
@@ -12,7 +12,7 @@ import { importRouteLoader } from '$lib/test/importRouteLoader';
 const now = '2026-05-11T12:00:00Z';
 
 describe('/worktrees/[worktreeId] route load', () => {
-  it('returns a cache hit when the worktree detail is already in the store', async () => {
+  it('returns cached worktree detail immediately and refreshes in the background', async () => {
     const store = new ReadModelEntityStore();
     store.applyWorktreeDetailSnapshot(worktreeDetailSnapshot('wt-1'));
     const client = mockClient();
@@ -21,7 +21,7 @@ describe('/worktrees/[worktreeId] route load', () => {
     const result = await loadWorktreeDetailRoute({ worktreeId: 'wt-1', loaderOptions: { store, client } });
 
     expect(result.result).toEqual({ status: 'cache-hit', tags: ['entity:worktree:wt-1'] });
-    expect(client.worktreeDetail).not.toHaveBeenCalled();
+    expect(client.worktreeDetail).toHaveBeenCalledWith('wt-1');
   });
 
   it('returns cold on a missing worktree detail so navigation can commit immediately', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/load.test.ts
@@ -51,7 +51,7 @@ describe('/worktrees/[worktreeId]/tickets/[ticketId] route load', () => {
       status: 'cache-hit',
       tags: ['entity:ticket:t-1', 'entity:worktree:wt-1']
     });
-    expect(client.ticketDetail).not.toHaveBeenCalled();
+    expect(client.ticketDetail).toHaveBeenCalledWith('t-1', { kind: 'worktree', id: 'wt-1' });
   });
 
   it('returns cold without blocking when ticket detail is missing', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/load.test.ts
@@ -60,7 +60,7 @@ describe('/worktrees/[worktreeId]/tickets route load', () => {
     });
 
     expect(result.result).toEqual({ status: 'cache-hit', tags: ['entity:worktree:wt-1'] });
-    expect(client.worktreeDetail).not.toHaveBeenCalled();
+    expect(client.worktreeDetail).toHaveBeenCalledWith('wt-1');
   });
 
   it('returns errors from blocking worktree detail fetches', async () => {


### PR DESCRIPTION
## Summary
- Add a `chatUrlProjection` helper so chat filter and committed-detail URL writes use `history.replaceState` / `pushState` instead of SvelteKit `goto` for same-page projection.
- Make read-model route helpers default to stale-while-revalidate by returning cached data immediately while kicking off non-blocking refreshes.
- Update repo, worktree, ticket, and chat route tests to lock the SWR and URL projection behavior.

## Validation
- `pnpm --dir src/codex_autorunner/web_frontend test -- src/lib/data/readModelLoaders.test.ts src/lib/routes/chatUrlProjection.test.ts src/lib/routes/chatListFiltersUrl.test.ts src/routes/chats/page.test.ts src/routes/chats/load.test.ts 'src/routes/repos/[repoId]/load.test.ts' 'src/routes/worktrees/[worktreeId]/load.test.ts' 'src/routes/tickets/[ticketId]/load.test.ts' 'src/routes/tickets/load.test.ts' 'src/routes/repos/[repoId]/tickets/load.test.ts' 'src/routes/worktrees/[worktreeId]/tickets/load.test.ts' 'src/routes/repos/[repoId]/tickets/[ticketId]/load.test.ts' 'src/routes/worktrees/[worktreeId]/tickets/[ticketId]/load.test.ts'`
- `pnpm --dir src/codex_autorunner/web_frontend lint`
- `pnpm --dir src/codex_autorunner/web_frontend web:test`
- Commit hook web-ui lane: guardrails, repo pytest suite, Web UI lab, frontend lint, build, frontend tests, SPA shell check

Closes #1960