### PR TITLE
[codex] Extract chat detail list read model

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailListReadModel.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailListReadModel.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatFacetCounts, ChatIndexCounters } from '$lib/api/readModelContracts';
+import type { ChatDraftRecord } from './chatDraftStore';
+import type { ChatSummary } from '$lib/viewModels/domain';
+import {
+  backendChatIndexFilter,
+  buildChatCategoryFilterOptions,
+  buildChatIndexRequest,
+  buildChatScopeKindFilterOptions,
+  buildChatStatusFilterCounts,
+  buildChatTicketRunGroupRequest,
+  buildChatTransportFilterOptions,
+  buildDraftChatSummary,
+  filterDraftChatsForChatList
+} from './chatDetailListReadModel';
+
+describe('chat detail list read model', () => {
+  it('builds screen-shaped chat index requests from page filters', () => {
+    expect(buildChatIndexRequest({
+      status: 'drafts',
+      category: 'ticket_run',
+      transport: 'discord',
+      scopeKind: 'repo',
+      search: '  bug  '
+    })).toEqual({
+      filter: 'all',
+      query: 'bug',
+      facets: {
+        categories: ['ticket_run'],
+        transports: ['discord'],
+        scopeKinds: ['repo']
+      },
+      groupBy: 'ticket_run',
+      limit: 50
+    });
+
+    expect(buildChatTicketRunGroupRequest({
+      status: 'waiting',
+      category: null,
+      transport: null,
+      scopeKind: null,
+      search: ''
+    })).toMatchObject({
+      filter: 'waiting',
+      query: null,
+      facets: { categories: ['ticket_run'], transports: [], scopeKinds: [] },
+      groupBy: 'ticket_run'
+    });
+    expect(backendChatIndexFilter('active')).toBe('active');
+  });
+
+  it('projects local draft records without making the Svelte page own row shape', () => {
+    const summary = buildDraftChatSummary(draftRecord('chat-1'), {
+      ...chatSummary('chat-1'),
+      title: 'Existing chat',
+      status: 'running',
+      raw: { source: 'backend' }
+    });
+
+    expect(summary).toMatchObject({
+      id: 'chat-1',
+      title: 'Existing chat',
+      status: 'running',
+      updatedAt: '2026-05-20T12:00:00.000Z',
+      raw: {
+        source: 'backend',
+        has_local_draft: true,
+        local_draft_updated_at: '2026-05-20T12:00:00.000Z'
+      }
+    });
+  });
+
+  it('filters draft rows through the same facet semantics as persisted chats', () => {
+    const repoDraft = {
+      ...chatSummary('repo-chat'),
+      repoId: 'repo-1',
+      raw: {
+        has_local_draft: true,
+        facets: {
+          category: 'regular',
+          turnKinds: ['message'],
+          originKinds: ['surface'],
+          transports: ['discord'],
+          scopeKind: 'repo'
+        }
+      }
+    };
+    const hubDraft = {
+      ...chatSummary('hub-chat'),
+      raw: {
+        has_local_draft: true,
+        facets: {
+          category: 'regular',
+          turnKinds: ['message'],
+          originKinds: ['surface'],
+          transports: ['web'],
+          scopeKind: 'hub'
+        }
+      }
+    };
+
+    const filtered = filterDraftChatsForChatList([repoDraft, hubDraft], {
+      status: 'drafts',
+      category: 'regular',
+      transport: 'discord',
+      scopeKind: 'repo',
+      search: 'repo'
+    }, {});
+
+    expect(filtered.map((chat) => chat.id)).toEqual(['repo-chat']);
+  });
+
+  it('combines backend counters, local placeholders, unread adjustment, and draft counts', () => {
+    const counts = buildChatStatusFilterCounts({
+      counters: counters({ total: 3, running: 1, waiting: 1, unread: 2, archived: 4 }),
+      statusFilter: 'all',
+      knownChats: [chatSummary('seen'), chatSummary('unseen')],
+      lastSeenMap: {
+        seen: '2026-05-20T12:01:00.000Z'
+      },
+      persistedFacetChats: [],
+      committedChatPlaceholders: [{ ...chatSummary('local'), status: 'running' }],
+      localChatPlaceholderCount: 1,
+      filteredDraftChatsLength: 2,
+      draftChatsLength: 5
+    });
+
+    expect(counts).toMatchObject({
+      all: 4,
+      active: 2,
+      waiting: 1,
+      drafts: 5,
+      archived: 4
+    });
+  });
+
+  it('keeps selected zero-count facet options visible', () => {
+    const facetCounts = emptyFacetCounts();
+
+    expect(buildChatCategoryFilterOptions({
+      counts: facetCounts.category,
+      ticketRunGroupCount: 0,
+      selectedCategory: 'automation'
+    }).map((item) => item.key)).toEqual(['automation']);
+    expect(buildChatTransportFilterOptions({
+      counts: facetCounts.transport,
+      selectedTransport: 'telegram'
+    }).map((item) => item.key)).toEqual(['telegram']);
+    expect(buildChatScopeKindFilterOptions({
+      counts: facetCounts.scopeKind,
+      selectedScopeKind: 'worktree',
+      label: (value) => value.toUpperCase()
+    })).toEqual([{ key: 'worktree', label: 'WORKTREE', count: 0 }]);
+  });
+});
+
+function draftRecord(chatId: string): ChatDraftRecord {
+  return {
+    chatId,
+    text: 'draft text',
+    updatedAt: '2026-05-20T12:00:00.000Z'
+  };
+}
+
+function chatSummary(id: string): ChatSummary {
+  return {
+    id,
+    title: id,
+    lifecycleStatus: 'active',
+    status: 'idle',
+    agentId: null,
+    chatKind: null,
+    agentProfile: null,
+    model: null,
+    runtime: null,
+    runtimeSource: null,
+    modelSource: null,
+    reasoning: null,
+    reasoningSource: null,
+    repoId: null,
+    worktreeId: null,
+    ticketId: null,
+    ticketPath: null,
+    runId: null,
+    unreadCount: 0,
+    flowType: null,
+    isTicketFlow: false,
+    ticketDone: null,
+    ticketStatus: null,
+    progressPercent: null,
+    updatedAt: '2026-05-20T11:00:00.000Z',
+    raw: {}
+  };
+}
+
+function counters(overrides: Partial<ChatIndexCounters> = {}): ChatIndexCounters {
+  return {
+    total: 0,
+    waiting: 0,
+    running: 0,
+    unread: 0,
+    archived: 0,
+    ...overrides
+  };
+}
+
+function emptyFacetCounts(): ChatFacetCounts {
+  return {
+    category: {},
+    turnKind: {},
+    originKind: {},
+    transport: {},
+    scopeKind: {},
+    agentKind: {}
+  };
+}

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailListReadModel.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailListReadModel.ts
@@ -1,0 +1,193 @@
+import type { ChatIndexWindowRequest } from '$lib/data';
+import type {
+  ChatFacetCategory,
+  ChatFacetScopeKind,
+  ChatFacetTransport,
+  ChatFacetCounts,
+  ChatIndexCounters
+} from '$lib/api/readModelContracts';
+import type { ChatDraftRecord } from './chatDraftStore';
+import type { ChatSummary } from '$lib/viewModels/domain';
+import {
+  adjustedUnreadFilterCount,
+  chatCategoryLabel,
+  chatFacets,
+  chatTransportLabel,
+  filterChats,
+  summarizeVisibleLocalPlaceholderStatusCounts,
+  CHAT_EXTERNAL_TRANSPORT_FILTERS,
+  type ChatStatusFilter
+} from '$lib/viewModels/chat';
+import type { ChatLastSeenMap } from '$lib/viewModels/unread';
+
+export type ChatDetailListFilters = {
+  status: ChatStatusFilter;
+  category: ChatFacetCategory | null;
+  transport: ChatFacetTransport | null;
+  scopeKind: ChatFacetScopeKind | null;
+  search: string;
+};
+
+export type ChatDetailFilterOption<T extends string> = {
+  key: T;
+  label: string;
+  count: number;
+};
+
+export function buildDraftChatSummary(
+  record: ChatDraftRecord,
+  known: ChatSummary | null
+): ChatSummary {
+  const raw = known?.raw ?? {};
+  return {
+    id: record.chatId,
+    title: known?.title ?? record.chatId,
+    lifecycleStatus: known?.lifecycleStatus ?? 'active',
+    status: known?.status ?? 'idle',
+    agentId: known?.agentId ?? null,
+    chatKind: known?.chatKind ?? null,
+    agentProfile: known?.agentProfile ?? null,
+    model: known?.model ?? null,
+    runtime: known?.runtime ?? null,
+    runtimeSource: known?.runtimeSource ?? null,
+    modelSource: known?.modelSource ?? null,
+    reasoning: known?.reasoning ?? null,
+    reasoningSource: known?.reasoningSource ?? null,
+    repoId: known?.repoId ?? null,
+    worktreeId: known?.worktreeId ?? null,
+    ticketId: known?.ticketId ?? null,
+    ticketPath: known?.ticketPath ?? null,
+    runId: known?.runId ?? null,
+    unreadCount: known?.unreadCount ?? 0,
+    flowType: known?.flowType ?? null,
+    isTicketFlow: known?.isTicketFlow ?? false,
+    ticketDone: known?.ticketDone ?? null,
+    ticketStatus: known?.ticketStatus ?? null,
+    progressPercent: known?.progressPercent ?? null,
+    updatedAt: record.updatedAt,
+    raw: {
+      ...raw,
+      has_local_draft: true,
+      local_draft_updated_at: record.updatedAt
+    }
+  };
+}
+
+export function filterDraftChatsForChatList(
+  source: ChatSummary[],
+  filters: ChatDetailListFilters,
+  lastSeenMap: ChatLastSeenMap
+): ChatSummary[] {
+  return filterChats(source, 'drafts', filters.search, lastSeenMap).filter((chat) => {
+    const facets = chatFacets(chat);
+    if (filters.category && facets?.category !== filters.category) return false;
+    if (filters.transport && !facets?.transports.includes(filters.transport)) return false;
+    if (filters.scopeKind && facets?.scopeKind !== filters.scopeKind) return false;
+    return true;
+  });
+}
+
+export function buildChatIndexRequest(filters: ChatDetailListFilters): ChatIndexWindowRequest {
+  return {
+    filter: backendChatIndexFilter(filters.status),
+    query: filters.search.trim() || null,
+    facets: {
+      categories: filters.category ? [filters.category] : [],
+      transports: filters.transport ? [filters.transport] : [],
+      scopeKinds: filters.scopeKind ? [filters.scopeKind] : []
+    },
+    groupBy: filters.category === 'ticket_run' ? 'ticket_run' : null,
+    limit: 50
+  };
+}
+
+export function buildChatTicketRunGroupRequest(
+  filters: ChatDetailListFilters
+): ChatIndexWindowRequest {
+  return {
+    filter: backendChatIndexFilter(filters.status),
+    query: filters.search.trim() || null,
+    facets: {
+      categories: ['ticket_run'],
+      transports: filters.transport ? [filters.transport] : [],
+      scopeKinds: filters.scopeKind ? [filters.scopeKind] : []
+    },
+    groupBy: 'ticket_run',
+    limit: 50
+  };
+}
+
+export function backendChatIndexFilter(
+  filter: ChatStatusFilter
+): ChatIndexWindowRequest['filter'] {
+  return filter === 'drafts' ? 'all' : filter;
+}
+
+export function buildChatStatusFilterCounts(input: {
+  counters: ChatIndexCounters;
+  statusFilter: ChatStatusFilter;
+  knownChats: ChatSummary[];
+  lastSeenMap: ChatLastSeenMap;
+  persistedFacetChats: ChatSummary[];
+  committedChatPlaceholders: ChatSummary[];
+  localChatPlaceholderCount: number;
+  filteredDraftChatsLength: number;
+  draftChatsLength: number;
+}): Record<ChatStatusFilter, number> {
+  const localStatusCounts = summarizeVisibleLocalPlaceholderStatusCounts(
+    input.persistedFacetChats,
+    input.committedChatPlaceholders
+  );
+  return {
+    all: input.counters.total + input.localChatPlaceholderCount,
+    active: input.counters.running + localStatusCounts.active,
+    waiting: input.counters.waiting + localStatusCounts.waiting,
+    unread: adjustedUnreadFilterCount(input.counters.unread, input.knownChats, input.lastSeenMap),
+    drafts: input.statusFilter === 'drafts'
+      ? input.filteredDraftChatsLength
+      : input.draftChatsLength,
+    archived: input.counters.archived
+  };
+}
+
+export function buildChatCategoryFilterOptions(input: {
+  counts: ChatFacetCounts['category'];
+  ticketRunGroupCount: number;
+  selectedCategory: ChatFacetCategory | null;
+}): ChatDetailFilterOption<ChatFacetCategory>[] {
+  const order: ChatDetailFilterOption<ChatFacetCategory>[] = [
+    { key: 'regular', label: chatCategoryLabel('regular'), count: input.counts.regular ?? 0 },
+    { key: 'ticket_run', label: chatCategoryLabel('ticket_run'), count: input.ticketRunGroupCount },
+    { key: 'automation', label: chatCategoryLabel('automation'), count: input.counts.automation ?? 0 },
+    { key: 'system', label: chatCategoryLabel('system'), count: input.counts.system ?? 0 }
+  ];
+  return order.filter((item) => item.count > 0 || input.selectedCategory === item.key);
+}
+
+export function buildChatTransportFilterOptions(input: {
+  counts: ChatFacetCounts['transport'];
+  selectedTransport: ChatFacetTransport | null;
+}): ChatDetailFilterOption<ChatFacetTransport>[] {
+  return [...CHAT_EXTERNAL_TRANSPORT_FILTERS]
+    .map((transport) => ({
+      key: transport,
+      label: chatTransportLabel(transport),
+      count: input.counts[transport] ?? 0
+    }))
+    .filter((item) => item.count > 0 || input.selectedTransport === item.key);
+}
+
+export function buildChatScopeKindFilterOptions(input: {
+  counts: ChatFacetCounts['scopeKind'];
+  selectedScopeKind: ChatFacetScopeKind | null;
+  label: (scopeKind: ChatFacetScopeKind) => string;
+}): ChatDetailFilterOption<ChatFacetScopeKind>[] {
+  const order: ChatFacetScopeKind[] = ['hub', 'repo', 'worktree', 'filesystem'];
+  return order
+    .map((scopeKind) => ({
+      key: scopeKind,
+      label: input.label(scopeKind),
+      count: input.counts[scopeKind] ?? 0
+    }))
+    .filter((item) => item.count > 0 || input.selectedScopeKind === item.key);
+}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte
@@ -42,6 +42,16 @@
     ChatFacetTransport
   } from '$lib/api/readModelContracts';
   import { buildChatDetailDisplayReadModel, type ChatTranscriptListItem } from '$lib/application/chatDetailReadModel';
