### PR TITLE
[codex] Add global command palette navigation

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/palette/Palette.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/Palette.svelte
@@ -16,7 +16,8 @@
   onMount(() => store.subscribe(() => revision += 1));
 
   function handleInputKeydown(event: KeyboardEvent): void {
-    if (store.handleKeydown(event)) return;
+    if (!store.handleKeydown(event)) return;
+    event.stopPropagation();
   }
 </script>
 

--- a/src/codex_autorunner/web_frontend/src/lib/palette/Palette.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/Palette.svelte
@@ -1,25 +1,26 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { PaletteStore } from '$lib/palette/store';
 
   let { store }: { store: PaletteStore } = $props();
   let searchInput: HTMLInputElement | null = $state(null);
+  let revision = $state(0);
 
   $effect(() => {
+    revision;
     if (store.open) {
       queueMicrotask(() => searchInput?.focus());
     }
   });
 
-  function handleKeydown(event: KeyboardEvent): void {
-    if (store.handleKeydown(event)) return;
-  }
+  onMount(() => store.subscribe(() => revision += 1));
 
   function handleInputKeydown(event: KeyboardEvent): void {
     if (store.handleKeydown(event)) return;
   }
 </script>
 
-{#if store.open}
+{#if revision >= 0 && store.open}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="palette-backdrop" onclick={() => store.closePalette()} onkeydown={() => {}}>
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -41,7 +42,7 @@
           bind:this={searchInput}
           class="palette-input"
           type="text"
-          placeholder="Search commands, threads, scopes, tickets..."
+          placeholder="Search repos, worktrees, chats..."
           value={store.query}
           oninput={(event) => store.setQuery((event.target as HTMLInputElement).value)}
           onkeydown={handleInputKeydown}
@@ -52,6 +53,9 @@
       </div>
       <ul class="palette-list" role="listbox" aria-label="Palette results">
         {#each store.items as item, index (item.id)}
+          {#if index === 0 || item.group !== store.items[index - 1]?.group}
+            <li class="palette-group" role="presentation">{item.group}</li>
+          {/if}
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <li
             class={`palette-item ${index === store.activeIndex ? 'active' : ''}`}
@@ -60,8 +64,18 @@
             onclick={() => store.selectItem(item)}
             onpointerenter={() => { store.moveActive(index - store.activeIndex); }}
           >
-            <span class="palette-item-label">{item.label}</span>
-            <span class="palette-item-group">{item.group}</span>
+            <span class="palette-glyph" style:--palette-accent={item.accent ?? 'var(--color-accent)'} aria-hidden="true">
+              {item.glyph ?? item.label.slice(0, 1).toUpperCase()}
+            </span>
+            <span class="palette-item-copy">
+              <span class="palette-item-label">{item.label}</span>
+              {#if item.meta}
+                <span class="palette-item-meta">{item.meta}</span>
+              {/if}
+            </span>
+            {#if item.chip}
+              <span class="palette-item-chip">{item.chip}</span>
+            {/if}
           </li>
         {/each}
         {#if store.items.length === 0}
@@ -137,11 +151,19 @@
     flex: 1;
   }
 
+  .palette-group {
+    padding: var(--space-3) var(--space-4) var(--space-1);
+    color: var(--color-ink-faint);
+    font-size: var(--font-size-0);
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+
   .palette-item {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: var(--space-3);
+    min-height: 48px;
     padding: var(--space-2) var(--space-4);
     cursor: pointer;
     font-size: var(--font-size-1);
@@ -163,6 +185,7 @@
   }
 
   .palette-item-label {
+    display: block;
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -170,7 +193,36 @@
     font-weight: 500;
   }
 
-  .palette-item-group {
+  .palette-item-copy {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .palette-item-meta {
+    display: block;
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-0);
+    color: var(--color-ink-muted);
+  }
+
+  .palette-glyph {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background: color-mix(in srgb, var(--palette-accent) 12%, white);
+    color: var(--palette-accent);
+    font-size: var(--font-size-0);
+    font-weight: 700;
+  }
+
+  .palette-item-chip {
     font-size: var(--font-size-0);
     color: var(--color-ink-faint);
     flex-shrink: 0;

--- a/src/codex_autorunner/web_frontend/src/lib/palette/index.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/index.ts
@@ -3,6 +3,8 @@ export { createPaletteStore, type PaletteStore } from './store';
 export { createShortcutRegistry, buildStandardShortcuts, createBinding, type ShortcutRegistry } from './registry';
 export {
   threadSource,
+  repoSource,
+  worktreeSource,
   scopeSource,
   ticketSource,
   contextspaceSource,

--- a/src/codex_autorunner/web_frontend/src/lib/palette/sources.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/sources.test.ts
@@ -163,6 +163,8 @@ describe('recentActionsSource', () => {
     const items = source.load();
     expect(items).toHaveLength(1);
     expect(items[0].label).toBe('Test action');
+    expect(items[0].group).toBe('Recent');
+    expect(items[0].keywords).toContain('Test');
   });
 });
 
@@ -241,6 +243,16 @@ describe('filterItems', () => {
     const result = filterItems(items, 'fxlgn');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('1');
+  });
+
+  it('preserves group order while sorting matches within each group', () => {
+    const result = filterItems([
+      { id: 'repo-low', label: 'Search repo', group: 'Repos', keywords: 'aaa', action: { kind: 'navigate' as const, href: '/repo-low' } },
+      { id: 'repo-high', label: 'repo', group: 'Repos', keywords: 'repo', action: { kind: 'navigate' as const, href: '/repo-high' } },
+      { id: 'chat-high', label: 'repo', group: 'Chats', keywords: 'repo', action: { kind: 'navigate' as const, href: '/chat-high' } },
+      { id: 'chat-low', label: 'Search repo', group: 'Chats', keywords: 'aaa', action: { kind: 'navigate' as const, href: '/chat-low' } }
+    ], 'repo');
+    expect(result.map((item) => item.id)).toEqual(['repo-high', 'repo-low', 'chat-high', 'chat-low']);
   });
 
   it('returns empty for no matches', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/palette/sources.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/sources.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import {
   threadSource,
+  repoSource,
+  worktreeSource,
   scopeSource,
   ticketSource,
   contextspaceSource,
@@ -40,10 +42,12 @@ describe('threadSource', () => {
       }
     ];
     const source = threadSource(threads);
-    expect(source.group).toBe('Threads');
+    expect(source.group).toBe('Chats');
     const items = source.load();
     expect(items).toHaveLength(1);
     expect(items[0].label).toBe('Fix login bug');
+    expect(items[0].group).toBe('Chats');
+    expect(items[0].chip).toBe('#1');
     expect(items[0].action.kind).toBe('navigate');
     if (items[0].action.kind === 'navigate') {
       expect(items[0].action.href).toContain('thread-1');
@@ -52,21 +56,48 @@ describe('threadSource', () => {
 });
 
 describe('scopeSource', () => {
-  it('produces navigation items for repos and worktrees', () => {
-    const repos: RepoSummary[] = [
-      { id: 'repo-1', name: 'my-repo', path: null, status: 'idle', defaultBranch: null, worktreeCount: 0, activeRuns: 0, openTickets: 0, lastActivityAt: null, raw: {} }
-    ];
-    const worktrees: WorktreeSummary[] = [
-      { id: 'wt-1', repoId: 'repo-1', name: 'feature-branch', path: null, branch: 'feature', status: 'idle', activeRuns: 0, openTickets: 0, lastActivityAt: null, raw: {} }
-    ];
-    const source = scopeSource(repos, worktrees);
+  it('produces navigation items', () => {
+    const source = scopeSource();
     const items = source.load();
     const labels = items.map((i) => i.label);
     expect(labels).toContain('Chats');
     expect(labels).toContain('Repos');
     expect(labels).toContain('Settings');
-    expect(labels).toContain('my-repo');
-    expect(labels).toContain('feature-branch');
+    expect(items.every((item) => item.group === 'Navigation')).toBe(true);
+  });
+});
+
+describe('repoSource', () => {
+  it('produces repo navigation results with identity metadata', () => {
+    const repos: RepoSummary[] = [
+      { id: 'repo-1', name: 'my-repo', path: '/tmp/my-repo', status: 'idle', defaultBranch: 'main', worktreeCount: 0, activeRuns: 0, openTickets: 0, lastActivityAt: null, raw: {} }
+    ];
+    const source = repoSource(repos);
+    const items = source.load();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      label: 'my-repo',
+      group: 'Repos',
+      chip: '#1'
+    });
+    expect(items[0].meta).toContain('main');
+  });
+});
+
+describe('worktreeSource', () => {
+  it('produces worktree navigation results with branch metadata', () => {
+    const worktrees: WorktreeSummary[] = [
+      { id: 'wt-1', repoId: 'repo-1', name: 'feature-branch', path: null, branch: 'feature', status: 'idle', activeRuns: 0, openTickets: 0, lastActivityAt: null, raw: {} }
+    ];
+    const source = worktreeSource(worktrees);
+    const items = source.load();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      label: 'feature-branch',
+      group: 'Worktrees',
+      chip: '#1'
+    });
+    expect(items[0].meta).toContain('feature');
   });
 });
 
@@ -189,7 +220,7 @@ describe('filterItems', () => {
   });
 
   it('filters by group', () => {
-    const result = filterItems(items, 'scopes');
+    const result = filterItems(items, 'scope');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('2');
   });
@@ -204,6 +235,12 @@ describe('filterItems', () => {
     const result = filterItems(items, 'add palette');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('3');
+  });
+
+  it('supports fuzzy subsequence search', () => {
+    const result = filterItems(items, 'fxlgn');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
   });
 
   it('returns empty for no matches', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/palette/sources.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/sources.ts
@@ -8,6 +8,7 @@ import {
   worktreeRoute,
   worktreeTicketRoute
 } from '$lib/viewModels/routes';
+import { repoAccent, repoInitials } from '$lib/viewModels/repoIdentity';
 
 const RECENT_ACTIONS_MAX = 20;
 
@@ -31,74 +32,106 @@ export function getRecentActions(): PaletteItem[] {
 
 export function threadSource(threads: ChatSummary[]): PaletteSource {
   return {
-    group: 'Threads',
+    group: 'Chats',
     priority: 10,
     load: () =>
-      threads.map((thread) => ({
+      [...threads].sort(compareActivity).map((thread) => ({
         id: `thread:${thread.id}`,
         label: thread.title,
-        group: 'Threads',
-        keywords: `${thread.id} ${thread.agentId ?? ''} ${thread.ticketId ?? ''} ${thread.model ?? ''}`,
+        group: 'Chats',
+        keywords: `${thread.id} ${thread.agentId ?? ''} ${thread.ticketId ?? ''} ${thread.model ?? ''} ${thread.repoId ?? ''} ${thread.worktreeId ?? ''}`,
+        glyph: repoInitials(thread.title),
+        accent: repoAccent(thread.repoId ?? thread.worktreeId ?? thread.title),
+        meta: compactMeta([thread.agentId, thread.repoId, thread.worktreeId, relativeActivity(thread.updatedAt)]),
+        chip: shortId(thread.id),
+        lastActivityAt: thread.updatedAt,
         action: { kind: 'navigate', href: chatRoute(thread.id) }
       }))
   };
 }
 
-export function scopeSource(
-  repos: RepoSummary[],
-  worktrees: WorktreeSummary[]
-): PaletteSource {
+export function repoSource(repos: RepoSummary[]): PaletteSource {
   return {
-    group: 'Scopes',
+    group: 'Repos',
     priority: 20,
+    load: () =>
+      [...repos].sort(compareActivity).map((repo) => ({
+        id: `repo:${repo.id}`,
+        label: repo.name,
+        group: 'Repos',
+        keywords: `repo repository ${repo.id} ${repo.path ?? ''} ${repo.defaultBranch ?? ''}`,
+        glyph: repoInitials(repo.name),
+        accent: repoAccent(repo.name),
+        meta: compactMeta([repo.defaultBranch, repo.path, relativeActivity(repo.lastActivityAt)]),
+        chip: shortId(repo.id),
+        lastActivityAt: repo.lastActivityAt,
+        action: { kind: 'navigate', href: repoRoute(repo.id) }
+      }))
+  };
+}
+
+export function worktreeSource(worktrees: WorktreeSummary[]): PaletteSource {
+  return {
+    group: 'Worktrees',
+    priority: 30,
+    load: () =>
+      [...worktrees].sort(compareActivity).map((wt) => ({
+        id: `worktree:${wt.id}`,
+        label: wt.name,
+        group: 'Worktrees',
+        keywords: `worktree ${wt.id} ${wt.branch ?? ''} ${wt.repoId ?? ''} ${wt.path ?? ''}`,
+        glyph: repoInitials(wt.name),
+        accent: repoAccent(wt.repoId ?? wt.name),
+        meta: compactMeta([wt.branch, wt.repoId, relativeActivity(wt.lastActivityAt)]),
+        chip: shortId(wt.id),
+        lastActivityAt: wt.lastActivityAt,
+        action: { kind: 'navigate', href: worktreeRoute(wt.id, wt.repoId ?? null) }
+      }))
+  };
+}
+
+export function scopeSource(): PaletteSource {
+  return {
+    group: 'Navigation',
+    priority: 40,
     load: () => {
       const items: PaletteItem[] = [];
       items.push({
         id: 'scope:chats',
         label: 'Chats',
-        group: 'Scopes',
+        group: 'Navigation',
         keywords: 'chats hub home',
+        glyph: 'C',
+        accent: 'var(--color-accent)',
         action: { kind: 'navigate', href: '/chats' }
       });
       items.push({
         id: 'scope:repos',
         label: 'Repos',
-        group: 'Scopes',
+        group: 'Navigation',
         keywords: 'repos repositories',
+        glyph: 'R',
+        accent: 'var(--color-accent)',
         action: { kind: 'navigate', href: '/repos' }
       });
       items.push({
         id: 'scope:automations',
         label: 'Automations',
-        group: 'Scopes',
+        group: 'Navigation',
         keywords: 'automations schedules periodic jobs ticket flows',
+        glyph: 'A',
+        accent: 'var(--color-accent)',
         action: { kind: 'navigate', href: '/automations' }
       });
       items.push({
         id: 'scope:settings',
         label: 'Settings',
-        group: 'Scopes',
+        group: 'Navigation',
         keywords: 'settings preferences configuration',
+        glyph: 'S',
+        accent: 'var(--color-accent)',
         action: { kind: 'navigate', href: '/settings' }
       });
-      for (const repo of repos) {
-        items.push({
-          id: `scope:repo:${repo.id}`,
-          label: repo.name,
-          group: 'Scopes',
-          keywords: `repo ${repo.id} ${repo.path ?? ''}`,
-          action: { kind: 'navigate', href: repoRoute(repo.id) }
-        });
-      }
-      for (const wt of worktrees) {
-        items.push({
-          id: `scope:worktree:${wt.id}`,
-          label: wt.name,
-          group: 'Scopes',
-          keywords: `worktree ${wt.id} ${wt.branch ?? ''} ${wt.repoId ?? ''}`,
-          action: { kind: 'navigate', href: worktreeRoute(wt.id, wt.repoId ?? null) }
-        });
-      }
       return items;
     }
   };
@@ -193,8 +226,61 @@ export function filterItems(items: PaletteItem[], query: string): PaletteItem[] 
   if (!query.trim()) return items;
   const lower = query.toLowerCase();
   const terms = lower.split(/\s+/).filter(Boolean);
-  return items.filter((item) => {
+  return items.map((item) => {
     const haystack = `${item.label} ${item.group} ${item.keywords}`.toLowerCase();
-    return terms.every((term) => haystack.includes(term));
-  });
+    const termScores = terms.map((term) => fuzzyScore(haystack, term));
+    const score = termScores.every((termScore) => termScore > 0)
+      ? termScores.reduce((total, termScore) => total + termScore, 0)
+      : 0;
+    return { item, score };
+  }).filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.item);
+}
+
+function fuzzyScore(haystack: string, needle: string): number {
+  if (!needle) return 1;
+  const exact = haystack.indexOf(needle);
+  if (exact >= 0) return 1000 - exact;
+  let cursor = 0;
+  let score = 0;
+  for (const char of needle) {
+    const found = haystack.indexOf(char, cursor);
+    if (found < 0) return 0;
+    score += Math.max(1, 40 - (found - cursor));
+    cursor = found + 1;
+  }
+  return score;
+}
+
+function compareActivity<T extends { lastActivityAt?: string | null; updatedAt?: string | null }>(a: T, b: T): number {
+  return activityMillis(b) - activityMillis(a);
+}
+
+function activityMillis(value: { lastActivityAt?: string | null; updatedAt?: string | null }): number {
+  const raw = value.lastActivityAt ?? value.updatedAt;
+  return raw ? Date.parse(raw) || 0 : 0;
+}
+
+function compactMeta(values: Array<string | null | undefined>): string | null {
+  const parts = values.map((value) => value?.trim()).filter((value): value is string => Boolean(value));
+  return parts.length ? parts.join(' · ') : null;
+}
+
+function shortId(id: string): string {
+  const cleaned = id.trim();
+  if (!cleaned) return '';
+  const tail = cleaned.includes('-') ? cleaned.split('-').filter(Boolean).at(-1) ?? cleaned : cleaned;
+  return `#${tail.slice(0, 7)}`;
+}
+
+function relativeActivity(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const millis = Date.parse(value);
+  if (!Number.isFinite(millis)) return null;
+  const delta = Date.now() - millis;
+  if (delta < 60_000) return 'just now';
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+  return `${Math.floor(delta / 86_400_000)}d ago`;
 }

--- a/src/codex_autorunner/web_frontend/src/lib/palette/sources.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/sources.ts
@@ -226,16 +226,33 @@ export function filterItems(items: PaletteItem[], query: string): PaletteItem[] 
   if (!query.trim()) return items;
   const lower = query.toLowerCase();
   const terms = lower.split(/\s+/).filter(Boolean);
-  return items.map((item) => {
+  const scored = items.map((item) => {
     const haystack = `${item.label} ${item.group} ${item.keywords}`.toLowerCase();
     const termScores = terms.map((term) => fuzzyScore(haystack, term));
     const score = termScores.every((termScore) => termScore > 0)
       ? termScores.reduce((total, termScore) => total + termScore, 0)
       : 0;
     return { item, score };
-  }).filter((entry) => entry.score > 0)
-    .sort((a, b) => b.score - a.score)
-    .map((entry) => entry.item);
+  }).filter((entry) => entry.score > 0);
+
+  const groupOrder: string[] = [];
+  const byGroup = new Map<string, typeof scored>();
+  for (const entry of scored) {
+    const group = entry.item.group;
+    if (!byGroup.has(group)) {
+      groupOrder.push(group);
+      byGroup.set(group, []);
+    }
+    byGroup.get(group)!.push(entry);
+  }
+
+  const result: PaletteItem[] = [];
+  for (const group of groupOrder) {
+    const entries = byGroup.get(group)!;
+    entries.sort((a, b) => b.score - a.score);
+    for (const entry of entries) result.push(entry.item);
+  }
+  return result;
 }
 
 function fuzzyScore(haystack: string, needle: string): number {

--- a/src/codex_autorunner/web_frontend/src/lib/palette/sources.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/sources.ts
@@ -195,7 +195,12 @@ export function recentActionsSource(): PaletteSource {
   return {
     group: 'Recent',
     priority: 0,
-    load: () => getRecentActions()
+    load: () =>
+      getRecentActions().map((item) => ({
+        ...item,
+        group: 'Recent',
+        keywords: `${item.group} ${item.keywords}`
+      }))
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/palette/store.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/store.test.ts
@@ -192,6 +192,54 @@ describe('createPaletteStore', () => {
     expect(store.items).toHaveLength(1);
   });
 
+  it('updateSources preserves the active item when it is still present', () => {
+    const store = makeStore();
+    store.updateSources([{
+      group: 'Test',
+      priority: 0,
+      load: () => [
+        { id: 'a', label: 'A', group: 'G', keywords: '', action: { kind: 'navigate', href: '/a' } },
+        { id: 'b', label: 'B', group: 'G', keywords: '', action: { kind: 'navigate', href: '/b' } }
+      ]
+    }]);
+    store.openPalette();
+    store.moveActive(1);
+    expect(store.items[store.activeIndex]?.id).toBe('b');
+    store.updateSources([{
+      group: 'Test',
+      priority: 0,
+      load: () => [
+        { id: 'new', label: 'New', group: 'G', keywords: '', action: { kind: 'navigate', href: '/new' } },
+        { id: 'a', label: 'A', group: 'G', keywords: '', action: { kind: 'navigate', href: '/a' } },
+        { id: 'b', label: 'B', group: 'G', keywords: '', action: { kind: 'navigate', href: '/b' } }
+      ]
+    }]);
+    expect(store.items[store.activeIndex]?.id).toBe('b');
+  });
+
+  it('refresh preserves the active item when source ordering changes', () => {
+    let flipped = false;
+    const store = makeStore();
+    store.updateSources([{
+      group: 'Test',
+      priority: 0,
+      load: () => flipped
+        ? [
+            { id: 'b', label: 'B', group: 'G', keywords: '', action: { kind: 'navigate', href: '/b' } },
+            { id: 'a', label: 'A', group: 'G', keywords: '', action: { kind: 'navigate', href: '/a' } }
+          ]
+        : [
+            { id: 'a', label: 'A', group: 'G', keywords: '', action: { kind: 'navigate', href: '/a' } },
+            { id: 'b', label: 'B', group: 'G', keywords: '', action: { kind: 'navigate', href: '/b' } }
+          ]
+    }]);
+    store.openPalette();
+    store.moveActive(1);
+    flipped = true;
+    store.refresh();
+    expect(store.items[store.activeIndex]?.id).toBe('b');
+  });
+
   it('destroy cleans up', () => {
     const store = makeStore();
     store.destroy();

--- a/src/codex_autorunner/web_frontend/src/lib/palette/store.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/store.ts
@@ -55,10 +55,16 @@ export function createPaletteStore(
   });
   for (const binding of standardShortcuts) registry.register(binding);
 
-  function recompute(): void {
+  function recompute(options?: { preserveActiveId?: boolean }): void {
+    const activeId = options?.preserveActiveId ? filteredItems[activeIdx]?.id : undefined;
     allItems = loadAllItems(currentSources);
     filteredItems = filterItems(allItems, query);
-    if (activeIdx >= filteredItems.length) activeIdx = Math.max(0, filteredItems.length - 1);
+    if (activeId) {
+      const nextIdx = filteredItems.findIndex((item) => item.id === activeId);
+      activeIdx = nextIdx >= 0 ? nextIdx : Math.min(activeIdx, Math.max(0, filteredItems.length - 1));
+    } else if (activeIdx >= filteredItems.length) {
+      activeIdx = Math.max(0, filteredItems.length - 1);
+    }
   }
 
   function notify(): void {
@@ -112,12 +118,12 @@ export function createPaletteStore(
       store.closePalette();
     },
     refresh() {
-      recompute();
+      recompute({ preserveActiveId: true });
       notify();
     },
     updateSources(newSources: PaletteSource[]) {
       currentSources = newSources;
-      recompute();
+      recompute({ preserveActiveId: true });
       notify();
     },
     handleKeydown(event: KeyboardEvent | KeyEventLike) {

--- a/src/codex_autorunner/web_frontend/src/lib/palette/store.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/store.ts
@@ -20,6 +20,7 @@ export type PaletteStore = {
   refresh: () => void;
   updateSources: (sources: PaletteSource[]) => void;
   handleKeydown: (event: KeyboardEvent | KeyEventLike) => boolean;
+  subscribe: (listener: () => void) => () => void;
   destroy: () => void;
 };
 
@@ -42,6 +43,7 @@ export function createPaletteStore(
   let isOpen = false;
   let query = '';
   let activeIdx = 0;
+  let listeners: Array<() => void> = [];
 
   const standardShortcuts = buildStandardShortcuts({
     togglePalette: () => store.toggle(),
@@ -57,6 +59,10 @@ export function createPaletteStore(
     allItems = loadAllItems(currentSources);
     filteredItems = filterItems(allItems, query);
     if (activeIdx >= filteredItems.length) activeIdx = Math.max(0, filteredItems.length - 1);
+  }
+
+  function notify(): void {
+    for (const listener of listeners) listener();
   }
 
   const store: PaletteStore = {
@@ -75,19 +81,23 @@ export function createPaletteStore(
       query = '';
       activeIdx = 0;
       recompute();
+      notify();
     },
     closePalette() {
       isOpen = false;
       query = '';
+      notify();
     },
     setQuery(newQuery: string) {
       query = newQuery;
       activeIdx = 0;
       recompute();
+      notify();
     },
     moveActive(delta: number) {
       if (filteredItems.length === 0) return;
       activeIdx = (activeIdx + delta + filteredItems.length) % filteredItems.length;
+      notify();
     },
     selectActive() {
       if (filteredItems[activeIdx]) store.selectItem(filteredItems[activeIdx]);
@@ -103,10 +113,12 @@ export function createPaletteStore(
     },
     refresh() {
       recompute();
+      notify();
     },
     updateSources(newSources: PaletteSource[]) {
       currentSources = newSources;
       recompute();
+      notify();
     },
     handleKeydown(event: KeyboardEvent | KeyEventLike) {
       const key = 'key' in event ? event.key : '';
@@ -143,8 +155,15 @@ export function createPaletteStore(
       }
       return registry.handleKeydown(event);
     },
+    subscribe(listener: () => void) {
+      listeners.push(listener);
+      return () => {
+        listeners = listeners.filter((candidate) => candidate !== listener);
+      };
+    },
     destroy() {
       registry.destroy();
+      listeners = [];
     }
   };
 

--- a/src/codex_autorunner/web_frontend/src/lib/palette/types.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/palette/types.ts
@@ -7,6 +7,11 @@ export type PaletteItem = {
   label: string;
   group: string;
   keywords: string;
+  glyph?: string | null;
+  accent?: string | null;
+  meta?: string | null;
+  chip?: string | null;
+  lastActivityAt?: string | null;
   action: PaletteAction;
 };
 

--- a/src/codex_autorunner/web_frontend/src/routes/+layout.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/+layout.svelte
@@ -5,7 +5,15 @@
   import { primaryNav, isActiveRoute } from '$lib/navigation';
   import { stripRuntimeBasePath, withRuntimeBasePath as href } from '$lib/runtime/basePath';
   import { webApi } from '$lib/api/client';
-  import { Palette, createPaletteStore, scopeSource } from '$lib/palette';
+  import { Palette, createPaletteStore, recentActionsSource, repoSource, scopeSource, threadSource, worktreeSource } from '$lib/palette';
+  import {
+    ensureChatIndexLoaded,
+    ensureRepoWorktreeIndexLoaded,
+    readModelEntityStore,
+    selectChats,
+    selectRepoSummaries,
+    selectWorktreeSummaries
+  } from '$lib/data';
   import { connectionStore, type ConnectionStatus } from '$lib/runtime/connectionStore.svelte';
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
   import {
@@ -29,7 +37,7 @@
   const breadcrumbs = $derived(breadcrumbsForPath(currentPath));
 
   const paletteStore = createPaletteStore(
-    [scopeSource([], [])],
+    [recentActionsSource(), scopeSource()],
     {
       toggleSidebar: () => (collapsed = !collapsed),
       toggleMemory: () => void goto(href('/settings?memory=1')),
@@ -48,6 +56,9 @@
       /* private mode / quota */
     }
     void loadHubState();
+    const unsubscribeReadModels = readModelEntityStore.subscribe(refreshPaletteSources);
+    void loadPaletteSources();
+    return () => unsubscribeReadModels();
   });
 
   onDestroy(() => {
@@ -66,6 +77,25 @@
     if (!result.ok) return;
     hubTitle = result.data.title;
     titleDraft = result.data.title;
+  }
+
+  async function loadPaletteSources(): Promise<void> {
+    await Promise.all([
+      ensureRepoWorktreeIndexLoaded({ limit: 2000, blocking: true }),
+      ensureChatIndexLoaded({ limit: 1000 }, { blocking: true })
+    ]);
+    refreshPaletteSources();
+  }
+
+  function refreshPaletteSources(): void {
+    const state = readModelEntityStore.snapshot();
+    paletteStore.updateSources([
+      recentActionsSource(),
+      threadSource(selectChats(state)),
+      repoSource(selectRepoSummaries(state)),
+      worktreeSource(selectWorktreeSummaries(state)),
+      scopeSource()
+    ]);
   }
 
   async function saveHubTitle(): Promise<void> {


### PR DESCRIPTION
## Summary
- add a global command palette data feed for recent actions, chats, repos, and worktrees
- render grouped palette results with identity glyphs, branch/short-id/activity metadata, and fuzzy search
- load repo/worktree and chat read-model snapshots from the root layout so Cmd/Ctrl+K works across pages

## Validation
- pnpm -C src/codex_autorunner/web_frontend exec vitest run src/lib/palette/sources.test.ts src/lib/palette/store.test.ts
- pnpm web:lint
- pnpm web:test
- pnpm -C src/codex_autorunner/web_frontend run build
- commit hook web-ui lane and guardrails passed

Closes #2000