### PR TITLE
Deduplicate stable injected prompt context

### DIFF
--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -345,6 +345,7 @@ class DiscordMessageTurnResult:
     durable_delivery_claim_token: Optional[str] = None
     deferred_delivery: bool = False
     preserve_progress_lease: bool = False
+    record_planned_injections: bool = True
 
 
 @dataclass(frozen=True)
@@ -1319,12 +1320,13 @@ async def _execute_discord_thread_message(
                 DiscordMessageTurnResult,
                 await run_turn(**run_turn_kwargs),
             )
-            for planned in planned_injections:
-                record_planned_prompt_injection(
-                    dispatch.service._config.root,
-                    planned.prompt_text,
-                    planned.render_plans,
-                )
+            if result.record_planned_injections:
+                for planned in planned_injections:
+                    record_planned_prompt_injection(
+                        dispatch.service._config.root,
+                        planned.prompt_text,
+                        planned.render_plans,
+                    )
             return result
         except TypeError as exc:
             error_text = str(exc)
@@ -1338,12 +1340,13 @@ async def _execute_discord_thread_message(
                 DiscordMessageTurnResult,
                 await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
             )
-            for planned in planned_injections:
-                record_planned_prompt_injection(
-                    dispatch.service._config.root,
-                    planned.prompt_text,
-                    planned.render_plans,
-                )
+            if result.record_planned_injections:
+                for planned in planned_injections:
+                    record_planned_prompt_injection(
+                        dispatch.service._config.root,
+                        planned.prompt_text,
+                        planned.render_plans,
+                    )
             return result
     except DiscordTurnStartupFailure as exc:
         dispatch.log_event_fn(
@@ -2709,12 +2712,14 @@ async def _run_discord_orchestrated_turn_for_message(
                         ),
                         execution_id=progress_execution_id,
                         send_final_message=not acknowledgement_delivered,
+                        record_planned_injections=False,
                     )
                 return DiscordMessageTurnResult(
                     final_message="",
                     preview_message_id=progress_message_id,
                     execution_id=progress_execution_id,
                     send_final_message=False,
+                    record_planned_injections=False,
                 )
             raise RuntimeError(str(finalized.error or public_execution_error))
         summary_snapshot = ""

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -348,6 +348,10 @@ class DiscordMessageTurnResult:
     record_planned_injections: bool = True
 
 
+def _should_record_planned_injections(result: object) -> bool:
+    return bool(getattr(result, "record_planned_injections", True))
+
+
 @dataclass(frozen=True)
 class _DiscordMessageTurnDispatch:
     service: Any
@@ -1320,7 +1324,7 @@ async def _execute_discord_thread_message(
                 DiscordMessageTurnResult,
                 await run_turn(**run_turn_kwargs),
             )