+  import {
+    buildChatCategoryFilterOptions,
+    buildChatIndexRequest,
+    buildChatScopeKindFilterOptions,
+    buildChatStatusFilterCounts,
+    buildChatTicketRunGroupRequest,
+    buildChatTransportFilterOptions,
+    buildDraftChatSummary,
+    filterDraftChatsForChatList
+  } from '$lib/application/chatDetailListReadModel';
   import { isOptimisticQueuedTurn } from '$lib/application/chatDetailOptimistic';
   import { progressWithLiveElapsed } from '$lib/application/chatDetailProgress';
   import { createChatSendController } from '$lib/application/chatSendController';
@@ -103,7 +113,6 @@
     SurfaceArtifact
   } from '$lib/viewModels/domain';
   import {
-    adjustedUnreadFilterCount,
     buildSemanticChatListEntries,
     chatRunGroupSummaryParts,
     buildChatScopeOptions,
@@ -111,7 +120,6 @@
     buildManagedThreadMessagePayload,
     countSemanticTicketRunGroups,
     filterChatEntries,
-    filterChats,
     formatBytes,
     formatRelativeTime,
     isChatArchived,
@@ -119,13 +127,11 @@
     mergeChatFacetSourceChats,
     mergeLocalChatPlaceholders,
     CHAT_FILTER_ORDER,
-    CHAT_EXTERNAL_TRANSPORT_FILTERS,
     CHAT_TICKET_RUNS_FILTER,
     chatKind,
     chatKindLabel,
     chatHeaderScopeLine,
     chatBadgeViews,
-    chatFacets,
     chatCategoryLabel,
     chatTransportLabel,
     chatScopeTagView,
@@ -133,7 +139,6 @@
     visibleLocalChatPlaceholders as selectVisibleLocalChatPlaceholders,
     removePendingAttachment,
     statusLabel,
-    summarizeVisibleLocalPlaceholderStatusCounts,
     type PendingAttachment,
     type ChatTranscriptCard,
     type ChatStatusFilter,
@@ -276,13 +281,7 @@
   }
 
   function filterDraftChatsForCurrentFilters(source: ChatSummary[]): ChatSummary[] {
-    return filterChats(source, 'drafts', search, lastSeenMap).filter((chat) => {
-      const facets = chatFacets(chat);
-      if (categoryFilter && facets?.category !== categoryFilter) return false;
-      if (transportFilter && !facets?.transports.includes(transportFilter)) return false;
-      if (scopeKindFilter && facets?.scopeKind !== scopeKindFilter) return false;
-      return true;
-    });
+    return filterDraftChatsForChatList(source, chatListFilters, lastSeenMap);
   }
 
   function draftRecordChatSummary(record: ChatDraftRecord): ChatSummary {
@@ -291,39 +290,7 @@
       (localDraftChat?.id === record.chatId ? localDraftChat : null) ??
       record.chatSnapshot ??
       null;
-    const raw = known?.raw ?? {};
-    return {
-      id: record.chatId,
-      title: known?.title ?? record.chatId,
-      lifecycleStatus: known?.lifecycleStatus ?? 'active',
-      status: known?.status ?? 'idle',
-      agentId: known?.agentId ?? null,
-      chatKind: known?.chatKind ?? null,
-      agentProfile: known?.agentProfile ?? null,
-      model: known?.model ?? null,
-      runtime: known?.runtime ?? null,
-      runtimeSource: known?.runtimeSource ?? null,
-      modelSource: known?.modelSource ?? null,
-      reasoning: known?.reasoning ?? null,
-      reasoningSource: known?.reasoningSource ?? null,
-      repoId: known?.repoId ?? null,
-      worktreeId: known?.worktreeId ?? null,
-      ticketId: known?.ticketId ?? null,
-      ticketPath: known?.ticketPath ?? null,
-      runId: known?.runId ?? null,
-      unreadCount: known?.unreadCount ?? 0,
-      flowType: known?.flowType ?? null,
-      isTicketFlow: known?.isTicketFlow ?? false,
-      ticketDone: known?.ticketDone ?? null,
-      ticketStatus: known?.ticketStatus ?? null,
-      progressPercent: known?.progressPercent ?? null,
-      updatedAt: record.updatedAt,
-      raw: {
-        ...raw,
-        has_local_draft: true,
-        local_draft_updated_at: record.updatedAt
-      }
-    };
+    return buildDraftChatSummary(record, known);
   }
   const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
   const progress = $derived<ChatRunProgress | null>(selectChatProgress(readModelState, activeChatId));
