### PR TITLE
[codex] Persist default chat model in surface turns

### DIFF
--- a/src/codex_autorunner/adapters/chat/canonical_turns.py
+++ b/src/codex_autorunner/adapters/chat/canonical_turns.py
@@ -18,11 +18,11 @@ def _surface_source_id(surface_kind: str, surface_key: str) -> str:
 
 
 def _resolved_model_payload(
-    agent: str, model: Optional[str]
+    agent: str, model: Optional[str], configured_default_model: Optional[str]
 ) -> tuple[Optional[str], dict[str, str]]:
-    resolved_model = model
-    if agent == "opencode" and not resolved_model:
-        resolved_model = DEFAULT_CHAT_AGENT_MODELS.get(agent)
+    resolved_model = (
+        model or configured_default_model or DEFAULT_CHAT_AGENT_MODELS.get(agent)
+    )
     payload = (
         resolve_opencode_model_payload(resolved_model) if agent == "opencode" else None
     )
@@ -41,13 +41,16 @@ def build_surface_turn_execution_request(
     sandbox_policy: Any,
     profile: Optional[str] = None,
     client_request_id: Optional[str] = None,
+    configured_default_model: Optional[str] = None,
     origin_metadata: Optional[Mapping[str, Any]] = None,
     delivery_surface_key: Optional[str] = None,
     delivery_metadata: Optional[Mapping[str, Any]] = None,
 ) -> TurnExecutionRequest:
     """Build the durable turn contract at chat-surface ingress."""
 
