### PR TITLE
[codex] Fix queued interrupt duplicate chat rows

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatSendController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatSendController.test.ts
@@ -139,6 +139,31 @@ describe('chat send controller', () => {
     );
   });
 
+  it('removes queued-turn interrupt optimistic rows after backend transcript confirmation', async () => {
+    const turn = queuedTurn('turn-queued');
+    const harness = createHarness({ queuedTurns: [turn] });
+    harness.store.upsertChatTranscriptCards('chat-1', [
+      userTranscriptCard('optimistic:user:unrelated', 'still pending', {
+        optimistic: true,
+        client_turn_id: 'optimistic:user:unrelated',
+        correlation_id: 'optimistic:user:unrelated'
+      })
+    ]);
+    harness.api.pma.cancelQueuedTurn.mockResolvedValue(ok({}));
+    harness.api.pma.sendMessage.mockResolvedValue(ok({ chatId: 'chat-1', id: 'turn-new', text: turn.prompt }));
+    harness.refreshActive.mockImplementation(async (chatId) => {
+      harness.store.upsertChatTranscriptCards(chatId, [
+        userTranscriptCard('turn-new:user', turn.prompt, {
+          identity: { correlation_id: 'optimistic:user:1778932800000:turn' }
+        })
+      ]);
+    });
+
+    await harness.controller.interruptWithQueuedTurn(turn);
+
+    expect(harness.transcriptIds('chat-1')).toEqual(['optimistic:user:unrelated', 'turn-new:user']);
+  });
+
   it('clears the real queue but ignores optimistic-only queue rows', async () => {
     const realTurn = queuedTurn('turn-real');
     const optimisticTurn = queuedTurn('optimistic-queue:client-1', { optimistic: true });
@@ -299,6 +324,26 @@ function queuedTurn(managedTurnId: string, raw: Record<string, unknown> = {}): C
     reasoning: null,
     enqueuedAt: now.toISOString(),
     raw
+  };
+}
+
+function userTranscriptCard(id: string, text: string, raw: Record<string, unknown>) {
+  return {
+    kind: 'message' as const,
+    id,
+    turnId: id.split(':')[1] ?? null,
+    orderKey: `00000001|${now.toISOString()}|${id}`,
+    timestamp: now.toISOString(),
+    message: {
+      id,
+      chatId: 'chat-1',
+      role: 'user' as const,
+      text,
+      createdAt: now.toISOString(),
+      status: null,
+      artifacts: [],
+      raw
+    }
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatSendController.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatSendController.ts
@@ -51,6 +51,7 @@ export type ChatSendControllerDeps = {
     | 'optimisticSend'
     | 'upsertChatTranscriptCards'
     | 'removeOptimisticChatTranscriptCards'
+    | 'removeOptimisticChatTranscriptCard'
     | 'failOptimisticMutation'
     | 'setChatQueue'
   >;
@@ -383,6 +384,9 @@ export function createChatSendController(deps: ChatSendControllerDeps): ChatSend
     if (result.ok) {
       await deps.invalidateChatMutation(chatId);
       await deps.refreshActive(chatId, { quiet: true });
+      if (transcriptHasBackendUserRow(chatId, clientTurnId)) {
+        deps.readModelStore.removeOptimisticChatTranscriptCard(chatId, clientTurnId);
+      }
     } else {
       deps.readModelStore.removeOptimisticChatTranscriptCards(chatId);
       deps.setComposeError(result.error);

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -354,6 +354,34 @@ describe('read model entity store', () => {
     });
   });
 
+  it('reconciles optimistic user transcript rows when matching backend rows append later', () => {
+    const store = new ReadModelEntityStore();
+    const optimistic = pmaMessageCard('chat-1', 'optimistic:user:client-1', 'queued prompt');
+    const unrelatedOptimistic = pmaMessageCard('chat-1', 'optimistic:user:client-2', 'still pending');
+    const backendUser = pmaMessageCard('chat-1', 'turn:1:user', 'queued prompt');
+    optimistic.message.raw = {
+      optimistic: true,
+      client_turn_id: 'client-1',
+      correlation_id: 'client-1'
+    };
+    unrelatedOptimistic.message.raw = {
+      optimistic: true,
+      client_turn_id: 'client-2',
+      correlation_id: 'client-2'
+    };
+    backendUser.message.raw = {
+      identity: { correlation_id: 'client-1' }
+    };
+
+    store.upsertChatTranscriptCards('chat-1', [optimistic, unrelatedOptimistic]);
+    store.upsertChatTranscriptCards('chat-1', [backendUser]);
+
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual([
+      'optimistic:user:client-2',
+      'turn:1:user'
+    ]);
+  });
+
   it('does not clone untouched cached transcripts when progress updates', () => {
     const store = new ReadModelEntityStore();
     const active = pmaMessageCard('chat-1', 'turn:1:user', 'hello');
@@ -1065,7 +1093,7 @@ describe('read model entity store', () => {
   });
 });
 
-function pmaMessageCard(chatId: string, id: string, text: string): ChatTranscriptCard {
+function pmaMessageCard(chatId: string, id: string, text: string): Extract<ChatTranscriptCard, { kind: 'message' }> {
   return {
     kind: 'message',
     id,

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -540,6 +540,10 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
         if (currentIndex >= 0) transcript.order.splice(currentIndex, 1);
       }
       insertOrderedChatTranscriptId(transcript, id);
+      for (const optimisticId of confirmedOptimisticTranscriptIds(transcript, card)) {
+        delete transcript.cardsById[optimisticId];
+        transcript.order = transcript.order.filter((itemId) => itemId !== optimisticId);
+      }
       changed = true;
     }
     if (!changed) return;
@@ -1472,6 +1476,39 @@ function transcriptCardTurnId(card: ChatTranscriptCard): string | null {
 function transcriptCardTimestamp(card: ChatTranscriptCard): string | null {
   if ('timestamp' in card && card.timestamp) return card.timestamp;
   if (card.kind === 'message') return card.message.createdAt;
+  return null;
+}
+
+function confirmedOptimisticTranscriptIds(
+  transcript: { cardsById: Record<string, ChatTranscriptCard>; order: string[] },
+  backendCard: ChatTranscriptCard
+): string[] {
+  if (backendCard.kind !== 'message' || backendCard.message.role !== 'user' || backendCard.id.startsWith('optimistic:')) {
+    return [];
+  }
+  const correlationId = transcriptCardCorrelationId(backendCard);
+  if (!correlationId) return [];
+  return transcript.order.filter((id) => {
+    if (!id.startsWith('optimistic:')) return false;
+    const optimistic = transcript.cardsById[id];
+    return (
+      optimistic?.kind === 'message' &&
+      optimistic.message.role === 'user' &&
+      transcriptCardCorrelationId(optimistic) === correlationId
+    );
+  });
+}
+
+function transcriptCardCorrelationId(card: ChatTranscriptCard): string | null {
+  if (card.kind !== 'message') return null;
+  const raw = card.message.raw;
+  const direct = raw.correlation_id ?? raw.client_turn_id;
+  if (typeof direct === 'string' && direct.trim()) return direct.trim();
+  const identity = raw.identity;
+  if (identity && typeof identity === 'object' && !Array.isArray(identity)) {
+    const value = (identity as Record<string, unknown>).correlation_id;
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
   return null;
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -562,6 +562,18 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     this.commit(next);
   }
 
+  removeOptimisticChatTranscriptCard(chatId: string, cardId: string): void {
+    const transcript = this.state.chatTranscripts[chatId];
+    if (!transcript || !cardId.startsWith('optimistic:') || !transcript.cardsById[cardId]) return;
+    const next = cloneState(this.state);
+    const target = cloneChatTranscript(next.chatTranscripts[chatId]);
+    delete target.cardsById[cardId];
+    target.order = target.order.filter((id) => id !== cardId);
+    next.chatTranscripts[chatId] = target;
+    bump(next, 'timeline', chatId);
+    this.commit(next);
+  }
+
   setChatProgress(chatId: string, progress: ChatRunProgress | null): void {
     const next = cloneState(this.state);
     if (progress) next.chatProgress[chatId] = withBoundedChatProgressEvents(progress);


### PR DESCRIPTION
## Summary
- Remove only the confirmed queued-turn interrupt optimistic transcript row after backend confirmation.
- Add a targeted read-model store remover for one optimistic transcript card.
- Cover the queue interrupt reconciliation path with a regression test that preserves unrelated optimistic rows.

## Root Cause
Interrupting with a queued turn added an optimistic user transcript card, then refreshed the backend transcript without removing the matching optimistic row after confirmation. This could render the same user message twice.

## Review
A subagent review flagged that the first fix removed all optimistic transcript rows. This PR addresses that by removing only the matching client turn id.

## Validation
- pnpm web:test -- --run src/lib/application/chatSendController.test.ts
- pnpm web:test -- --run src/lib/data/readModelStore.test.ts
- pnpm web:lint
- pnpm web:test
- commit hook web-ui lane, build, SPA shell check, and repo-wide pytest: 9659 passed

## Notes
The first commit attempt hit unrelated core pytest failures/timeouts; the named failures passed individually and the retry passed the full hook suite.