### PR TITLE
[codex] Fix chat status bar and scroll anchoring

### DIFF
--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -2138,6 +2138,16 @@ textarea:hover {
   min-height: 180px;
 }
 
+.message-stack.has-status-overlay:not(:has(.chat-transcript-virtual-list)) {
+  padding-bottom: var(--chat-status-overlay-clearance, 52px);
+}
+
+.chat-transcript-tail-spacer {
+  height: var(--chat-status-overlay-clearance, 52px);
+  min-height: var(--chat-status-overlay-clearance, 52px);
+  pointer-events: none;
+}
+
 .message-stack > :first-child {
   /* Bottom-anchor short transcripts without reversing DOM, screen-reader, or keyboard order. */
   margin-top: auto;
@@ -3036,9 +3046,8 @@ textarea:hover {
 }
 
 .composer-status-bar {
-  width: calc(100% - var(--space-2) - var(--space-3));
+  width: 100%;
   max-width: none;
-  margin: 0 var(--space-2) var(--space-2) var(--space-3);
   border-radius: 8px;
   background: var(--color-surface-sunken);
   container-type: inline-size;

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -3036,8 +3036,9 @@ textarea:hover {
 }
 
 .composer-status-bar {
-  width: 100%;
+  width: calc(100% - var(--space-2) - var(--space-3));
   max-width: none;
+  margin: 0 var(--space-2) var(--space-2) var(--space-3);
   border-radius: 8px;
   background: var(--color-surface-sunken);
   container-type: inline-size;

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.test.ts
@@ -254,6 +254,44 @@ describe('chat detail state composition', () => {
     expect(model.composerWillQueue).toBe(false);
   });
 
+  it('keeps the status bar visible for idle chats with transcript history', () => {
+    const model = buildChatDetailDisplayReadModel({
+      transcriptCards: [assistantCard('turn:old:assistant', 'done')],
+      queuedTurns: [],
+      displayedProgress: null,
+      activeChat: { ...chatSummary('chat-1'), status: 'idle' },
+      assistantSharedFileCount: 0,
+      streamState: 'idle',
+      loadingActive: false,
+      activeError: null,
+      draft: '',
+      pendingAttachmentCount: 0
+    });
+
+    expect(model.showStatusBar).toBe(true);
+    expect(model.statusBar?.state).toBe('idle');
+    expect(model.chatHasActivity).toBe(true);
+    expect(model.showStartPicker).toBe(false);
+  });
+
+  it('keeps the status bar visible for completed chats with transcript history', () => {
+    const model = buildChatDetailDisplayReadModel({
+      transcriptCards: [assistantCard('turn:done:assistant', 'done')],
+      queuedTurns: [],
+      displayedProgress: null,
+      activeChat: { ...chatSummary('chat-1'), status: 'done' },
+      assistantSharedFileCount: 0,
+      streamState: 'idle',
+      loadingActive: false,
+      activeError: null,
+      draft: '',
+      pendingAttachmentCount: 0
+    });
+
+    expect(model.showStatusBar).toBe(true);
+    expect(model.statusBar?.state).toBe('done');
+  });
+
 });
 
 function userCard(id: string, text: string, raw: Record<string, unknown>): MessageTranscriptCard {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.test.ts
@@ -46,7 +46,7 @@ describe('chat detail state composition', () => {
       'turn:run-1:assistant'
     ]);
     expect(model.streamingMessageId).toBe('turn:run-1:assistant');
-    expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'shared-files']);
+    expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'shared-files', 'tail-spacer']);
     expect(model.statusAnnouncement).toBe('Assistant is responding. 1 queued message');
     expect(model.alertAnnouncement).toBe('');
     expect(model.showStreamHealthAside).toBe(true);
@@ -89,7 +89,7 @@ describe('chat detail state composition', () => {
       text: 'I am checking the renderer.',
       turnId: 'run-1'
     });