-    model, model_payload = _resolved_model_payload(agent, request.model)
+    model, model_payload = _resolved_model_payload(
+        agent, request.model, configured_default_model
+    )
     delivery_key = delivery_surface_key or surface_key
     return TurnExecutionRequest(
         request_id=request_id,

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -47,12 +47,14 @@ from ...adapters.chat.models import ChatMessageEvent
 from ...adapters.chat.runtime_thread_errors import (
     sanitize_runtime_thread_error,
 )
+from ...core.agent_model_defaults import resolve_model_for_agent
 from ...core.apps.install import installed_apps_root
 from ...core.artifact_delivery import ArtifactDeliveryService
 from ...core.artifact_instructions import (
     ArtifactDeliveryContext,
     render_agent_artifact_instructions,
 )
+from ...core.config import ConfigError, load_hub_config
 from ...core.context_awareness import (
     maybe_inject_car_awareness,
     maybe_inject_filebox_hint,
@@ -87,6 +89,8 @@ from ...core.pma_notification_store import (
     build_notification_context_block,
     notification_surface_key,
 )
+from ...core.state import load_state
+from ...core.state_roots import resolve_repo_runner_state_db_path
 from ...core.utils import canonicalize_path
 from ..chat.agents import DEFAULT_CHAT_AGENT_MODELS
 from ..chat.bound_chat_execution_metadata import merge_bound_chat_execution_metadata
@@ -484,6 +488,29 @@ def _extract_binding_resource_fields(
             if isinstance(resource_id, str) and resource_id.strip()
             else None
         ),
+    )
+
+
+def _resolve_configured_surface_turn_default_model(
+    service: Any,
+    *,
+    agent: str,
+) -> Optional[str]:
+    hub_root = Path(getattr(service._config, "root", Path.cwd()))
+    try:
+        hub_config = load_hub_config(hub_root)
+    except (ConfigError, OSError, RuntimeError, TypeError, ValueError):
+        hub_config = None
+    try:
+        state_path = resolve_repo_runner_state_db_path(hub_root)
+        state = load_state(state_path) if state_path.exists() else None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        state = None
+    return resolve_model_for_agent(
+        agent,
+        state=state,
+        config=hub_config,
+        include_builtin=False,
     )
 
 
@@ -2766,6 +2793,9 @@ async def _run_discord_orchestrated_turn_for_message(
         sandbox_policy=sandbox_policy,
         profile=getattr(thread, "agent_profile", None),
         client_request_id=client_request_id,
+        configured_default_model=_resolve_configured_surface_turn_default_model(
+            service, agent=agent
+        ),
         origin_metadata={
             "channel_id": channel_id,
             "session_key": session_key,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -1782,6 +1782,7 @@ async def _run_telegram_managed_thread_turn(
         sandbox_policy=sandbox_policy or "dangerFullAccess",
         profile=agent_profile,
         client_request_id=client_request_id,
+        configured_default_model=record.model,
         origin_metadata={
             "chat_id": message.chat_id,
             "thread_id": message.thread_id,
@@ -2925,6 +2926,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                     sandbox_policy=sandbox_policy or "dangerFullAccess",
                     profile=profile,
                     client_request_id=canonical_client_request_id,
+                    configured_default_model=record.model,
                     origin_metadata={
                         "chat_id": message.chat_id,
                         "thread_id": message.thread_id,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
@@ -924,6 +924,7 @@ class GitHubCommands(TelegramCommandSupportMixin):
                     client_request_id=(
                         f"telegram:{topic_key}:review:{secrets.token_hex(6)}"
                     ),
+                    configured_default_model=record.model,
                     origin_metadata={
                         "chat_id": message.chat_id,
                         "thread_id": message.thread_id,

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from ..agent_model_defaults import builtin_default_model_for_agent
 from ..car_context import CarContextProfile
 from ..domain.refs import ScopeRef
 from ..logging_utils import log_event
@@ -59,9 +60,10 @@ class ForeignModelError(ValueError):
     """Raised when a turn specifies a model the resolved agent cannot use.
 
     An agent without the ``model_listing`` capability (e.g. Hermes/ACP) has no
-    caller-selectable model catalog, so any non-empty model on such a turn is
-    foreign. The turn is rejected before dispatch so the model never reaches
-    the agent session and never lands in ``orch_thread_executions`` (#1854).
+    caller-selectable model catalog, so a non-empty model that is not the
+    agent's built-in default is foreign. The turn is rejected before dispatch so
+    the foreign model never reaches the agent session and never lands in
+    ``orch_thread_executions`` (#1854).
     """
 
     def __init__(self, *, agent_id: str, model: str) -> None:
@@ -814,13 +816,17 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
 
         # Reject a caller-specified model the resolved agent cannot use, before
         # the turn is created or dispatched. An agent without `model_listing`
-        # (e.g. Hermes/ACP) has no caller-selectable model catalog, so a
-        # non-empty model on such a turn is foreign. Letting it through pins
-        # the bad model onto the agent session and bricks every later turn
-        # (#1854). Raising here keeps the foreign model out of the agent
-        # session and out of orch_thread_executions entirely.
+        # (e.g. Hermes/ACP) has no caller-selectable model catalog, but its own
+        # built-in default can be persisted as system-resolved runtime metadata.
+        # Any other non-empty model is foreign; letting it through pins the bad
+        # model onto the agent session and bricks every later turn (#1854).
         requested_model = (message_request.model or "").strip()
-        if requested_model and "model_listing" not in definition.capabilities:
+        builtin_model = builtin_default_model_for_agent(definition.agent_id)
+        if (
+            requested_model
+            and "model_listing" not in definition.capabilities
+            and requested_model != builtin_model
+        ):
             raise ForeignModelError(
                 agent_id=definition.agent_id,
                 model=requested_model,

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_send_runtime.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_send_runtime.py
@@ -293,6 +293,7 @@ async def run_managed_thread_message_send(
             sandbox_policy=options.sandbox_policy or "dangerFullAccess",
             profile=options.agent_profile,
             client_request_id=client_turn_id,
+            configured_default_model=options.model,
         )
         automation_child_plan = _prepare_automation_child_for_managed_send(
             hub_root,

--- a/tests/adapters/chat/test_canonical_turns.py
+++ b/tests/adapters/chat/test_canonical_turns.py
@@ -95,6 +95,77 @@ def test_surface_turn_builder_validates_opencode_provider_model_payload() -> Non
     }
 
 
+def test_surface_turn_builder_records_codex_default_model_when_implicit() -> None:
+    request = replace(_message_request(), model=None)
+
+    turn_request = build_surface_turn_execution_request(
+        request,
+        request_id="codex-request",
+        workspace_root="/repo",
+        surface_kind="discord",
+        surface_key="channel-1",
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+    )
+
+    assert turn_request.model == "gpt-5.5"
+
+
+def test_surface_turn_builder_prefers_configured_default_model() -> None:
+    request = replace(_message_request(), model=None)
+
+    turn_request = build_surface_turn_execution_request(
+        request,
+        request_id="codex-request",
+        workspace_root="/repo",
+        surface_kind="discord",
+        surface_key="channel-1",
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        configured_default_model="gpt-configured",
+    )
+
+    assert turn_request.model == "gpt-configured"
+
+
+def test_surface_turn_builder_prefers_explicit_model_over_configured_default() -> None:
+    request = replace(_message_request(), model="gpt-explicit")
+
+    turn_request = build_surface_turn_execution_request(
+        request,
+        request_id="codex-request",
+        workspace_root="/repo",
+        surface_kind="discord",
+        surface_key="channel-1",
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        configured_default_model="gpt-configured",
+    )
+
+    assert turn_request.model == "gpt-explicit"
+
+
+def test_surface_turn_builder_leaves_unknown_agent_model_unset() -> None:
+    request = replace(_message_request(), model=None)
+
+    turn_request = build_surface_turn_execution_request(
+        request,
+        request_id="custom-agent-request",
+        workspace_root="/repo",
+        surface_kind="discord",
+        surface_key="channel-1",
+        agent="custom-agent",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+    )
+
+    assert turn_request.model is None
+    assert turn_request.model_payload == {}
+
+
 @pytest.mark.parametrize("command_id", ["car.new", "car.files.inbox"])
 def test_stable_and_partial_command_metadata_can_build_valid_surface_turns(
     command_id: str,

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -1496,6 +1496,24 @@ def test_normalize_discord_command_path_preserves_compatibility_aliases() -> Non
     )
 
 
+def test_discord_surface_turn_default_model_uses_hub_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = SimpleNamespace(_config=SimpleNamespace(root=tmp_path))
+    monkeypatch.setattr(
+        discord_message_turns,
+        "load_hub_config",
+        lambda root: SimpleNamespace(codex_model="gpt-configured"),
+    )
+
+    assert (
+        discord_message_turns._resolve_configured_surface_turn_default_model(
+            service, agent="codex"
+        )
+        == "gpt-configured"
+    )
+
+
 def _bind_select_interaction(
     *, selected_value: str = "repo-1", user_id: str = "user-1"
 ) -> dict[str, Any]:

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -763,6 +763,42 @@ async def test_prepare_rejects_foreign_model_for_non_model_listing_agent(
     assert service.get_running_execution(thread.thread_target_id) is None
 
 
+async def test_prepare_allows_builtin_default_for_non_listing_codex_agent(
+    tmp_path: Path,
+) -> None:
+    # Some tests and plugin descriptors can omit `model_listing` while still
+    # representing the built-in Codex agent. Persisting Codex's own default is
+    # not a foreign picker override and should not block dispatch.
+    harness = _HarnessWithWait()
+    service = _build_service(
+        tmp_path,
+        harness,
+        capabilities=frozenset(["durable_threads", "message_turns", "review"]),
+    )
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+
+    started = await begin_runtime_thread_execution(
+        service,
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="hello codex",
+            model="gpt-5.5",
+        ),
+    )
+    outcome = await await_runtime_thread_outcome(
+        started,
+        interrupt_event=asyncio.Event(),
+        timeout_seconds=5,
+        execution_error_message="Managed thread execution failed",
+    )
+
+    assert outcome.status == "ok"
+    assert harness.start_turn_calls[0]["model"] == "gpt-5.5"
+
+
 async def test_prepare_allows_model_for_model_listing_agent(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Resolve known agents to their built-in default model when a surface turn omits an explicit model.
- Preserve the foreign-model guard by allowing only the resolved agent's own built-in default through for non-model-listing descriptors.
- Add regression coverage for implicit Codex defaults, unknown-agent behavior, and the non-model-listing Codex compatibility path.

## Root Cause
Surface turns only defaulted OpenCode models. Codex turns without an explicit picker override persisted `NULL` model data, so chat list rows and detail headers projected `model unknown`.

## Review
Subagent review completed. Initial review found no issues; follow-up review found stale guard wording, which was fixed.

## Validation
- `.venv/bin/python -m pytest tests/adapters/chat/test_canonical_turns.py`
- `.venv/bin/python -m pytest tests/adapters/chat/test_canonical_turns.py tests/core/orchestration/test_runtime_threads.py -q`
- `.venv/bin/python -m pytest tests/test_agent_runtime_options.py tests/core/orchestration/test_runtime_threads.py tests/core/orchestration/test_service.py -q`
- Commit hook aggregate lane: guardrails, mypy, repo-wide pytest (`9657 passed`), web lint/build/tests (`910 passed`), SPA shell check