@@ -839,50 +806,26 @@
   }
 
   function chatIndexRequestForCurrentFilters(): ChatIndexWindowRequest {
-    const facets = {
-      categories: categoryFilter ? [categoryFilter] : [],
-      transports: transportFilter ? [transportFilter] : [],
-      scopeKinds: scopeKindFilter ? [scopeKindFilter] : []
-    };
-    return {
-      filter: backendChatIndexFilter(statusFilter),
-      query: search.trim() || null,
-      facets,
-      groupBy: categoryFilter === 'ticket_run' ? 'ticket_run' : null,
-      limit: 50
-    };
+    return buildChatIndexRequest(chatListFilters);
   }
 
   function chatTicketRunGroupRequestForFilters(): ChatIndexWindowRequest {
-    return {
-      filter: backendChatIndexFilter(statusFilter),
-      query: search.trim() || null,
-      facets: {
-        categories: ['ticket_run'],
-        transports: transportFilter ? [transportFilter] : [],
-        scopeKinds: scopeKindFilter ? [scopeKindFilter] : []
-      },
-      groupBy: 'ticket_run',
-      limit: 50
-    };
+    return buildChatTicketRunGroupRequest(chatListFilters);
   }
 
   function chatStatusFilterCounts(): Record<ChatStatusFilter, number> {
     const counters = selectedChatWindowView.window ? selectedChatWindowView.counters : readModelState.chatCounters;
-    const knownChats = facetChats;
-    const localStatusCounts = summarizeVisibleLocalPlaceholderStatusCounts(persistedFacetChats, committedChatPlaceholders);
-    return {
-      all: counters.total + localChatPlaceholderCount,
-      active: counters.running + localStatusCounts.active,
-      waiting: counters.waiting + localStatusCounts.waiting,
-      unread: adjustedUnreadFilterCount(counters.unread, knownChats, lastSeenMap),
-      drafts: statusFilter === 'drafts' ? filteredDraftChats.length : sortedChatDraftRecords(chatDraftRecords).length,
-      archived: counters.archived
-    };
-  }
-
-  function backendChatIndexFilter(filter: ChatStatusFilter): ChatIndexWindowRequest['filter'] {
-    return filter === 'drafts' ? 'all' : filter;
+    return buildChatStatusFilterCounts({
+      counters,
+      statusFilter,
+      knownChats: facetChats,
+      lastSeenMap,
+      persistedFacetChats,
+      committedChatPlaceholders,
+      localChatPlaceholderCount,
+      filteredDraftChatsLength: filteredDraftChats.length,
+      draftChatsLength: sortedChatDraftRecords(chatDraftRecords).length
+    });
   }
 
   const categoryFilterOptions = $derived(chatCategoryFilterOptions());