-            if result.record_planned_injections:
+            if _should_record_planned_injections(result):
                 for planned in planned_injections:
                     record_planned_prompt_injection(
                         dispatch.service._config.root,
@@ -1340,7 +1344,7 @@ async def _execute_discord_thread_message(
                 DiscordMessageTurnResult,
                 await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
             )
-            if result.record_planned_injections:
+            if _should_record_planned_injections(result):
                 for planned in planned_injections:
                     record_planned_prompt_injection(
                         dispatch.service._config.root,

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -56,9 +56,10 @@ from ...core.artifact_instructions import (
 )
 from ...core.config import ConfigError, load_hub_config
 from ...core.context_awareness import (
-    maybe_inject_car_awareness,
     maybe_inject_filebox_hint,
-    maybe_inject_prompt_writing_hint,
+    plan_car_awareness_injection,
+    plan_prompt_writing_hint_injection,
+    record_planned_prompt_injection,
 )
 from ...core.filebox import inbox_dir
 from ...core.logging_utils import log_event
@@ -1083,10 +1084,19 @@ async def _execute_discord_thread_message(
         )
 
     if not dispatch.effective_pma_enabled:
-        prompt_text, injected = maybe_inject_car_awareness(
+        planned_injections = []
+        planned_car = plan_car_awareness_injection(
             prompt_text,
+            hub_root=dispatch.service._config.root,
+            surface_kind="discord",
+            surface_key=dispatch.channel_id,
+            managed_thread_id=dispatch.session_key,
+            worktree_id=str(request_workspace_root),
             declared_profile="car_ambient",
         )
+        prompt_text, injected = planned_car.prompt_text, planned_car.injected
+        if injected:
+            planned_injections.append(planned_car)
         if injected:
             dispatch.log_event_fn(
                 dispatch.service._logger,
@@ -1095,10 +1105,18 @@ async def _execute_discord_thread_message(
                 channel_id=dispatch.channel_id,
                 message_id=dispatch.event.message.message_id,
             )
-        prompt_text, injected = maybe_inject_prompt_writing_hint(
+        planned_prompt = plan_prompt_writing_hint_injection(
             prompt_text,
+            hub_root=dispatch.service._config.root,
+            surface_kind="discord",
+            surface_key=dispatch.channel_id,
+            managed_thread_id=dispatch.session_key,
+            worktree_id=str(request_workspace_root),
             trigger_text=dispatch.text,
         )
+        prompt_text, injected = planned_prompt.prompt_text, planned_prompt.injected
+        if injected:
+            planned_injections.append(planned_prompt)
         if injected:
             dispatch.log_event_fn(
                 dispatch.service._logger,
@@ -1107,6 +1125,8 @@ async def _execute_discord_thread_message(
                 channel_id=dispatch.channel_id,
                 message_id=dispatch.event.message.message_id,
             )
+    else:
+        planned_injections = []
         prompt_text, injected = _maybe_inject_discord_filebox_hint(
             prompt_text,
             user_text=dispatch.text,
@@ -1166,6 +1186,7 @@ async def _execute_discord_thread_message(
                 prompt_state_key=dispatch.session_key,
                 user_input_texts=[dispatch.text],
             )
+            planned_injections.extend(prompt_variants.planned_injections)
             prompt_text = prompt_variants.new_session_prompt
             existing_session_prompt_text = prompt_variants.existing_session_prompt
         except (OSError, ValueError, KeyError, TypeError) as exc:
@@ -1191,6 +1212,11 @@ async def _execute_discord_thread_message(
         request_workspace_root,
         link_source_text=dispatch.turn_text,
         allow_cross_repo=dispatch.pma_enabled,
+        surface_kind="discord",
+        surface_key=dispatch.channel_id,
+        managed_thread_id=dispatch.session_key,
+        worktree_id=str(request_workspace_root),
+        planned_injections=planned_injections,
     )
     if existing_session_prompt_text is not None:
         (
@@ -1201,6 +1227,11 @@ async def _execute_discord_thread_message(
             request_workspace_root,
             link_source_text=dispatch.turn_text,
             allow_cross_repo=dispatch.pma_enabled,
+            surface_kind="discord",
+            surface_key=dispatch.channel_id,
+            managed_thread_id=dispatch.session_key,
+            worktree_id=str(request_workspace_root),
+            planned_injections=planned_injections,
         )
     if dispatch.pending_compact_seed:
         prompt_text = f"{dispatch.pending_compact_seed}\n\n{prompt_text}"
@@ -1284,10 +1315,17 @@ async def _execute_discord_thread_message(
             elif not _callable_accepts_keyword(run_turn, "user_visible_text"):
                 run_turn_kwargs.pop("user_visible_text", None)
                 run_turn_kwargs.pop("title_seed", None)
-            return cast(
+            result = cast(
                 DiscordMessageTurnResult,
                 await run_turn(**run_turn_kwargs),
             )
+            for planned in planned_injections:
+                record_planned_prompt_injection(
+                    dispatch.service._config.root,
+                    planned.prompt_text,
+                    planned.render_plans,
+                )
+            return result
         except TypeError as exc:
             error_text = str(exc)
             if "supervision" in error_text:
@@ -1296,10 +1334,17 @@ async def _execute_discord_thread_message(
                 run_turn_kwargs.pop("existing_session_prompt_text", None)
             else:
                 raise
-            return cast(
+            result = cast(
                 DiscordMessageTurnResult,
                 await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
             )
+            for planned in planned_injections:
+                record_planned_prompt_injection(
+                    dispatch.service._config.root,
+                    planned.prompt_text,
+                    planned.render_plans,
+                )
+            return result
     except DiscordTurnStartupFailure as exc:
         dispatch.log_event_fn(
             dispatch.service._logger,

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -2879,6 +2879,13 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         *,
         link_source_text: Optional[str] = None,
         allow_cross_repo: bool = False,
+        surface_kind: Optional[str] = None,
+        surface_key: Optional[str] = None,
+        managed_thread_id: Optional[str] = None,
+        backend_thread_id: Optional[str] = None,
+        repo_id: Optional[str] = None,
+        worktree_id: Optional[str] = None,
+        planned_injections: Optional[list[Any]] = None,
     ) -> tuple[str, bool]:
         return await maybe_inject_github_context(
             prompt_text=prompt_text,
@@ -2887,6 +2894,14 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             logger=self._logger,
             event_prefix="discord.github_context",
             allow_cross_repo=allow_cross_repo,
+            hub_root=self._config.root,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+            managed_thread_id=managed_thread_id,
+            backend_thread_id=backend_thread_id,
+            repo_id=repo_id,
+            worktree_id=worktree_id,
+            planned_injections=planned_injections,
         )
 
     def _build_message_session_key(

--- a/src/codex_autorunner/adapters/github/context_injection.py
+++ b/src/codex_autorunner/adapters/github/context_injection.py
@@ -230,7 +230,7 @@ async def maybe_inject_github_context(
                         },
                         exc_info=True,
                     )
-                    return prompt_text, False
+                    return append_capsules_to_prompt(prompt_text, (capsule,))
             return append_capsules_to_prompt(prompt_text, (capsule,))
 
     log_event(

--- a/src/codex_autorunner/adapters/github/context_injection.py
+++ b/src/codex_autorunner/adapters/github/context_injection.py
@@ -7,7 +7,16 @@ from pathlib import Path
 from typing import Optional
 
 from ...core.config import load_repo_config
+from ...core.context_awareness import PlannedPromptInjection
+from ...core.context_capsule_planner import plan_context_capsules_for_prompt
+from ...core.context_capsules import (
+    ContextCapsule,
+    ContextCapsuleExpiry,
+    ContextCapsuleScope,
+)
 from ...core.logging_utils import log_event
+from ...core.orchestration.context_capsule_ledger import SQLiteContextCapsuleLedger
+from ...core.orchestration.sqlite import open_orchestration_sqlite
 from ...core.surface_context_capsules import (
     append_capsules_to_prompt,
     build_github_context_capsule,
@@ -77,6 +86,14 @@ async def maybe_inject_github_context(
     logger: logging.Logger,
     event_prefix: str,
     allow_cross_repo: bool = False,
+    hub_root: Optional[Path] = None,
+    surface_kind: Optional[str] = None,
+    surface_key: Optional[str] = None,
+    managed_thread_id: Optional[str] = None,
+    backend_thread_id: Optional[str] = None,
+    repo_id: Optional[str] = None,
+    worktree_id: Optional[str] = None,
+    planned_injections: Optional[list[PlannedPromptInjection]] = None,
 ) -> tuple[str, bool]:
     if not prompt_text or not workspace_root:
         return prompt_text, False
@@ -159,6 +176,16 @@ async def maybe_inject_github_context(
                 path=str(result.get("path") or ""),
                 kind=str(result.get("kind") or (parsed[1] if parsed else "")),
             )
+            capsule = ContextCapsule(
+                capsule_id=capsule.capsule_id,
+                version=capsule.version,
+                scope=ContextCapsuleScope.THREAD,
+                visibility=capsule.visibility,
+                source_digest=capsule.source_digest,
+                expiry=ContextCapsuleExpiry.WHEN_SOURCE_CHANGES,
+                reason=capsule.reason,
+                payload=capsule.payload,
+            )
             log_event(
                 logger,
                 logging.INFO,
@@ -167,6 +194,43 @@ async def maybe_inject_github_context(
                 path=result.get("path"),
                 source="user_message",
             )
+            if hub_root and surface_kind and surface_key and managed_thread_id:
+                try:
+                    with open_orchestration_sqlite(hub_root) as conn:
+                        planned = plan_context_capsules_for_prompt(
+                            (capsule,),
+                            ledger=SQLiteContextCapsuleLedger(conn),
+                            surface_kind=surface_kind,
+                            surface_key=surface_key,
+                            managed_thread_id=managed_thread_id,
+                            backend_thread_id=backend_thread_id,
+                            repo_id=repo_id,
+                            worktree_id=worktree_id or str(repo_root),
+                        )
+                    injection = planned.rendered_text.strip()
+                    if not injection:
+                        return prompt_text, False
+                    separator = "\n" if prompt_text.endswith("\n") else "\n\n"
+                    planned_prompt = f"{prompt_text}{separator}{injection}"
+                    if planned_injections is not None:
+                        planned_injections.append(
+                            PlannedPromptInjection(
+                                planned_prompt,
+                                True,
+                                planned.plans,
+                            )
+                        )
+                    return planned_prompt, True
+                except Exception:
+                    logger.warning(
+                        "Failed to plan GitHub context capsule",
+                        extra={
+                            "surface_kind": surface_kind,
+                            "surface_key": surface_key,
+                        },
+                        exc_info=True,
+                    )
+                    return prompt_text, False
             return append_capsules_to_prompt(prompt_text, (capsule,))
 
     log_event(

--- a/src/codex_autorunner/adapters/github/context_injection.py
+++ b/src/codex_autorunner/adapters/github/context_injection.py
@@ -209,7 +209,7 @@ async def maybe_inject_github_context(
                         )
                     injection = planned.rendered_text.strip()
                     if not injection:
-                        return prompt_text, False
+                        continue
                     separator = "\n" if prompt_text.endswith("\n") else "\n\n"
                     planned_prompt = f"{prompt_text}{separator}{injection}"
                     if planned_injections is not None:

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -234,6 +234,7 @@ class _TurnRunResult:
     durable_delivery_pending: bool = False
     durable_delivery_id: Optional[str] = None
     durable_delivery_claim_token: Optional[str] = None
+    record_planned_injections: bool = True
 
 
 @dataclass(frozen=True)
@@ -3324,6 +3325,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             intermediate_response=turn_delivery_state.intermediate_response,
             interrupt_status_turn_id=turn_handle_id,
             interrupt_status_fallback_text=interrupt_status_fallback_text,
+            record_planned_injections=not was_interrupted,
         )
 
     def _prepare_turn_prompt(
@@ -3765,6 +3767,8 @@ class ExecutionCommands(TelegramCommandSupportMixin):
 
         def _record_pending_planned_injections(result: object) -> None:
             if not isinstance(result, _TurnRunResult):
+                return
+            if not result.record_planned_injections:
                 return
             for planned in pending_planned_injections:
                 record_planned_prompt_injection(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -104,10 +104,14 @@ from .....core.artifact_instructions import (
 from .....core.config import load_hub_config
 from .....core.config_contract import ConfigError
 from .....core.context_awareness import (
+    PlannedPromptInjection,
     has_file_context_signal,
     maybe_inject_car_awareness,
     maybe_inject_filebox_hint,
     maybe_inject_prompt_writing_hint,
+    plan_car_awareness_injection,
+    plan_prompt_writing_hint_injection,
+    record_planned_prompt_injection,
 )
 from .....core.hub_control_plane import (
     RemoteSurfaceBindingStore,
@@ -132,6 +136,7 @@ from .....core.orchestration.runtime_threads import (
     begin_runtime_thread_execution,
 )
 from .....core.pma_context import (
+    PmaPromptVariants,
     build_hub_unavailable_snapshot,
     format_pma_discoverability_preamble,
     format_pma_prompt_variants,
@@ -1852,9 +1857,13 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         *,
         link_source_text: Optional[str] = None,
         allow_cross_repo: bool = False,
+        topic_key: Optional[str] = None,
+        planned_injections: Optional[list[PlannedPromptInjection]] = None,
     ) -> tuple[str, bool]:
         if not prompt_text or not record or not record.workspace_path:
             return prompt_text, False
+        surface_key = topic_key if isinstance(topic_key, str) and topic_key else None
+        hub_root = getattr(getattr(self, "_config", None), "root", None)
         return await maybe_inject_github_context(
             prompt_text=prompt_text,
             link_source_text=link_source_text or prompt_text,
@@ -1862,24 +1871,64 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             logger=self._logger,
             event_prefix="telegram.github_context",
             allow_cross_repo=allow_cross_repo,
+            hub_root=hub_root,
+            surface_kind="telegram" if surface_key else None,
+            surface_key=surface_key,
+            managed_thread_id=surface_key,
+            worktree_id=record.workspace_path,
+            planned_injections=planned_injections,
         )
 
     def _maybe_inject_prompt_context(
         self,
         prompt_text: str,
         *,
+        record: Optional["TelegramTopicRecord"] = None,
+        topic_key: Optional[str] = None,
         trigger_text: Optional[str] = None,
     ) -> tuple[str, bool]:
-        return maybe_inject_prompt_writing_hint(
+        if record is None or not topic_key:
+            return maybe_inject_prompt_writing_hint(
+                prompt_text,
+                trigger_text=trigger_text,
+            )
+        hub_root = getattr(getattr(self, "_config", None), "root", None)
+        hub_root = hub_root or record.workspace_path
+        planned = plan_prompt_writing_hint_injection(
             prompt_text,
+            hub_root=hub_root,
+            surface_kind="telegram",
+            surface_key=topic_key,
+            managed_thread_id=topic_key,
+            worktree_id=record.workspace_path,
             trigger_text=trigger_text,
         )
+        return planned.prompt_text, planned.injected
 
-    def _maybe_inject_car_context(self, prompt_text: str) -> tuple[str, bool]:
-        return maybe_inject_car_awareness(
+    def _maybe_inject_car_context(
+        self,
+        prompt_text: str,
+        *,
+        record: Optional["TelegramTopicRecord"] = None,
+        topic_key: Optional[str] = None,
+    ) -> tuple[str, bool]:
+        if record is None or not topic_key:
+            return maybe_inject_car_awareness(
+                prompt_text,
+                declared_profile="car_ambient",
+            )
+        hub_root = getattr(getattr(self, "_config", None), "root", None)
+        hub_root = hub_root or record.workspace_path
+        planned = plan_car_awareness_injection(
             prompt_text,
+            hub_root=hub_root,
+            surface_kind="telegram",
+            surface_key=topic_key,
+            managed_thread_id=topic_key,
+            worktree_id=record.workspace_path,
             declared_profile="car_ambient",
         )
+        return planned.prompt_text, planned.injected
 
     def _maybe_inject_outbox_context(
         self,
@@ -3322,7 +3371,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         record: "TelegramTopicRecord",
         message: TelegramMessage,
         user_input_texts: list[str | None] | None = None,
-    ) -> Optional[tuple[str, str]]:
+    ) -> Optional[PmaPromptVariants]:
         hub_root = getattr(self, "_hub_root", None)
         if hub_root is None:
             return None
@@ -3366,10 +3415,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 prompt_state_key=prompt_state_key,
                 user_input_texts=user_input_texts,
             )
-            return (
-                prompt_variants.new_session_prompt,
-                prompt_variants.existing_session_prompt,
-            )
+            return prompt_variants
         except (OSError, ValueError, RuntimeError, ConfigError):
             return None
 
@@ -3386,12 +3432,24 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         raw_user_input = (
             user_input_text if user_input_text is not None else message.text
         )
+        planned_injections = []
 
-        prompt_text, injected = await self._maybe_inject_github_context(
-            prompt_text,
-            record,
-            link_source_text=raw_user_input,
-        )
+        try:
+            prompt_text, injected = await self._maybe_inject_github_context(
+                prompt_text,
+                record,
+                link_source_text=raw_user_input,
+                topic_key=key,
+                planned_injections=planned_injections,
+            )
+        except TypeError as exc:
+            if "topic_key" not in str(exc):
+                raise
+            prompt_text, injected = await self._maybe_inject_github_context(
+                prompt_text,
+                record,
+                link_source_text=raw_user_input,
+            )
         if injected:
             await self._send_message(
                 message.chat_id,
@@ -3400,7 +3458,20 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 reply_to=message.message_id,
             )
 
-        prompt_text, injected = self._maybe_inject_car_context(prompt_text)
+        hub_root = getattr(getattr(self, "_config", None), "root", None)
+        hub_root = hub_root or record.workspace_path
+        planned_car = plan_car_awareness_injection(
+            prompt_text,
+            hub_root=hub_root,
+            surface_kind="telegram",
+            surface_key=key,
+            managed_thread_id=key,
+            worktree_id=record.workspace_path,
+            declared_profile="car_ambient",
+        )
+        prompt_text, injected = planned_car.prompt_text, planned_car.injected
+        if injected:
+            planned_injections.append(planned_car)
         if injected:
             log_event(
                 self._logger,
@@ -3411,10 +3482,18 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 message_id=message.message_id,
             )
 
-        prompt_text, injected = self._maybe_inject_prompt_context(
+        planned_prompt = plan_prompt_writing_hint_injection(
             prompt_text,
+            hub_root=hub_root,
+            surface_kind="telegram",
+            surface_key=key,
+            managed_thread_id=key,
+            worktree_id=record.workspace_path,
             trigger_text=raw_user_input,
         )
+        prompt_text, injected = planned_prompt.prompt_text, planned_prompt.injected
+        if injected:
+            planned_injections.append(planned_prompt)
         if injected:
             log_event(
                 self._logger,
@@ -3448,6 +3527,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 message_id=message.message_id,
             )
 
+        self._pending_planned_prompt_injections = tuple(planned_injections)
         return prompt_text, key
 
     async def _prepare_turn_placeholder(
@@ -3613,6 +3693,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         )
         existing_session_prompt_text: Optional[str] = None
         if pma_enabled:
+            pma_planned_injections: list[PlannedPromptInjection] = []
             user_message_prompt = prompt_text
             if isinstance(pma_context_prefix, str) and pma_context_prefix.strip():
                 user_message_prompt = (
@@ -3636,12 +3717,16 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                     transcript_message_id=transcript_message_id,
                     transcript_text=transcript_text,
                 )
-            pma_prompt, existing_session_prompt_text = pma_prompt_variants
+            pma_prompt = pma_prompt_variants.new_session_prompt
+            existing_session_prompt_text = pma_prompt_variants.existing_session_prompt
+            pma_planned_injections.extend(pma_prompt_variants.planned_injections)
             prompt_text, injected = await self._maybe_inject_github_context(
                 pma_prompt,
                 record,
                 link_source_text=user_message_prompt,
                 allow_cross_repo=True,
+                topic_key=key,
+                planned_injections=pma_planned_injections,
             )
             if existing_session_prompt_text:
                 existing_session_prompt_text, _ = (
@@ -3650,8 +3735,11 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                         record,
                         link_source_text=user_message_prompt,
                         allow_cross_repo=True,
+                        topic_key=key,
+                        planned_injections=pma_planned_injections,
                     )
                 )
+            self._pending_planned_prompt_injections = tuple(pma_planned_injections)
             if injected:
                 await self._send_message(
                     message.chat_id,
@@ -3670,9 +3758,24 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 ),
             )
 
+        pending_planned_injections = tuple(
+            getattr(self, "_pending_planned_prompt_injections", ())
+        )
+        self._pending_planned_prompt_injections = ()
+
+        def _record_pending_planned_injections(result: object) -> None:
+            if not isinstance(result, _TurnRunResult):
+                return
+            for planned in pending_planned_injections:
+                record_planned_prompt_injection(
+                    self._config.root,
+                    planned.prompt_text,
+                    planned.render_plans,
+                )
+
         if pma_enabled and uses_managed_thread_runtime:
             approval_policy, sandbox_policy = self._effective_policies(record)
-            return await _run_telegram_managed_thread_turn(
+            result = await _run_telegram_managed_thread_turn(
                 self,
                 message=message,
                 runtime=runtime,
@@ -3694,10 +3797,12 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 user_visible_text=user_visible_seed,
                 title_seed=user_visible_seed,
             )
+            _record_pending_planned_injections(result)
+            return result
 
         if uses_managed_thread_runtime:
             approval_policy, sandbox_policy = self._effective_policies(record)
-            return await _run_telegram_managed_thread_turn(
+            result = await _run_telegram_managed_thread_turn(
                 self,
                 message=message,
                 runtime=runtime,
@@ -3724,6 +3829,8 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 user_visible_text=user_visible_seed,
                 title_seed=user_visible_seed,
             )
+            _record_pending_planned_injections(result)
+            return result
 
         turn_semaphore = self._ensure_turn_semaphore()
         queued = turn_semaphore.locked()
@@ -3735,7 +3842,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             queued=queued,
         )
 
-        return await self._execute_codex_turn(
+        result = await self._execute_codex_turn(
             message,
             runtime,
             record,
@@ -3754,3 +3861,5 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             managed_thread_registry=managed_thread_registry,
             managed_thread_key=managed_thread_key,
         )
+        _record_pending_planned_injections(result)
+        return result

--- a/src/codex_autorunner/core/context_awareness.py
+++ b/src/codex_autorunner/core/context_awareness.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 from .car_context import (
@@ -12,6 +15,20 @@ from .car_context import (
     build_car_context_capsule,
     render_car_context_transport,
 )
+from .context_capsule_planner import (
+    plan_context_capsules_for_prompt,
+    record_context_capsule_renders,
+)
+from .context_capsules import (
+    ContextCapsule,
+    ContextCapsuleExpiry,
+    ContextCapsuleRenderPlan,
+    ContextCapsuleScope,
+    ContextCapsuleVisibility,
+    stable_json_digest,
+)
+from .orchestration.context_capsule_ledger import SQLiteContextCapsuleLedger
+from .orchestration.sqlite import open_orchestration_sqlite
 from .orchestration.turn_context import render_context_capsule_for_prompt
 from .surface_context_capsules import (
     append_capsules_to_prompt,
@@ -37,7 +54,10 @@ WORKTREE_PR_HINT = (
     "hub worktree is explicitly required outside managed-thread creation, use "
     "`car hub worktree create <base_repo_id> <branch> --path <hub_root>`."
 )
-_PROMPT_CONTEXT_RE = re.compile(r"\bprompt\b", re.IGNORECASE)
+_PROMPT_CONTEXT_RE = re.compile(
+    r"\b(?:write|create|draft|compose|generate)\s+(?:a\s+)?prompt\b",
+    re.IGNORECASE,
+)
 _WORKTREE_PR_CONTEXT_RE = re.compile(
     r"\b(?:worktree|worktrees|branch|branches|pr|prs|pull\s+request|pull\s+requests)\b",
     re.IGNORECASE,
@@ -50,6 +70,14 @@ _FILEBOX_HINT_KEYWORD_RE = re.compile(
     r"\b(?:filebox|inbox|outbox)\b",
     re.IGNORECASE,
 )
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PlannedPromptInjection:
+    prompt_text: str
+    injected: bool
+    render_plans: tuple[ContextCapsuleRenderPlan, ...] = ()
 
 
 def maybe_inject_car_awareness(
@@ -59,7 +87,7 @@ def maybe_inject_car_awareness(
     target_path: str | None = None,
     initiated_by_ticket_flow: bool = False,
 ) -> tuple[str, bool]:
-    """Inject CAR repo awareness context when the selected profile requires it."""
+    """Inject CAR awareness for explicit single-turn prompts without a ledger scope."""
     prompt_text = prompt_text or ""
     bundle = build_car_context_bundle(
         declared_profile,
@@ -78,6 +106,96 @@ def maybe_inject_car_awareness(
     return f"{injection}\n\n{prompt_text}", True
 
 
+def plan_car_awareness_injection(
+    prompt_text: str,
+    *,
+    hub_root: str | Path,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    backend_thread_id: str | None = None,
+    repo_id: str | None = None,
+    worktree_id: str | None = None,
+    declared_profile: CarContextProfile = DEFAULT_REPO_THREAD_CONTEXT_PROFILE,
+    target_path: str | None = None,
+    initiated_by_ticket_flow: bool = False,
+    record_rendered: bool = False,
+) -> PlannedPromptInjection:
+    """Plan CAR repo awareness through the durable capsule planner."""
+    prompt_text = prompt_text or ""
+    bundle = build_car_context_bundle(
+        declared_profile,
+        prompt_text=prompt_text,
+        target_path=target_path,
+        initiated_by_ticket_flow=initiated_by_ticket_flow,
+    )
+    capsule = build_car_context_capsule(bundle)
+    if capsule is None:
+        return PlannedPromptInjection(prompt_text, False)
+    try:
+        with open_orchestration_sqlite(Path(hub_root)) as conn:
+            planned = plan_context_capsules_for_prompt(
+                (capsule,),
+                ledger=SQLiteContextCapsuleLedger(conn),
+                surface_kind=surface_kind,
+                surface_key=surface_key,
+                managed_thread_id=managed_thread_id,
+                backend_thread_id=backend_thread_id,
+                repo_id=repo_id,
+                worktree_id=worktree_id,
+            )
+    except Exception:
+        _logger.warning(
+            "Failed to plan CAR awareness context capsule",
+            extra={"surface_kind": surface_kind, "surface_key": surface_key},
+            exc_info=True,
+        )
+        return PlannedPromptInjection(prompt_text, False)
+    injection = planned.rendered_text.strip()
+    if not injection:
+        return PlannedPromptInjection(prompt_text, False, planned.plans)
+    if not prompt_text.strip():
+        planned_prompt = injection
+    else:
+        planned_prompt = f"{injection}\n\n{prompt_text}"
+    if record_rendered:
+        record_planned_prompt_injection(hub_root, planned.rendered_text, planned.plans)
+    return PlannedPromptInjection(planned_prompt, True, planned.plans)
+
+
+def maybe_inject_planned_car_awareness(
+    prompt_text: str,
+    *,
+    hub_root: str | Path,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    backend_thread_id: str | None = None,
+    repo_id: str | None = None,
+    worktree_id: str | None = None,
+    declared_profile: CarContextProfile = DEFAULT_REPO_THREAD_CONTEXT_PROFILE,
+    target_path: str | None = None,
+    initiated_by_ticket_flow: bool = False,
+    record_rendered: bool = True,
+) -> tuple[str, bool]:
+    """Inject CAR repo awareness through the durable capsule planner."""
+    planned = plan_car_awareness_injection(
+        prompt_text,
+        hub_root=hub_root,
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        managed_thread_id=managed_thread_id,
+        backend_thread_id=backend_thread_id,
+        repo_id=repo_id,
+        worktree_id=worktree_id,
+        declared_profile=declared_profile,
+        target_path=target_path,
+        initiated_by_ticket_flow=initiated_by_ticket_flow,
+        record_rendered=record_rendered,
+    )
+    return planned.prompt_text, planned.injected
+
+
 def maybe_inject_prompt_writing_hint(
     prompt_text: str,
     *,
@@ -94,6 +212,103 @@ def maybe_inject_prompt_writing_hint(
     return append_capsules_to_prompt(
         prompt_text, (build_prompt_writing_capsule(PROMPT_WRITING_HINT),)
     )
+
+
+def plan_prompt_writing_hint_injection(
+    prompt_text: str,
+    *,
+    hub_root: str | Path,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    backend_thread_id: str | None = None,
+    repo_id: str | None = None,
+    worktree_id: str | None = None,
+    trigger_text: str | None = None,
+    record_rendered: bool = False,
+) -> PlannedPromptInjection:
+    """Plan prompt-writing guidance through the durable capsule planner."""
+    if not prompt_text or not prompt_text.strip():
+        return PlannedPromptInjection(prompt_text, False)
+    trigger_text = trigger_text if isinstance(trigger_text, str) else prompt_text
+    if not _PROMPT_CONTEXT_RE.search(trigger_text):
+        return PlannedPromptInjection(prompt_text, False)
+    capsule = build_prompt_writing_capsule(PROMPT_WRITING_HINT)
+    if PROMPT_WRITING_HINT in prompt_text:
+        return PlannedPromptInjection(prompt_text, False)
+    try:
+        with open_orchestration_sqlite(Path(hub_root)) as conn:
+            planned = plan_context_capsules_for_prompt(
+                (capsule,),
+                ledger=SQLiteContextCapsuleLedger(conn),
+                surface_kind=surface_kind,
+                surface_key=surface_key,
+                managed_thread_id=managed_thread_id,
+                backend_thread_id=backend_thread_id,
+                repo_id=repo_id,
+                worktree_id=worktree_id,
+            )
+    except Exception:
+        _logger.warning(
+            "Failed to plan prompt-writing context capsule",
+            extra={"surface_kind": surface_kind, "surface_key": surface_key},
+            exc_info=True,
+        )
+        return PlannedPromptInjection(prompt_text, False)
+    injection = planned.rendered_text.strip()
+    if not injection:
+        return PlannedPromptInjection(prompt_text, False, planned.plans)
+    separator = "\n" if prompt_text.endswith("\n") else "\n\n"
+    planned_prompt = f"{prompt_text}{separator}{injection}"
+    if record_rendered:
+        record_planned_prompt_injection(hub_root, planned.rendered_text, planned.plans)
+    return PlannedPromptInjection(planned_prompt, True, planned.plans)
+
+
+def maybe_inject_planned_prompt_writing_hint(
+    prompt_text: str,
+    *,
+    hub_root: str | Path,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    backend_thread_id: str | None = None,
+    repo_id: str | None = None,
+    worktree_id: str | None = None,
+    trigger_text: str | None = None,
+    record_rendered: bool = True,
+) -> tuple[str, bool]:
+    """Inject prompt-writing guidance through the durable capsule planner."""
+    planned = plan_prompt_writing_hint_injection(
+        prompt_text,
+        hub_root=hub_root,
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        managed_thread_id=managed_thread_id,
+        backend_thread_id=backend_thread_id,
+        repo_id=repo_id,
+        worktree_id=worktree_id,
+        trigger_text=trigger_text,
+        record_rendered=record_rendered,
+    )
+    return planned.prompt_text, planned.injected
+
+
+def record_planned_prompt_injection(
+    hub_root: str | Path,
+    rendered_text: str,
+    plans: Sequence[ContextCapsuleRenderPlan],
+) -> None:
+    if not rendered_text.strip() or not plans:
+        return
+    try:
+        with open_orchestration_sqlite(Path(hub_root)) as conn:
+            record_context_capsule_renders(SQLiteContextCapsuleLedger(conn), plans)
+    except Exception:
+        _logger.warning(
+            "Failed to record planned prompt context capsules",
+            exc_info=True,
+        )
 
 
 def has_user_worktree_pr_hint_request(
@@ -135,6 +350,85 @@ def maybe_inject_worktree_pr_hint(
             ),
         ),
     )
+
+
+def plan_worktree_pr_hint_injection(
+    prompt_text: str,
+    *,
+    hub_root: str | Path,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    hint_text: str = WORKTREE_PR_HINT,
+    user_input_texts: Sequence[str | None] | None = None,
+    record_rendered: bool = False,
+) -> PlannedPromptInjection:
+    if not prompt_text or not prompt_text.strip():
+        return PlannedPromptInjection(prompt_text, False)
+    if "worktree.pr_mode" in prompt_text or "PR-mode managed thread" in prompt_text:
+        return PlannedPromptInjection(prompt_text, False)
+    if not has_user_worktree_pr_hint_request(user_input_texts):
+        return PlannedPromptInjection(prompt_text, False)
+    payload = {"text": hint_text}
+    capsule = ContextCapsule(
+        capsule_id="worktree.pr_mode",
+        version=1,
+        scope=ContextCapsuleScope.THREAD,
+        visibility=ContextCapsuleVisibility.MODEL_ONLY,
+        source_digest=stable_json_digest(payload),
+        expiry=ContextCapsuleExpiry.WHEN_SOURCE_CHANGES,
+        reason="worktree_pr_keyword_detected",
+        payload=payload,
+    )
+    try:
+        with open_orchestration_sqlite(Path(hub_root)) as conn:
+            planned = plan_context_capsules_for_prompt(
+                (capsule,),
+                ledger=SQLiteContextCapsuleLedger(conn),
+                surface_kind=surface_kind,
+                surface_key=surface_key,
+                managed_thread_id=managed_thread_id,
+                record_rendered=record_rendered,
+            )
+    except Exception:
+        _logger.warning(
+            "Failed to plan worktree/PR context capsule",
+            extra={"surface_kind": surface_kind, "surface_key": surface_key},
+            exc_info=True,
+        )
+        return PlannedPromptInjection(prompt_text, False)
+    injection = planned.rendered_text.strip()
+    if not injection:
+        return PlannedPromptInjection(prompt_text, False, planned.plans)
+    separator = "\n" if prompt_text.endswith("\n") else "\n\n"
+    planned_prompt = f"{prompt_text}{separator}{injection}"
+    if record_rendered:
+        record_planned_prompt_injection(hub_root, planned.rendered_text, planned.plans)
+    return PlannedPromptInjection(planned_prompt, True, planned.plans)
+
+
+def maybe_inject_planned_worktree_pr_hint(
+    prompt_text: str,
+    *,
+    hub_root: str | Path,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    hint_text: str = WORKTREE_PR_HINT,
+    user_input_texts: Sequence[str | None] | None = None,
+    record_rendered: bool = True,
+) -> tuple[str, bool]:
+    planned = plan_worktree_pr_hint_injection(
+        prompt_text,
+        hub_root=hub_root,
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        managed_thread_id=managed_thread_id,
+        hint_text=hint_text,
+        user_input_texts=user_input_texts,
+        record_rendered=record_rendered,
+    )
+    return planned.prompt_text, planned.injected
 
 
 def has_file_context_signal(prompt_text: str) -> bool:

--- a/src/codex_autorunner/core/context_awareness.py
+++ b/src/codex_autorunner/core/context_awareness.py
@@ -163,39 +163,6 @@ def plan_car_awareness_injection(
     return PlannedPromptInjection(planned_prompt, True, planned.plans)
 
 
-def maybe_inject_planned_car_awareness(
-    prompt_text: str,
-    *,
-    hub_root: str | Path,
-    surface_kind: str,
-    surface_key: str,
-    managed_thread_id: str,
-    backend_thread_id: str | None = None,
-    repo_id: str | None = None,
-    worktree_id: str | None = None,
-    declared_profile: CarContextProfile = DEFAULT_REPO_THREAD_CONTEXT_PROFILE,
-    target_path: str | None = None,
-    initiated_by_ticket_flow: bool = False,
-    record_rendered: bool = True,
-) -> tuple[str, bool]:
-    """Inject CAR repo awareness through the durable capsule planner."""
-    planned = plan_car_awareness_injection(
-        prompt_text,
-        hub_root=hub_root,
-        surface_kind=surface_kind,
-        surface_key=surface_key,
-        managed_thread_id=managed_thread_id,
-        backend_thread_id=backend_thread_id,
-        repo_id=repo_id,
-        worktree_id=worktree_id,
-        declared_profile=declared_profile,
-        target_path=target_path,
-        initiated_by_ticket_flow=initiated_by_ticket_flow,
-        record_rendered=record_rendered,
-    )
-    return planned.prompt_text, planned.injected
-
-
 def maybe_inject_prompt_writing_hint(
     prompt_text: str,
     *,
@@ -263,35 +230,6 @@ def plan_prompt_writing_hint_injection(
     if record_rendered:
         record_planned_prompt_injection(hub_root, planned.rendered_text, planned.plans)
     return PlannedPromptInjection(planned_prompt, True, planned.plans)
-
-
-def maybe_inject_planned_prompt_writing_hint(
-    prompt_text: str,
-    *,
-    hub_root: str | Path,
-    surface_kind: str,
-    surface_key: str,
-    managed_thread_id: str,
-    backend_thread_id: str | None = None,
-    repo_id: str | None = None,
-    worktree_id: str | None = None,
-    trigger_text: str | None = None,
-    record_rendered: bool = True,
-) -> tuple[str, bool]:
-    """Inject prompt-writing guidance through the durable capsule planner."""
-    planned = plan_prompt_writing_hint_injection(
-        prompt_text,
-        hub_root=hub_root,
-        surface_kind=surface_kind,
-        surface_key=surface_key,
-        managed_thread_id=managed_thread_id,
-        backend_thread_id=backend_thread_id,
-        repo_id=repo_id,
-        worktree_id=worktree_id,
-        trigger_text=trigger_text,
-        record_rendered=record_rendered,
-    )
-    return planned.prompt_text, planned.injected
 
 
 def record_planned_prompt_injection(

--- a/src/codex_autorunner/core/context_capsule_planner.py
+++ b/src/codex_autorunner/core/context_capsule_planner.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .context_capsules import (
+    ContextCapsule,
+    ContextCapsuleRenderPlan,
+    ledger_backend_thread_id_for_scope,
+    ledger_scope_id_for_capsule,
+)
+from .orchestration.context_capsule_ledger import SQLiteContextCapsuleLedger
+from .orchestration.turn_context import (
+    ManagedThreadCapsuleRef,
+    render_context_capsule_for_prompt,
+)
+
+
+@dataclass(frozen=True)
+class PlannedContextCapsules:
+    rendered_text: str
+    capsule_refs: tuple[ManagedThreadCapsuleRef, ...]
+    plans: tuple[ContextCapsuleRenderPlan, ...]
+
+    @property
+    def rendered(self) -> bool:
+        return bool(self.rendered_text.strip())
+
+
+def plan_context_capsules_for_prompt(
+    capsules: Iterable[ContextCapsule | None],
+    *,
+    ledger: SQLiteContextCapsuleLedger,
+    surface_kind: str,
+    surface_key: str,
+    managed_thread_id: str,
+    backend_thread_id: str | None = None,
+    repo_id: str | None = None,
+    worktree_id: str | None = None,
+    turn_id: str | None = None,
+    force_refresh: bool = False,
+    record_rendered: bool = False,
+) -> PlannedContextCapsules:
+    """Plan and render model context capsules through the durable ledger."""
+    rendered: list[str] = []
+    refs: list[ManagedThreadCapsuleRef] = []
+    plans: list[ContextCapsuleRenderPlan] = []
+    for capsule in capsules:
+        if capsule is None:
+            continue
+        plan = ledger.plan_render(
+            capsule,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+            managed_thread_id=managed_thread_id,
+            backend_thread_id=ledger_backend_thread_id_for_scope(
+                capsule,
+                backend_thread_id=backend_thread_id,
+            ),
+            scope_id=ledger_scope_id_for_capsule(
+                capsule,
+                repo_id=repo_id,
+                worktree_id=worktree_id,
+                managed_thread_id=managed_thread_id,
+                backend_thread_id=backend_thread_id,
+                turn_id=turn_id,
+            ),
+            force_refresh=force_refresh,
+        )
+        plans.append(plan)
+        refs.append(ManagedThreadCapsuleRef.from_render_plan(plan))
+        if not plan.should_render:
+            continue
+        text = render_context_capsule_for_prompt(capsule)
+        if text.strip():
+            rendered.append(text)
+    planned = PlannedContextCapsules(
+        rendered_text="\n\n".join(rendered),
+        capsule_refs=tuple(refs),
+        plans=tuple(plans),
+    )
+    if record_rendered:
+        record_context_capsule_renders(ledger, planned.plans)
+    return planned
+
+
+def record_context_capsule_renders(
+    ledger: SQLiteContextCapsuleLedger,
+    plans: Iterable[ContextCapsuleRenderPlan],
+) -> None:
+    for plan in plans:
+        if plan.should_render:
+            ledger.record_render(plan)
+
+
+__all__ = [
+    "PlannedContextCapsules",
+    "plan_context_capsules_for_prompt",
+    "record_context_capsule_renders",
+]

--- a/src/codex_autorunner/core/context_capsules.py
+++ b/src/codex_autorunner/core/context_capsules.py
@@ -154,6 +154,40 @@ class ContextCapsuleRenderPlan:
         return self.capsule.can_seed_durable_user_fields
 
 
+def ledger_backend_thread_id_for_scope(
+    capsule: ContextCapsule,
+    *,
+    backend_thread_id: str | None,
+) -> str:
+    """Return the backend id component that belongs in a capsule ledger key."""
+    if capsule.scope is ContextCapsuleScope.BACKEND_SESSION:
+        return (backend_thread_id or "").strip()
+    return ""
+
+
+def ledger_scope_id_for_capsule(
+    capsule: ContextCapsule,
+    *,
+    repo_id: str | None = None,
+    worktree_id: str | None = None,
+    managed_thread_id: str | None = None,
+    backend_thread_id: str | None = None,
+    turn_id: str | None = None,
+) -> str:
+    """Resolve the scope id for a capsule from the standard runtime ids."""
+    if capsule.scope is ContextCapsuleScope.REPO:
+        return _required_text(repo_id or managed_thread_id, "scope_id")
+    if capsule.scope is ContextCapsuleScope.WORKTREE:
+        return _required_text(worktree_id or managed_thread_id, "scope_id")
+    if capsule.scope is ContextCapsuleScope.THREAD:
+        return _required_text(managed_thread_id or backend_thread_id, "scope_id")
+    if capsule.scope is ContextCapsuleScope.BACKEND_SESSION:
+        return _required_text(backend_thread_id or managed_thread_id, "scope_id")
+    if capsule.scope is ContextCapsuleScope.TURN:
+        return _required_text(turn_id or managed_thread_id, "scope_id")
+    return _required_text(managed_thread_id or backend_thread_id, "scope_id")
+
+
 def stable_json_digest(value: Any) -> str:
     encoded = json.dumps(
         value,
@@ -199,7 +233,7 @@ def plan_capsule_render(
     )
 
 
-def _required_text(value: str, field_name: str) -> str:
+def _required_text(value: object, field_name: str) -> str:
     text = value.strip() if isinstance(value, str) else ""
     if not text:
         raise ValueError(f"{field_name} is required")
@@ -216,6 +250,8 @@ __all__ = [
     "ContextCapsuleScope",
     "ContextCapsuleVisibility",
     "capsule_payload_digest",
+    "ledger_backend_thread_id_for_scope",
+    "ledger_scope_id_for_capsule",
     "plan_capsule_render",
     "stable_json_digest",
 ]

--- a/src/codex_autorunner/core/pma/message_options.py
+++ b/src/codex_autorunner/core/pma/message_options.py
@@ -6,10 +6,15 @@ from typing import Any, Optional
 
 from ..car_context import (
     build_car_context_bundle,
+    build_car_context_capsule,
     default_managed_thread_context_profile,
     normalize_car_context_profile,
 )
+from ..context_capsule_planner import plan_context_capsules_for_prompt
+from ..context_capsules import ContextCapsuleRenderPlan
 from ..managed_thread_kinds import infer_managed_thread_chat_kind
+from ..orchestration.context_capsule_ledger import SQLiteContextCapsuleLedger
+from ..orchestration.sqlite import open_orchestration_sqlite
 from ..text_utils import _normalize_optional_text
 from .attachments import (
     build_managed_thread_attachment_execution_context,
@@ -37,6 +42,7 @@ class ManagedThreadMessageInput:
     attachments: Any
     defaults: dict[str, Any]
     thread: dict[str, Any]
+    managed_thread_id: str
     hub_root: Path
     runtime_cwd: Path | None
     live_backend_thread_id: str
@@ -63,6 +69,7 @@ class ManagedThreadMessageOptions:
     live_backend_thread_id: str
     execution_prompt: str
     capsule_refs: tuple[dict[str, Any], ...]
+    capsule_render_plans: tuple[ContextCapsuleRenderPlan, ...]
     execution_input_items: Optional[list[dict[str, Any]]]
     delivery_payload: dict[str, Any]
 
@@ -110,6 +117,18 @@ def resolve_managed_thread_message_options(
         context_profile,
         prompt_text=message,
     )
+    context_capsule = build_car_context_capsule(context_bundle)
+    with open_orchestration_sqlite(input.hub_root) as conn:
+        planned_context = plan_context_capsules_for_prompt(
+            (context_capsule,),
+            ledger=SQLiteContextCapsuleLedger(conn),
+            surface_kind="web",
+            surface_key=input.managed_thread_id,
+            managed_thread_id=input.managed_thread_id,
+            backend_thread_id=input.live_backend_thread_id,
+            repo_id=_normalize_optional_text(input.thread.get("repo_id")),
+            worktree_id=_normalize_optional_text(input.thread.get("workspace_root")),
+        )
     prompt_assembly = compose_managed_thread_execution_prompt_with_capsules(
         ManagedThreadPromptRequest(
             agent=input.thread.get("agent"),
@@ -119,6 +138,8 @@ def resolve_managed_thread_message_options(
             compact_seed=compact_seed,
             message=execution_message,
             context_bundle=context_bundle,
+            rendered_context=planned_context.rendered_text,
+            capsule_refs=planned_context.capsule_refs,
             chat_kind=chat_kind,
         )
     )
@@ -146,6 +167,7 @@ def resolve_managed_thread_message_options(
         live_backend_thread_id=input.live_backend_thread_id,
         execution_prompt=execution_prompt,
         capsule_refs=tuple(ref.to_dict() for ref in prompt_assembly.capsule_refs),
+        capsule_render_plans=planned_context.plans,
         execution_input_items=(
             attachment_context.input_items if attachment_context is not None else None
         ),

--- a/src/codex_autorunner/core/pma/prompts.py
+++ b/src/codex_autorunner/core/pma/prompts.py
@@ -4,16 +4,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from ..car_context import build_car_context_capsule
 from ..managed_thread_kinds import (
     MANAGED_THREAD_CHAT_KIND_PMA,
     ManagedThreadChatKind,
     normalize_managed_thread_chat_kind,
 )
-from ..orchestration.turn_context import (
-    ManagedThreadCapsuleRef,
-    render_context_capsule_for_prompt,
-)
+from ..orchestration.turn_context import ManagedThreadCapsuleRef
 from ..pma_context import format_pma_discoverability_preamble
 
 
@@ -26,6 +22,8 @@ class ManagedThreadPromptRequest:
     compact_seed: str | None
     message: str
     context_bundle: Any
+    rendered_context: str = ""
+    capsule_refs: tuple[ManagedThreadCapsuleRef, ...] = ()
     chat_kind: ManagedThreadChatKind = MANAGED_THREAD_CHAT_KIND_PMA
 
 
@@ -70,19 +68,15 @@ def compose_managed_thread_execution_prompt_with_capsules(
             f"Hub root: `{request.hub_root.expanduser().resolve()}`.\n{runtime_text}\n"
         )
     user_message = f"<user_message>\n{execution_message}\n</user_message>\n"
-    capsule = build_car_context_capsule(request.context_bundle)
-    car_context = render_context_capsule_for_prompt(capsule) if capsule else ""
-    capsule_refs = (
-        (ManagedThreadCapsuleRef.from_capsule(capsule),) if capsule is not None else ()
-    )
-    if not car_context:
+    rendered_context = str(request.rendered_context or "").strip()
+    if not rendered_context:
         return ManagedThreadPromptAssembly(
             prompt=f"{preamble}{user_message}",
-            capsule_refs=capsule_refs,
+            capsule_refs=request.capsule_refs,
         )
     return ManagedThreadPromptAssembly(
-        prompt=f"{preamble}{car_context}\n\n{user_message}",
-        capsule_refs=capsule_refs,
+        prompt=f"{preamble}{rendered_context}\n\n{user_message}",
+        capsule_refs=request.capsule_refs,
     )
 
 

--- a/src/codex_autorunner/core/pma/queue_prompts.py
+++ b/src/codex_autorunner/core/pma/queue_prompts.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+from ..context_awareness import (
+    PlannedPromptInjection,
+    plan_worktree_pr_hint_injection,
+    record_planned_prompt_injection,
+)
 from ..managed_thread_identity import pma_automation_key, pma_base_key
 from ..pma_context import format_pma_prompt
 from ..pma_origin import PmaOriginContext, extract_pma_origin_metadata
@@ -88,16 +93,42 @@ def build_queue_execution_prompt(
         force_full_base_prompt=force_full_base_prompt,
         user_input_texts=[inputs.message],
     )
+    planned_pma_injections: tuple[PlannedPromptInjection, ...] = ()
+    # Queue prompts do not use the two-variant PMA builder, so collect equivalent
+    # stable hint plans after prompt rendering and record them from this lifecycle.
+    planned_worktree = plan_worktree_pr_hint_injection(
+        inputs.message,
+        hub_root=inputs.hub_root,
+        surface_kind="pma",
+        surface_key=inputs.prompt_state_key,
+        managed_thread_id=inputs.prompt_state_key,
+        user_input_texts=[inputs.message],
+    )
+    if planned_worktree.injected:
+        planned_pma_injections = (planned_worktree,)
     if inputs.github_context_injector is None:
+        for planned in planned_pma_injections:
+            record_planned_prompt_injection(
+                inputs.hub_root,
+                planned.prompt_text,
+                planned.render_plans,
+            )
         return built
-    return _inject_github_context(inputs, built)
+    return _inject_github_context(
+        inputs,
+        built,
+        planned_pma_injections=planned_pma_injections,
+    )
 
 
 async def _inject_github_context(
     inputs: PmaQueuePromptInputs,
     built: str,
+    *,
+    planned_pma_injections: tuple[PlannedPromptInjection, ...] = (),
 ) -> str:
     assert inputs.github_context_injector is not None
+    planned_injections: list[PlannedPromptInjection] = []
     injected, _ = await inputs.github_context_injector(
         prompt_text=built,
         link_source_text=inputs.message,
@@ -105,7 +136,24 @@ async def _inject_github_context(
         logger=inputs.logger,
         event_prefix="web.pma.github_context",
         allow_cross_repo=True,
+        hub_root=inputs.hub_root,
+        surface_kind="pma",
+        surface_key=inputs.prompt_state_key,
+        managed_thread_id=inputs.prompt_state_key,
+        planned_injections=planned_injections,
     )
+    for planned in planned_injections:
+        record_planned_prompt_injection(
+            inputs.hub_root,
+            planned.prompt_text,
+            planned.render_plans,
+        )
+    for planned in planned_pma_injections:
+        record_planned_prompt_injection(
+            inputs.hub_root,
+            planned.prompt_text,
+            planned.render_plans,
+        )
     return injected
 
 

--- a/src/codex_autorunner/core/pma/queue_prompts.py
+++ b/src/codex_autorunner/core/pma/queue_prompts.py
@@ -92,6 +92,7 @@ def build_queue_execution_prompt(
         prompt_state_key=inputs.prompt_state_key,
         force_full_base_prompt=force_full_base_prompt,
         user_input_texts=[inputs.message],
+        record_worktree_pr_hint=False,
     )
     planned_pma_injections: tuple[PlannedPromptInjection, ...] = ()
     # Queue prompts do not use the two-variant PMA builder, so collect equivalent

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any, Mapping, Optional, cast
 
 from .config_contract import ConfigError
-from .context_awareness import maybe_inject_worktree_pr_hint
+from .context_awareness import (
+    PlannedPromptInjection,
+    maybe_inject_planned_worktree_pr_hint,
+    maybe_inject_worktree_pr_hint,
+    plan_worktree_pr_hint_injection,
+)
 from .hub import HubSupervisor
 from .managed_thread_snapshot import (
     snapshot_managed_threads as _snapshot_managed_threads,
@@ -63,6 +68,7 @@ class PmaPromptVariants:
 
     new_session_prompt: str
     existing_session_prompt: str
+    planned_injections: tuple[PlannedPromptInjection, ...] = ()
 
 
 def format_pma_discoverability_preamble(
@@ -97,11 +103,23 @@ def format_pma_prompt(
     force_full_context: bool = False,
     force_full_base_prompt: bool = False,
     user_input_texts: Sequence[str | None] | None = None,
+    record_worktree_pr_hint: bool = True,
 ) -> str:
-    message, _ = maybe_inject_worktree_pr_hint(
-        message,
-        user_input_texts=user_input_texts,
-    )
+    if hub_root is not None and prompt_state_key:
+        message, _ = maybe_inject_planned_worktree_pr_hint(
+            message,
+            hub_root=hub_root,
+            surface_kind="pma",
+            surface_key=prompt_state_key,
+            managed_thread_id=prompt_state_key,
+            user_input_texts=user_input_texts,
+            record_rendered=record_worktree_pr_hint,
+        )
+    else:
+        message, _ = maybe_inject_worktree_pr_hint(
+            message,
+            user_input_texts=user_input_texts,
+        )
     limits = PmaPromptRenderLimits.from_snapshot(snapshot)
     snapshot_text = _render_hub_snapshot(
         snapshot,
@@ -200,6 +218,7 @@ def format_pma_prompt_variants(
         prompt_state_key=prompt_state_key,
         force_full_context=force_full_context,
         user_input_texts=user_input_texts,
+        record_worktree_pr_hint=False,
     )
     existing_session_prompt = new_session_prompt
     if hub_root is not None and prompt_state_key and not force_full_context:
@@ -210,10 +229,24 @@ def format_pma_prompt_variants(
             hub_root=hub_root,
             prompt_state_key=prompt_state_key,
             user_input_texts=user_input_texts,
+            record_worktree_pr_hint=False,
         )
+    planned_injections: tuple[PlannedPromptInjection, ...] = ()
+    if hub_root is not None and prompt_state_key:
+        planned_worktree = plan_worktree_pr_hint_injection(
+            message,
+            hub_root=hub_root,
+            surface_kind="pma",
+            surface_key=prompt_state_key,
+            managed_thread_id=prompt_state_key,
+            user_input_texts=user_input_texts,
+        )
+        if planned_worktree.injected:
+            planned_injections = (planned_worktree,)
     return PmaPromptVariants(
         new_session_prompt=new_session_prompt,
         existing_session_prompt=existing_session_prompt,
+        planned_injections=planned_injections,
     )
 
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
@@ -173,6 +173,7 @@ def resolve_managed_thread_message_options(
                 attachments=payload.attachments,
                 defaults=defaults,
                 thread=thread,
+                managed_thread_id=managed_thread_id,
                 hub_root=request.app.state.config.root,
                 runtime_cwd=(
                     Path(str(thread.get("workspace_root")))

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime_payloads.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime_payloads.py
@@ -173,6 +173,7 @@ def resolve_managed_thread_message_options(
                 attachments=payload.attachments,
                 defaults=defaults,
                 thread=thread,
+                managed_thread_id=managed_thread_id,
                 hub_root=request.app.state.config.root,
                 runtime_cwd=(
                     Path(str(thread.get("workspace_root")))

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_send_runtime.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_send_runtime.py
@@ -23,14 +23,17 @@ from .....core.automation.models import (
     AutomationChildExecutionEdge,
 )
 from .....core.automation.store import AutomationStore
+from .....core.context_capsule_planner import record_context_capsule_renders
 from .....core.managed_thread_store import (
     ManagedThreadAlreadyHasRunningTurnError,
     ManagedThreadNotActiveError,
     ManagedThreadStore,
 )
 from .....core.orchestration import MessageRequest
+from .....core.orchestration.context_capsule_ledger import SQLiteContextCapsuleLedger
 from .....core.orchestration.runtime_threads import RuntimeThreadExecution
 from .....core.orchestration.service import BusyInterruptFailedError
+from .....core.orchestration.sqlite import open_orchestration_sqlite
 from .....core.orchestration.turn_execution_contract import TurnExecutionRequest
 from .....core.pma.message_options import ManagedThreadMessageOptions
 from .....core.pma.outbound_payloads import (
@@ -397,6 +400,19 @@ async def run_managed_thread_message_send(
             error=detail,
             delivery_payload=options.delivery_payload,
         )
+    if options.capsule_render_plans:
+        try:
+            with open_orchestration_sqlite(hub_root) as conn:
+                record_context_capsule_renders(
+                    SQLiteContextCapsuleLedger(conn),
+                    options.capsule_render_plans,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to record managed-thread context capsule renders",
+                extra={"managed_thread_id": managed_thread_id},
+                exc_info=True,
+            )
 
     notification: Optional[dict[str, Any]] = None
     if options.notify_on == "terminal":

--- a/tests/core/test_context_capsules.py
+++ b/tests/core/test_context_capsules.py
@@ -12,6 +12,8 @@ from codex_autorunner.core.context_capsules import (
     ContextCapsuleScope,
     ContextCapsuleVisibility,
     capsule_payload_digest,
+    ledger_backend_thread_id_for_scope,
+    ledger_scope_id_for_capsule,
     plan_capsule_render,
 )
 from codex_autorunner.core.injected_context import (
@@ -75,6 +77,55 @@ def test_capsule_identity_uses_canonical_scope_and_boundaries() -> None:
         "1",
     )
     assert first.stable_id() != second.stable_id()
+
+
+def test_capsule_ledger_scope_helpers_keep_thread_scope_backend_independent() -> None:
+    capsule = _capsule()
+
+    assert (
+        ledger_backend_thread_id_for_scope(
+            capsule,
+            backend_thread_id="backend-1",
+        )
+        == ""
+    )
+    assert (
+        ledger_scope_id_for_capsule(
+            capsule,
+            managed_thread_id="managed-1",
+            backend_thread_id="backend-1",
+        )
+        == "managed-1"
+    )
+
+
+def test_capsule_ledger_scope_helpers_keep_backend_session_specific() -> None:
+    capsule = ContextCapsule(
+        capsule_id="pma.base_prompt",
+        version=1,
+        scope=ContextCapsuleScope.BACKEND_SESSION,
+        visibility=ContextCapsuleVisibility.MODEL_ONLY,
+        source_digest="source",
+        expiry=ContextCapsuleExpiry.WHEN_SOURCE_CHANGES,
+        reason="test",
+        payload={"text": "base prompt"},
+    )
+
+    assert (
+        ledger_backend_thread_id_for_scope(
+            capsule,
+            backend_thread_id="backend-1",
+        )
+        == "backend-1"
+    )
+    assert (
+        ledger_scope_id_for_capsule(
+            capsule,
+            managed_thread_id="managed-1",
+            backend_thread_id="backend-1",
+        )
+        == "backend-1"
+    )
 
 
 def test_capsule_payload_digest_is_stable_before_transport_rendering() -> None:

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime_payloads.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime_payloads.py
@@ -7,10 +7,15 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 
+from codex_autorunner.core.context_capsule_planner import record_context_capsule_renders
+from codex_autorunner.core.orchestration.context_capsule_ledger import (
+    SQLiteContextCapsuleLedger,
+)
 from codex_autorunner.core.orchestration.runtime_threads import (
     RUNTIME_THREAD_INTERRUPTED_ERROR,
     RUNTIME_THREAD_TIMEOUT_ERROR,
 )
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.surfaces.web.routes.pma_routes.managed_thread_runtime_payloads import (
     MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
     build_accepted_send_payload,
@@ -156,6 +161,52 @@ def test_resolve_message_options_uses_thread_metadata_profile(tmp_path: Path) ->
     )
 
     assert options.agent_profile == "alpha"
+
+
+def test_resolve_message_options_dedupes_thread_scoped_car_awareness(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    workspace_root = tmp_path / "repo"
+    hub_root.mkdir()
+    workspace_root.mkdir()
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(config=SimpleNamespace(root=hub_root, raw={}))
+        )
+    )
+    thread = {
+        "agent": "codex",
+        "workspace_root": str(workspace_root),
+        "resource_kind": "repo",
+    }
+
+    first = resolve_managed_thread_message_options(
+        request,
+        ManagedThreadMessageRequest(message="Can you check our car board?"),
+        managed_thread_id="thread-1",
+        thread=thread,
+        service=SimpleNamespace(),
+    )
+    with open_orchestration_sqlite(hub_root) as conn:
+        record_context_capsule_renders(
+            SQLiteContextCapsuleLedger(conn),
+            first.capsule_render_plans,
+        )
+    second = resolve_managed_thread_message_options(
+        request,
+        ManagedThreadMessageRequest(message="Can you check our car board?"),
+        managed_thread_id="thread-1",
+        thread=thread,
+        service=SimpleNamespace(),
+    )
+
+    assert "<injected context>" in first.execution_prompt
+    assert "You are operating inside a Codex Autorunner" in first.execution_prompt
+    assert "<injected context>" not in second.execution_prompt
+    assert "You are operating inside a Codex Autorunner" not in second.execution_prompt
+    assert first.capsule_refs[0]["render_decision"] == "new"
+    assert second.capsule_refs[0]["render_decision"] == "skip_duplicate"
 
 
 @patch(

--- a/tests/test_context_awareness.py
+++ b/tests/test_context_awareness.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from codex_autorunner.core.context_awareness import (
     CAR_AWARENESS_BLOCK,
     maybe_inject_filebox_hint,
+    maybe_inject_planned_car_awareness,
+    maybe_inject_planned_prompt_writing_hint,
     maybe_inject_worktree_pr_hint,
 )
 
@@ -48,3 +50,51 @@ def test_worktree_pr_hint_not_injected_from_existing_context_only() -> None:
 
     assert injected is False
     assert prompt == CAR_AWARENESS_BLOCK
+
+
+def test_planned_car_awareness_dedupes_by_thread_scope(tmp_path) -> None:
+    first, first_injected = maybe_inject_planned_car_awareness(
+        "please check our car board",
+        hub_root=tmp_path,
+        surface_kind="discord",
+        surface_key="channel-1",
+        managed_thread_id="thread-1",
+        declared_profile="car_ambient",
+    )
+    second, second_injected = maybe_inject_planned_car_awareness(
+        "please check our car board",
+        hub_root=tmp_path,
+        surface_kind="discord",
+        surface_key="channel-1",
+        managed_thread_id="thread-1",
+        declared_profile="car_ambient",
+    )
+
+    assert first_injected is True
+    assert "You are operating inside a Codex Autorunner" in first
+    assert second_injected is False
+    assert second == "please check our car board"
+
+
+def test_planned_prompt_writing_hint_dedupes_by_thread_scope(tmp_path) -> None:
+    first, first_injected = maybe_inject_planned_prompt_writing_hint(
+        "write a prompt for this",
+        hub_root=tmp_path,
+        surface_kind="telegram",
+        surface_key="topic-1",
+        managed_thread_id="topic-1",
+        trigger_text="write a prompt for this",
+    )
+    second, second_injected = maybe_inject_planned_prompt_writing_hint(
+        "write a prompt for this",
+        hub_root=tmp_path,
+        surface_kind="telegram",
+        surface_key="topic-1",
+        managed_thread_id="topic-1",
+        trigger_text="write a prompt for this",
+    )
+
+    assert first_injected is True
+    assert "put the prompt in a ```code block```" in first
+    assert second_injected is False
+    assert second == "write a prompt for this"

--- a/tests/test_context_awareness.py
+++ b/tests/test_context_awareness.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from codex_autorunner.core.context_awareness import (
     CAR_AWARENESS_BLOCK,
     maybe_inject_filebox_hint,
-    maybe_inject_planned_car_awareness,
-    maybe_inject_planned_prompt_writing_hint,
     maybe_inject_worktree_pr_hint,
+    plan_car_awareness_injection,
+    plan_prompt_writing_hint_injection,
 )
 
 
@@ -53,48 +53,52 @@ def test_worktree_pr_hint_not_injected_from_existing_context_only() -> None:
 
 
 def test_planned_car_awareness_dedupes_by_thread_scope(tmp_path) -> None:
-    first, first_injected = maybe_inject_planned_car_awareness(
+    first = plan_car_awareness_injection(
         "please check our car board",
         hub_root=tmp_path,
         surface_kind="discord",
         surface_key="channel-1",
         managed_thread_id="thread-1",
         declared_profile="car_ambient",
+        record_rendered=True,
     )
-    second, second_injected = maybe_inject_planned_car_awareness(
+    second = plan_car_awareness_injection(
         "please check our car board",
         hub_root=tmp_path,
         surface_kind="discord",
         surface_key="channel-1",
         managed_thread_id="thread-1",
         declared_profile="car_ambient",
+        record_rendered=True,
     )
 
-    assert first_injected is True
-    assert "You are operating inside a Codex Autorunner" in first
-    assert second_injected is False
-    assert second == "please check our car board"
+    assert first.injected is True
+    assert "You are operating inside a Codex Autorunner" in first.prompt_text
+    assert second.injected is False
+    assert second.prompt_text == "please check our car board"
 
 
 def test_planned_prompt_writing_hint_dedupes_by_thread_scope(tmp_path) -> None:
-    first, first_injected = maybe_inject_planned_prompt_writing_hint(
+    first = plan_prompt_writing_hint_injection(
         "write a prompt for this",
         hub_root=tmp_path,
         surface_kind="telegram",
         surface_key="topic-1",
         managed_thread_id="topic-1",
         trigger_text="write a prompt for this",
+        record_rendered=True,
     )
-    second, second_injected = maybe_inject_planned_prompt_writing_hint(
+    second = plan_prompt_writing_hint_injection(
         "write a prompt for this",
         hub_root=tmp_path,
         surface_kind="telegram",
         surface_key="topic-1",
         managed_thread_id="topic-1",
         trigger_text="write a prompt for this",
+        record_rendered=True,
     )
 
-    assert first_injected is True
-    assert "put the prompt in a ```code block```" in first
-    assert second_injected is False
-    assert second == "write a prompt for this"
+    assert first.injected is True
+    assert "put the prompt in a ```code block```" in first.prompt_text
+    assert second.injected is False
+    assert second.prompt_text == "write a prompt for this"

--- a/tests/test_github_context_injection.py
+++ b/tests/test_github_context_injection.py
@@ -6,9 +6,14 @@ from pathlib import Path
 import pytest
 
 import codex_autorunner.adapters.github.context_injection as context_module
+from codex_autorunner.core.context_capsule_planner import record_context_capsule_renders
 from codex_autorunner.core.injected_context import (
     render_legacy_injected_context_transport,
 )
+from codex_autorunner.core.orchestration.context_capsule_ledger import (
+    SQLiteContextCapsuleLedger,
+)
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.utils import RepoNotFoundError
 
 
@@ -31,6 +36,18 @@ class _GitHubServiceStub:
         return {
             "path": ".codex-autorunner/github_context/issue-123.md",
             "hint": render_legacy_injected_context_transport("Context: injected"),
+        }
+
+
+class _MultiLinkGitHubServiceStub(_GitHubServiceStub):
+    def build_context_file_from_url(
+        self, url: str, *, allow_cross_repo: bool = False
+    ) -> dict[str, str]:
+        self.calls.append((url, allow_cross_repo))
+        issue = url.rsplit("/", 1)[-1]
+        return {
+            "path": f".codex-autorunner/github_context/issue-{issue}.md",
+            "hint": render_legacy_injected_context_transport(f"Context: issue {issue}"),
         }
 
 
@@ -151,3 +168,56 @@ async def test_pma_injection_skips_when_repo_not_found_without_fallback(
 
     assert injected is False
     assert injected_prompt == prompt_text
+
+
+@pytest.mark.anyio
+async def test_scoped_injection_continues_after_duplicate_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(context_module, "find_repo_root", lambda _path: tmp_path)
+    monkeypatch.setattr(context_module, "load_repo_config", lambda _path: None)
+    monkeypatch.setattr(context_module, "GitHubService", _MultiLinkGitHubServiceStub)
+
+    first_link = "https://github.com/example/repo/issues/123"
+    second_link = "https://github.com/example/repo/issues/456"
+    first_planned: list[context_module.PlannedPromptInjection] = []
+    first_prompt, first_injected = await context_module.maybe_inject_github_context(
+        prompt_text="PMA prompt",
+        link_source_text=f"please inspect {first_link}",
+        workspace_root=tmp_path,
+        logger=logging.getLogger("test.github_context.duplicate_first"),
+        event_prefix="test.github_context",
+        allow_cross_repo=True,
+        hub_root=tmp_path,
+        surface_kind="telegram",
+        surface_key="topic-1",
+        managed_thread_id="topic-1",
+        planned_injections=first_planned,
+    )
+    with open_orchestration_sqlite(tmp_path) as conn:
+        record_context_capsule_renders(
+            SQLiteContextCapsuleLedger(conn),
+            first_planned[0].render_plans,
+        )
+
+    second_planned: list[context_module.PlannedPromptInjection] = []
+    second_prompt, second_injected = await context_module.maybe_inject_github_context(
+        prompt_text="PMA prompt",
+        link_source_text=f"{first_link} {second_link}",
+        workspace_root=tmp_path,
+        logger=logging.getLogger("test.github_context.duplicate_then_new"),
+        event_prefix="test.github_context",
+        allow_cross_repo=True,
+        hub_root=tmp_path,
+        surface_kind="telegram",
+        surface_key="topic-1",
+        managed_thread_id="topic-1",
+        planned_injections=second_planned,
+    )
+
+    assert first_injected is True
+    assert "Context: issue 123" in first_prompt
+    assert second_injected is True
+    assert "Context: issue 123" not in second_prompt
+    assert "Context: issue 456" in second_prompt
+    assert len(second_planned) == 1


### PR DESCRIPTION
## Summary
- add a durable context capsule planner for stable model-only injected context
- route CAR awareness, prompt-writing, GitHub link context, and PMA worktree/PR guidance through scoped ledger decisions
- record stable context only after accepted/successful turn lifecycle points where available, while keeping current-turn attachment/filebox context turn-scoped

## Validation
- scripts/check.sh
  - Python: 9664 passed
  - Web UI: 921 passed, 2 skipped
  - web UI lab fast check: 27 scenarios passed
- Subagent review waves run until the final actionable lifecycle findings were fixed