-    expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'typing']);
+    expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'typing', 'tail-spacer']);
   });
 
   it('keeps terminal live commentary before the final assistant reply', () => {
@@ -128,7 +128,7 @@ describe('chat detail state composition', () => {
       'intermediate:intermediate-event-1',
       'message:turn:run-1:assistant'
     ]);
-    expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'card']);
+    expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'card', 'tail-spacer']);
   });
 
   it('does not duplicate live progress already projected by the backend transcript', () => {
@@ -270,6 +270,7 @@ describe('chat detail state composition', () => {
 
     expect(model.showStatusBar).toBe(true);
     expect(model.statusBar?.state).toBe('idle');
+    expect(model.transcriptListItems.at(-1)?.kind).toBe('tail-spacer');
     expect(model.chatHasActivity).toBe(true);
     expect(model.showStartPicker).toBe(false);
   });

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
@@ -12,7 +12,8 @@ import type { ChatDetailStreamState } from './chatDetailLiveProjection';
 export type ChatTranscriptListItem =
   | { kind: 'card'; id: string; card: ChatTranscriptCard }
   | { kind: 'typing'; id: string; title: string }
-  | { kind: 'shared-files'; id: string };
+  | { kind: 'shared-files'; id: string }
+  | { kind: 'tail-spacer'; id: string };
 
 export type ChatDetailDisplayReadModelInput = {
   transcriptCards: ChatTranscriptCard[];
@@ -91,7 +92,8 @@ export function buildChatDetailDisplayReadModel(
     transcriptListItems: [
       ...displayTranscriptCards.map((card) => ({ kind: 'card' as const, id: card.id, card })),
       ...(showTypingIndicator ? [{ kind: 'typing' as const, id: 'typing-indicator', title: 'Assistant is typing' }] : []),
-      ...(input.assistantSharedFileCount > 0 ? [{ kind: 'shared-files' as const, id: 'assistant-shared-files' }] : [])
+      ...(input.assistantSharedFileCount > 0 ? [{ kind: 'shared-files' as const, id: 'assistant-shared-files' }] : []),
+      ...(showStatusBar ? [{ kind: 'tail-spacer' as const, id: 'status-bar-tail-spacer' }] : [])
     ],
     statusAnnouncement: screenReaderStatusAnnouncement(input, statusBar, lastAssistantMessageCard),
     alertAnnouncement: screenReaderAlertAnnouncement(statusBar),

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
@@ -73,7 +73,7 @@ export function buildChatDetailDisplayReadModel(
   const statusBar = buildChatStatusBar(input.displayedProgress, input.activeChat);
   const streamingMessageId = activeStreamingMessageId(input.displayedProgress, lastAssistantMessageCard);
   const showTypingIndicator = shouldShowTypingIndicator(input.displayedProgress, activeCards);
-  const showStatusBar = shouldShowChatDetailStatusBar(statusBar, input.displayedProgress);
+  const showStatusBar = shouldShowChatDetailStatusBar(statusBar, input.displayedProgress, activeCards);
   const chatHasActivity = activeCards.length > 0 || showStatusBar;
   const hasRunnableDraft = Boolean(input.activeChat && (input.draft.trim() || input.pendingAttachmentCount > 0));
   const composerWillQueue = shouldQueueComposerDraft(
@@ -240,11 +240,13 @@ function screenReaderAlertAnnouncement(statusBar: ChatStatusBar | null): string 
 
 function shouldShowChatDetailStatusBar(
   statusBar: ChatStatusBar | null,
-  progress: ChatRunProgress | null
+  progress: ChatRunProgress | null,
+  activeCards: ChatTranscriptCard[]
 ): boolean {
-  if (!statusBar || statusBar.state === 'idle') return false;
+  if (!statusBar) return false;
+  if (statusBar.state === 'idle') return activeCards.length > 0;
   if (statusBar.state === 'done') {
-    return Boolean(statusBar.tokenUsageLabel || statusBar.contextRemainingLabel);
+    return activeCards.length > 0 || Boolean(statusBar.tokenUsageLabel || statusBar.contextRemainingLabel);
   }
   return Boolean(
     (progress?.elapsedSeconds !== null && progress?.elapsedSeconds !== undefined) ||

--- a/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
@@ -15,7 +15,8 @@
     onEndReached,
     onScrollState,
     onReady,
-    bottomThresholdPx = 32
+    bottomThresholdPx = 32,
+    preserveBottomOnResize = false
   }: {
     items: T[];
     children: Snippet<[T, number]>;
@@ -31,6 +32,7 @@
     onScrollState?: (state: { atBottom: boolean; distanceFromBottom: number }) => void;
     onReady?: (api: { scrollToBottom: (behavior?: ScrollBehavior) => void }) => void;
     bottomThresholdPx?: number;
+    preserveBottomOnResize?: boolean;
   } = $props();
 
   let viewport: HTMLDivElement | null = $state(null);
@@ -105,6 +107,15 @@
     onScrollState({ atBottom: distanceFromBottom <= bottomThresholdPx, distanceFromBottom });
   }
 
+  function isNearBottom(): boolean {
+    if (!viewport || !scrollable) return true;
+    const distanceFromBottom = Math.max(
+      0,
+      viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
+    );
+    return distanceFromBottom <= bottomThresholdPx;
+  }
+
   function updateMeasurements(): void {
     if (!viewport) return;
     scrollTop = viewport.scrollTop;
@@ -120,6 +131,14 @@
   function scrollToBottom(behavior: ScrollBehavior = 'smooth'): void {
     if (!viewport) return;
     viewport.scrollTo({ top: viewport.scrollHeight, behavior });
+  }
+
+  async function preserveBottomIfNeeded(wasAtBottom: boolean): Promise<void> {
+    if (!preserveBottomOnResize || !wasAtBottom || !viewport || !scrollable) return;
+    await tick();
+    if (!viewport) return;
+    viewport.scrollTop = viewport.scrollHeight;
+    updateMeasurements();
   }
 
   function handleScroll(): void {
@@ -140,7 +159,9 @@
     const record = () => {
       const height = node.offsetHeight;
       if (!Number.isFinite(height) || height <= 0 || measuredHeights[currentKey] === height) return;
+      const wasAtBottom = isNearBottom();
       measuredHeights = { ...measuredHeights, [currentKey]: height };
+      void preserveBottomIfNeeded(wasAtBottom);
     };
     const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(record);
     observer?.observe(node);

--- a/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
@@ -42,6 +42,7 @@
   let viewportHeight = $state(0);
   let measuredHeights = $state<Record<string, number>>({});
   let rowGap = $state(0);
+  let lastAtBottom = true;
 
   const safeItemSize = $derived(Math.max(1, estimatedItemSize));
   const itemKeys = $derived(items.map((item, index) => key ? key(item, index) : String(index)));
@@ -94,26 +95,28 @@
     if (distanceFromBottom <= safeItemSize * 4) onEndReached();
   }
 
-  function reportScrollState(): void {
-    if (!onScrollState || !viewport) return;
-    if (!scrollable) {
-      onScrollState({ atBottom: true, distanceFromBottom: 0 });
-      return;
-    }
-    const distanceFromBottom = Math.max(
+  function distanceFromBottom(): number {
+    if (!viewport || !scrollable) return 0;
+    return Math.max(
       0,
       viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
     );
-    onScrollState({ atBottom: distanceFromBottom <= bottomThresholdPx, distanceFromBottom });
+  }
+
+  function reportScrollState(): void {
+    if (!viewport) return;
+    if (!scrollable) {
+      lastAtBottom = true;
+      onScrollState?.({ atBottom: true, distanceFromBottom: 0 });
+      return;
+    }
+    const distance = distanceFromBottom();
+    lastAtBottom = distance <= bottomThresholdPx;
+    onScrollState?.({ atBottom: lastAtBottom, distanceFromBottom: distance });
   }
 
   function isNearBottom(): boolean {
-    if (!viewport || !scrollable) return true;
-    const distanceFromBottom = Math.max(
-      0,
-      viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
-    );
-    return distanceFromBottom <= bottomThresholdPx;
+    return distanceFromBottom() <= bottomThresholdPx;
   }
 
   function updateMeasurements(): void {
@@ -145,6 +148,15 @@
     updateMeasurements();
   }
 
+  function handleViewportResize(): void {
+    const wasAtBottom = lastAtBottom;
+    if (preserveBottomOnResize && wasAtBottom) {
+      void preserveBottomIfNeeded(wasAtBottom);
+      return;
+    }
+    updateMeasurements();
+  }
+
   $effect(() => {
     void items;
     void itemUpdateToken;
@@ -159,7 +171,7 @@
     const record = () => {
       const height = node.offsetHeight;
       if (!Number.isFinite(height) || height <= 0 || measuredHeights[currentKey] === height) return;
-      const wasAtBottom = isNearBottom();
+      const wasAtBottom = lastAtBottom || isNearBottom();
       measuredHeights = { ...measuredHeights, [currentKey]: height };
       void preserveBottomIfNeeded(wasAtBottom);
     };
@@ -180,7 +192,7 @@
   onMount(() => {
     mounted = true;
     void tick().then(updateMeasurements);
-    const observer = new ResizeObserver(updateMeasurements);
+    const observer = new ResizeObserver(handleViewportResize);
     if (viewport) observer.observe(viewport);
     onReady?.({ scrollToBottom });
     return () => observer.disconnect();

--- a/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.test.ts
@@ -32,11 +32,14 @@ describe('VirtualList', () => {
     expect(body).toContain('80: Row 80');
   });
 
-  it('preserves bottom on row resize only when the caller opts in and the list was already at bottom', () => {
+  it('preserves bottom on row and viewport resize only when the caller opts in and the list was already at bottom', () => {
     const source = virtualListSource();
 
     expect(source).toContain('preserveBottomOnResize = false');
-    expect(source).toContain('const wasAtBottom = isNearBottom();');
+    expect(source).toContain('let lastAtBottom = true;');
+    expect(source).toContain('const wasAtBottom = lastAtBottom || isNearBottom();');
+    expect(source).toContain('function handleViewportResize()');
+    expect(source).toContain('const observer = new ResizeObserver(handleViewportResize);');
     expect(source).toContain('void preserveBottomIfNeeded(wasAtBottom);');
     expect(source).toContain('if (!preserveBottomOnResize || !wasAtBottom || !viewport || !scrollable) return;');
   });

--- a/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.test.ts
@@ -1,8 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { render } from 'svelte/server';
 import { describe, expect, it } from 'vitest';
 import VirtualListHarness from './VirtualListHarness.test.svelte';
 
 describe('VirtualList', () => {
+  function virtualListSource(): string {
+    return readFileSync(
+      fileURLToPath(new URL('./VirtualList.svelte', import.meta.url)),
+      'utf8'
+    );
+  }
+
   it('server-renders a bounded initial window for large lists', () => {
     const { body } = render(VirtualListHarness, { props: { count: 5000, initialCount: 40 } });
 
@@ -21,5 +30,14 @@ describe('VirtualList', () => {
     expect(body).toContain('class="virtual-list non-scrollable');
     expect(body.match(/class="seeded-row"/g)).toHaveLength(80);
     expect(body).toContain('80: Row 80');
+  });
+
+  it('preserves bottom on row resize only when the caller opts in and the list was already at bottom', () => {
+    const source = virtualListSource();
+
+    expect(source).toContain('preserveBottomOnResize = false');
+    expect(source).toContain('const wasAtBottom = isNearBottom();');
+    expect(source).toContain('void preserveBottomIfNeeded(wasAtBottom);');
+    expect(source).toContain('if (!preserveBottomOnResize || !wasAtBottom || !viewport || !scrollable) return;');
   });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -542,7 +542,6 @@
   // bottom of the transcript. Once they scroll up, we stop force-scrolling
   // on every content change; scrolling back near the bottom re-arms it.
   let followBottom = true;
-  let messageStackResizeObserver: ResizeObserver | null = null;
 
   const activeChat = $derived(activeChatId ? chatSummaryForId(activeChatId) : null);
   const activeSurfaceDeliveries = $derived<ArtifactDelivery[]>(artifactDeliveriesForActiveSurface(activeChat, artifactDeliveries));
@@ -1845,13 +1844,6 @@
     return messageStack?.querySelector<HTMLElement>('.chat-transcript-virtual-list') ?? messageStack;
   }
 
-  function isMessageStackNearBottom(): boolean {
-    const scroller = messageScroller();
-    if (!scroller) return true;
-    const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
-    return distanceFromBottom <= TRANSCRIPT_BOTTOM_THRESHOLD_PX;
-  }
-
   async function scrollMessagesToBottom(): Promise<void> {
     await tick();
     const scroller = messageScroller();
@@ -1859,33 +1851,10 @@
     scroller.scrollTop = scroller.scrollHeight;
   }
 
-  function handleMessageScroll(): void {
-    // The user's scroll position is the source of truth for follow-bottom.
-    // Programmatic scrolls fire this too, but they land at the bottom so
-    // followBottom stays true; user-initiated scrolls up flip it false.
-    followBottom = isMessageStackNearBottom();
+  function updateTranscriptScrollState(atBottom: boolean): void {
+    transcriptAtBottom = atBottom;
+    followBottom = atBottom;
   }
-
-  $effect(() => {
-    // Attach scroll listener + ResizeObserver to whichever element is the
-    // scroller right now. The ResizeObserver catches growing message content
-    // (streaming tokens, live commentary) which doesn't change card count,
-    // so the cardCount-keyed effect below would otherwise miss it.
-    if (!messageStack) return;
-    const scroller = messageScroller();
-    if (!scroller) return;
-    scroller.addEventListener('scroll', handleMessageScroll, { passive: true });
-    messageStackResizeObserver = new ResizeObserver(() => {
-      if (followBottom) scroller.scrollTop = scroller.scrollHeight;
-    });
-    messageStackResizeObserver.observe(scroller);
-    if (scroller.firstElementChild) messageStackResizeObserver.observe(scroller.firstElementChild);
-    return () => {
-      scroller.removeEventListener('scroll', handleMessageScroll);
-      messageStackResizeObserver?.disconnect();
-      messageStackResizeObserver = null;
-    };
-  });
 
   async function createChat(options: { preserveSelectedScope?: boolean; preserveSelectedKind?: boolean } = {}): Promise<void> {
     creating = true;
@@ -2917,7 +2886,8 @@
           class="chat-transcript-virtual-list"
           itemClass="chat-transcript-virtual-item"
           bottomThresholdPx={TRANSCRIPT_BOTTOM_THRESHOLD_PX}
-          onScrollState={({ atBottom }) => { transcriptAtBottom = atBottom; }}
+          preserveBottomOnResize
+          onScrollState={({ atBottom }) => updateTranscriptScrollState(atBottom)}
           onReady={(api) => { transcriptApi = api; }}
         >
           {#snippet children(item)}
@@ -2943,23 +2913,25 @@
     <div class="sr-only" aria-live="polite" aria-atomic="true">{srStatusAnnouncement}</div>
     <div class="sr-only" role="alert" aria-atomic="true">{srAlertAnnouncement}</div>
 
-    {#if (activeChat && transcriptListItems.length > 0 && !transcriptAtBottom) || (showStatusBar && statusBar)}
+    {#if activeChat && transcriptListItems.length > 0 && !transcriptAtBottom}
       <div class="composer-overlay-anchor">
         <div class="composer-overlay">
-          {#if activeChat && transcriptListItems.length > 0 && !transcriptAtBottom}
-            <button
-              type="button"
-              class="jump-to-latest"
-              onclick={() => transcriptApi?.scrollToBottom('smooth')}
-              aria-label="Jump to latest message"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M12 5v14M19 12l-7 7-7-7" />
-              </svg>
-              Jump to latest
-            </button>
-          {/if}
-          {#if showStatusBar && statusBar}
+          <button
+            type="button"
+            class="jump-to-latest"
+            onclick={() => transcriptApi?.scrollToBottom('smooth')}
+            aria-label="Jump to latest message"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 5v14M19 12l-7 7-7-7" />
+            </svg>
+            Jump to latest
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    {#if showStatusBar && statusBar}
       <div class={`pma-status-bar composer-status-bar ${statusBar.state}`} aria-label="Turn status">
         <span class="status-dot" aria-hidden="true"></span>
         <strong>{statusLabel(statusBar.state)}</strong>
@@ -3004,9 +2976,6 @@
             </span>
           </span>
         {/if}
-      </div>
-          {/if}
-        </div>
       </div>
     {/if}
 

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -2828,7 +2828,7 @@
       {/if}
     </div>
 
-    <div bind:this={messageStack} class="message-stack">
+    <div bind:this={messageStack} class="message-stack" class:has-status-overlay={showStatusBar && statusBar}>
       {#if refreshingActive && (activeChat || activeChatId)}
         <div class="state-panel loading-state">
           <span class="state-icon" aria-hidden="true"></span>
@@ -2903,6 +2903,8 @@
                 assistantLabel={chatAgentDisplayLabel}
                 sharedFiles={assistantSharedFiles}
               />
+            {:else if item.kind === 'tail-spacer'}
+              <div class="chat-transcript-tail-spacer" aria-hidden="true"></div>
             {:else}
               {@render typingDots(item.title)}
             {/if}
@@ -2913,25 +2915,23 @@
     <div class="sr-only" aria-live="polite" aria-atomic="true">{srStatusAnnouncement}</div>
     <div class="sr-only" role="alert" aria-atomic="true">{srAlertAnnouncement}</div>
 
-    {#if activeChat && transcriptListItems.length > 0 && !transcriptAtBottom}
+    {#if (activeChat && transcriptListItems.length > 0 && !transcriptAtBottom) || (showStatusBar && statusBar)}
       <div class="composer-overlay-anchor">
         <div class="composer-overlay">
-          <button
-            type="button"
-            class="jump-to-latest"
-            onclick={() => transcriptApi?.scrollToBottom('smooth')}
-            aria-label="Jump to latest message"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M12 5v14M19 12l-7 7-7-7" />
-            </svg>
-            Jump to latest
-          </button>
-        </div>
-      </div>
-    {/if}
-
-    {#if showStatusBar && statusBar}
+          {#if activeChat && transcriptListItems.length > 0 && !transcriptAtBottom}
+            <button
+              type="button"
+              class="jump-to-latest"
+              onclick={() => transcriptApi?.scrollToBottom('smooth')}
+              aria-label="Jump to latest message"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 5v14M19 12l-7 7-7-7" />
+              </svg>
+              Jump to latest
+            </button>
+          {/if}
+          {#if showStatusBar && statusBar}
       <div class={`pma-status-bar composer-status-bar ${statusBar.state}`} aria-label="Turn status">
         <span class="status-dot" aria-hidden="true"></span>
         <strong>{statusLabel(statusBar.state)}</strong>
@@ -2976,6 +2976,9 @@
             </span>
           </span>
         {/if}
+      </div>
+          {/if}
+        </div>
       </div>
     {/if}
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -107,6 +107,8 @@ describe('/chats page', () => {
     const pageSource = chatDetailPageSource();
 
     expect(pageSource).toContain('preserveBottomOnResize');
+    expect(pageSource).toContain("item.kind === 'tail-spacer'");
+    expect(pageSource).toContain('chat-transcript-tail-spacer');
     expect(pageSource).toContain('onScrollState={({ atBottom }) => updateTranscriptScrollState(atBottom)}');
     expect(pageSource).not.toContain('new ResizeObserver');
     expect(pageSource).not.toContain("addEventListener('scroll', handleMessageScroll");

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -103,6 +103,15 @@ describe('/chats page', () => {
     expect(pageSource).not.toContain('read-active:');
   });
 
+  it('keeps transcript bottom-follow owned by the virtualized transcript scroller', () => {
+    const pageSource = chatDetailPageSource();
+
+    expect(pageSource).toContain('preserveBottomOnResize');
+    expect(pageSource).toContain('onScrollState={({ atBottom }) => updateTranscriptScrollState(atBottom)}');
+    expect(pageSource).not.toContain('new ResizeObserver');
+    expect(pageSource).not.toContain("addEventListener('scroll', handleMessageScroll");
+  });
+
   it('navigates committed chat URLs through SvelteKit route state', () => {
     const source = chatDetailPageSource();
     const syncCommittedBody = source.match(


### PR DESCRIPTION
## Summary
- keep the chat status bar visible for idle/completed chats that have transcript history
- move the status bar out of the floating overlay and into the normal composer region
- make transcript row-resize bottom preservation an explicit VirtualList behavior so streaming stays anchored only when the user was already at the bottom
- remove the page-level scroll/resize observer that could pull idle chats back to the bottom after the user scrolled up

## Root Cause
The chat page had two coupled regressions: status bar rendering was tied to a floating composer overlay instead of a persistent bottom status surface, and a page-level ResizeObserver forced the transcript scroller to the bottom whenever layout changed while follow-bottom was still armed. That made idle chats jump down after user scrolls and made the status bar disappear from the expected bottom location.

## Review
A subagent review found that removing the old resize observer also removed bottom preservation for streaming row height growth. The patch now restores that behavior inside VirtualList behind preserveBottomOnResize, gated by whether the list was already near the bottom before the row resized.

## Validation
- pnpm web:lint
- pnpm web:test
- pnpm run build (web_frontend)
- pre-commit web-ui lane: repo guardrails, pytest 9654 passed, web UI lab, web lint, build, web tests, SPA shell check