@@ -898,14 +841,11 @@
   }
 
   function chatCategoryFilterOptions(): { key: ChatFacetCategory; label: string; count: number }[] {
-    const counts = contextualFacetCounts.category;
-    const order: { key: ChatFacetCategory; label: string; count: number }[] = [
-      { key: 'regular', label: chatCategoryLabel('regular'), count: counts.regular ?? 0 },
-      { key: 'ticket_run', label: chatCategoryLabel('ticket_run'), count: ticketRunGroupCount },
-      { key: 'automation', label: chatCategoryLabel('automation'), count: counts.automation ?? 0 },
-      { key: 'system', label: chatCategoryLabel('system'), count: counts.system ?? 0 }
-    ];
-    return order.filter((item) => item.count > 0 || categoryFilter === item.key);
+    return buildChatCategoryFilterOptions({
+      counts: contextualFacetCounts.category,
+      ticketRunGroupCount,
+      selectedCategory: categoryFilter
+    });
   }
 
   const hasNonStatusFilter = $derived(
@@ -972,18 +912,18 @@
   });
 
   function chatTransportFilterOptions(): { key: ChatFacetTransport; label: string; count: number }[] {
-    const counts = contextualFacetCounts.transport;
-    return [...CHAT_EXTERNAL_TRANSPORT_FILTERS]
-      .map((transport) => ({ key: transport, label: chatTransportLabel(transport), count: counts[transport] ?? 0 }))
-      .filter((item) => item.count > 0 || transportFilter === item.key);
+    return buildChatTransportFilterOptions({
+      counts: contextualFacetCounts.transport,
+      selectedTransport: transportFilter
+    });
   }
 
   function chatScopeKindFilterOptions(): { key: ChatFacetScopeKind; label: string; count: number }[] {
-    const counts = contextualFacetCounts.scopeKind;
-    const order: ChatFacetScopeKind[] = ['hub', 'repo', 'worktree', 'filesystem'];
-    return order
-      .map((scopeKind) => ({ key: scopeKind, label: facetChipLabel(scopeKind), count: counts[scopeKind] ?? 0 }))
-      .filter((item) => item.count > 0 || scopeKindFilter === item.key);
+    return buildChatScopeKindFilterOptions({
+      counts: contextualFacetCounts.scopeKind,
+      selectedScopeKind: scopeKindFilter,
+      label: facetChipLabel
+    });
   }
 
   function composerRecipientLabel(chat: ChatSummary | null): string {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -22,6 +22,13 @@ describe('/chats page', () => {
     );
   }
 
+  function chatDetailListReadModelSource(): string {
+    return readFileSync(
+      fileURLToPath(new URL('../../lib/application/chatDetailListReadModel.ts', import.meta.url)),
+      'utf8'
+    );
+  }
+
   it('uses remembered new-chat preferences unless a route-selected draft is being created', () => {
     const source = chatDetailPageSource();
     const createChatBody = source.match(
@@ -176,8 +183,9 @@ describe('/chats page', () => {
 
   it('does not re-apply chat search locally after requesting a backend search window', () => {
     const pageSource = chatDetailPageSource();
+    const listReadModelSource = chatDetailListReadModelSource();
 
-    expect(pageSource).toContain('query: search.trim() || null');
+    expect(listReadModelSource).toContain('query: filters.search.trim() || null');
     expect(pageSource).toContain("filterChatEntries(chatListEntries, statusFilter === 'drafts' ? 'all' : statusFilter, '', lastSeenMap)");
   });
 
@@ -245,13 +253,15 @@ describe('/chats page', () => {
 
   it('keeps composer drafts keyed by chat and treats draft filtering as a local overlay', () => {
     const pageSource = chatDetailPageSource();
+    const listReadModelSource = chatDetailListReadModelSource();
 
     expect(pageSource).toContain('loadChatDraftRecords');
     expect(pageSource).toContain('setChatDraftText(chatDraftRecords, chatId, value, chatSummaryForId(chatId))');
     expect(pageSource).toContain("statusFilter === 'drafts' ? filteredDraftChats");
-    expect(pageSource).toContain("filterChats(source, 'drafts', search, lastSeenMap)");
-    expect(pageSource).toContain("facets?.category !== categoryFilter");
-    expect(pageSource).toContain("filter === 'drafts' ? 'all' : filter");
+    expect(pageSource).toContain("filterDraftChatsForChatList(source, chatListFilters, lastSeenMap)");
+    expect(listReadModelSource).toContain("filterChats(source, 'drafts', filters.search, lastSeenMap)");
+    expect(listReadModelSource).toContain('facets?.category !== filters.category');
+    expect(listReadModelSource).toContain("filter === 'drafts' ? 'all' : filter");
     expect(pageSource).toContain("filterChatEntries(chatListEntries, statusFilter === 'drafts' ? 'all' : statusFilter");
   });
 
@@ -320,13 +330,15 @@ describe('/chats page', () => {
 
     const { body } = render(Page);
     const pageSource = chatDetailPageSource();
+    const listReadModelSource = chatDetailListReadModelSource();
 
     expect(body).toContain('More filters');
     expect(body).toContain('Discord');
     expect(body).not.toContain('PMA 2');
     expect(body).toContain('Automation Discord');
-    expect(pageSource).toContain("chatCategoryLabel('regular')");
-    expect(pageSource).toContain('CHAT_EXTERNAL_TRANSPORT_FILTERS');
+    expect(pageSource).toContain('buildChatCategoryFilterOptions');
+    expect(listReadModelSource).toContain("chatCategoryLabel('regular')");
+    expect(listReadModelSource).toContain('CHAT_EXTERNAL_TRANSPORT_FILTERS');
     expect(pageSource).toContain('contextualFacetCounts.transport');
   });
 

--- a/tests/test_hotspot_budgets.py
+++ b/tests/test_hotspot_budgets.py
@@ -148,12 +148,12 @@ STANDARD_FILE_BUDGETS = (
     ),
     FileBudget(
         path="src/codex_autorunner/surfaces/web/services/pma/managed_thread_read_models.py",
-        max_lines=660,
-        reason="Ticket 008 moved managed-thread read-model shaping behind a web service boundary.",
+        max_lines=713,
+        reason="Current managed-thread read-model service baseline; future growth should move to focused helpers.",
     ),
     FileBudget(
         path="src/codex_autorunner/surfaces/web/services/chat_read_models.py",
-        max_lines=1194,
+        max_lines=1261,
         reason="Current chat read-model contract baseline outside frontend route loaders.",
     ),
     FileBudget(
@@ -368,13 +368,13 @@ STANDARD_FUNCTION_BUDGETS = (
     FunctionBudget(
         path="src/codex_autorunner/surfaces/web/services/pma/managed_thread_read_models.py",
         qualname="_serialize_thread_target",
-        max_lines=95,
-        reason="Ticket 008 keeps managed-thread target serialization inside the read-model service.",
+        max_lines=119,
+        reason="Current managed-thread target serialization baseline; future growth should split runtime/thread field helpers.",
     ),
     FunctionBudget(
         path="src/codex_autorunner/surfaces/web/services/chat_read_models.py",
         qualname="hub_chat_row_to_chat_index_row",
-        max_lines=162,
+        max_lines=167,
         reason="Current chat index row normalization baseline inside the web read-model service.",
     ),
     FunctionBudget(
@@ -519,8 +519,8 @@ LEGACY_FILE_CAPS = (
     ),
     FileBudget(
         path="src/codex_autorunner/web_frontend/src/routes/chats/+page.svelte",
-        max_lines=3461,
-        reason="Current legacy chat detail page baseline after the route was already over budget.",
+        max_lines=3452,
+        reason="Chat detail route baseline after list read-model extraction; future state/list derivations belong in application modules.",
     ),
     FileBudget(
         path="src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts",
@@ -565,18 +565,6 @@ LEGACY_FUNCTION_CAPS = (
         qualname="TicketRunner.step",
         max_lines=625,
         reason="TicketRunner.step() is still a legacy orchestration hotspot, but new growth should fail.",
-    ),
-    FunctionBudget(
-        path="src/codex_autorunner/core/pma_automation_store.py",
-        qualname="PmaAutomationStore.create_subscription",
-        max_lines=100,
-        reason="Legacy PMA automation store facade capped after ticket 001 service/persistence extraction.",
-    ),
-    FunctionBudget(
-        path="src/codex_autorunner/core/pma_automation_store.py",
-        qualname="PmaAutomationStore.notify_transition",
-        max_lines=100,
-        reason="Legacy PMA automation store facade capped after tickets 001-002 moved transition side effects to services/mirrors.",
     ),
 )
 


### PR DESCRIPTION
Refs #1856

## Summary
- move chat detail list request shaping, draft row projection, counts, and facet option derivation into a focused application read-model module
- keep the chats route as a binding layer by delegating local draft filtering and backend window request construction
- update route/source tests and hotspot budgets so the PMA facade extraction and lower chat route baseline are encoded in guardrails

## Validation
- pre-commit web-core-contract lane: guardrails, ruff, black check, import boundaries, mypy, pytest (9654 passed), web UI lab, web lint, web build, web tests (899 passed), SPA shell check
- pnpm test
- pnpm lint
- .venv/bin/python -m pytest -q tests/test_hotspot_budgets.py
