### PR TITLE
[codex] Add non-destructive worktree archive

### DIFF
--- a/schemas/hub.json
+++ b/schemas/hub.json
@@ -51,6 +51,7 @@
       "cleanup_blocked_by_chat_binding": {"type": "boolean"},
       "has_car_state": {"type": "boolean"},
       "resource_kind": {"type": "string", "enum": ["repo"]},
+      "archived": {"type": "boolean"},
       "mounted": {"type": "boolean"},
       "mount_error": {"type": ["null", "string"]},
       "ticket_flow": {

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -681,6 +681,17 @@ class HubSupervisor:
             archive_profile=archive_profile,
         )
 
+    def set_worktree_archived(
+        self,
+        *,
+        worktree_repo_id: str,
+        archived: bool,
+    ) -> Dict[str, object]:
+        return self._worktree_manager.set_worktree_archived(
+            worktree_repo_id=worktree_repo_id,
+            archived=archived,
+        )
+
     def cleanup_repo_threads(self, *, repo_id: str) -> Dict[str, object]:
         return self._repo_manager.cleanup_repo_threads(repo_id=repo_id)
 

--- a/src/codex_autorunner/core/hub_repo_projection.py
+++ b/src/codex_autorunner/core/hub_repo_projection.py
@@ -100,6 +100,7 @@ class HubRepoProjectionService:
             str(repo_root),
             bool(snapshot.exists_on_disk),
             bool(snapshot.initialized),
+            bool(getattr(snapshot, "archived", False)),
             snapshot.last_run_id,
             snapshot.last_run_started_at,
             snapshot.last_run_finished_at,

--- a/src/codex_autorunner/core/hub_topology.py
+++ b/src/codex_autorunner/core/hub_topology.py
@@ -189,6 +189,7 @@ class RepoSnapshot:
     cleanup_blocked_by_chat_binding: bool = False
     has_car_state: bool = False
     resource_kind: str = "repo"
+    archived: bool = False
 
     def to_dict(self, hub_root: Path) -> Dict[str, object]:
         try:
@@ -228,6 +229,7 @@ class RepoSnapshot:
             "cleanup_blocked_by_chat_binding": self.cleanup_blocked_by_chat_binding,
             "has_car_state": self.has_car_state,
             "resource_kind": self.resource_kind,
+            "archived": self.archived,
         }
 
 
@@ -698,6 +700,7 @@ def build_repo_snapshot(
         last_exit_code=runner_state.last_exit_code if runner_state else None,
         runner_pid=runner_state.runner_pid if runner_state else None,
         effective_destination=effective_destination,
+        archived=bool(record.repo.archived),
     )
 
 
@@ -813,6 +816,7 @@ def load_hub_state(state_path: Path, hub_root: Path) -> HubState:
                     normalize_manifest_destination(entry.get("effective_destination"))
                     or default_local_destination()
                 ),
+                archived=bool(entry.get("archived", False)),
             )
             repos.append(repo)
         except (ValueError, TypeError, KeyError) as exc:

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -1223,6 +1223,26 @@ print(
             archive_profile=archive_profile,
         )
 
+    def set_worktree_archived(
+        self,
+        *,
+        worktree_repo_id: str,
+        archived: bool,
+    ) -> Dict[str, object]:
+        self._ctx.invalidate_cache()
+        manifest = self._topology_repository.load_manifest()
+        entry = manifest.get(worktree_repo_id)
+        if not entry or entry.kind != "worktree":
+            raise ValueError(f"Worktree repo not found: {worktree_repo_id}")
+        entry.archived = bool(archived)
+        self._topology_repository.save_manifest(manifest)
+        return {
+            "status": "ok",
+            "worktree_repo_id": worktree_repo_id,
+            "archive_state": "archived" if archived else "active",
+            "archived": bool(archived),
+        }
+
     def _collect_cleanup_worktrees(
         self,
         *,

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -1263,6 +1263,8 @@ print(
             if not entry.worktree_of:
                 if not is_legacy_linked_worktree:
                     continue
+            if entry.archived:
+                continue
             try:
                 if self._has_active_chat_binding(entry.id):
                     continue

--- a/src/codex_autorunner/manifest.py
+++ b/src/codex_autorunner/manifest.py
@@ -89,6 +89,7 @@ class ManifestRepo:
     display_name: Optional[str] = None
     worktree_setup_commands: Optional[List[str]] = None
     destination: Optional[Dict[str, Any]] = None
+    archived: bool = False
 
     def to_dict(self, hub_root: Path) -> Dict[str, object]:
         rel = _relative_to_hub_root(hub_root, self.path)
@@ -109,6 +110,8 @@ class ManifestRepo:
             payload["worktree_setup_commands"] = [
                 str(cmd) for cmd in self.worktree_setup_commands if str(cmd).strip()
             ]
+        if self.archived:
+            payload["archived"] = True
         destination = preserve_manifest_destination(self.destination)
         if destination is not None:
             payload["destination"] = destination
@@ -326,6 +329,7 @@ def _parse_manifest_repos_with_issues(
                     or None
                 ),
                 destination=destination,
+                archived=bool(entry.get("archived", False)),
             )
         )
 

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -505,6 +505,7 @@ class RepoTopology(ReadModelContract):
     label: str
     path: str
     archived: bool = False
+    archive_state: Literal["active", "archived"] = "active"
     is_pinned: bool = False
     destination_id: Optional[str] = None
     child_worktree_ids: list[str] = Field(default_factory=list)
@@ -522,6 +523,7 @@ class WorktreeTopology(ReadModelContract):
     path: str
     branch: Optional[str] = None
     archived: bool = False
+    archive_state: Literal["active", "archived"] = "active"
     destination_id: Optional[str] = None
     chat_bound: bool = False
     chat_binding_count: int = Field(default=0, ge=0)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 if TYPE_CHECKING:
     from ...app_state import HubAppContext
     from ...schemas import (
+        HubArchiveWorktreeRequest,
         HubCreateWorktreeRequest,
         HubRetireWorktreeRequest,
     )
@@ -174,6 +175,28 @@ class HubWorktreeService:
             request_id=self._get_request_id(),
         )
         return job.to_dict()
+
+    async def archive_worktree(
+        self, payload: HubArchiveWorktreeRequest
+    ) -> dict[str, Any]:
+        from .....core.logging_utils import safe_log
+
+        safe_log(
+            self._context.logger,
+            logging.INFO,
+            "Hub archive worktree id=%s archived=%s"
+            % (payload.worktree_repo_id, payload.archived),
+        )
+        try:
+            result = await asyncio.to_thread(
+                self._context.supervisor.set_worktree_archived,
+                worktree_repo_id=str(payload.worktree_repo_id),
+                archived=bool(payload.archived),
+            )
+        except (RuntimeError, OSError, ValueError, TypeError, KeyError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        self._enricher.invalidate_runtime_caches()
+        return cast(dict[str, Any], result)
 
     async def delete_worktree(
         self,

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException
 from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ..app_state import HubAppContext
 from ..schemas import (
+    HubArchiveWorktreeRequest,
     HubCreateWorktreeRequest,
     HubDeleteWorktreeRequest,
     HubDestinationSetRequest,
@@ -133,6 +134,10 @@ def build_hub_repo_routes(
     @router.post("/hub/jobs/worktrees/retire", response_model=HubJobResponse)
     async def retire_worktree_job(payload: HubRetireWorktreeRequest):
         return await worktree.retire_worktree_job(payload)
+
+    @router.post("/hub/worktrees/archive")
+    async def archive_worktree(payload: HubArchiveWorktreeRequest):
+        return await worktree.archive_worktree(payload)
 
     @router.post("/hub/worktrees/delete")
     async def delete_worktree(payload: HubDeleteWorktreeRequest):

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -184,6 +184,15 @@ class HubRetireWorktreeRequest(Payload):
     )
 
 
+class HubArchiveWorktreeRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    worktree_repo_id: str = Field(
+        validation_alias=AliasChoices("worktree_repo_id", "worktreeRepoId")
+    )
+    archived: bool = True
+
+
 class HubDeleteWorktreeRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 

--- a/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
@@ -572,6 +572,7 @@ class RepoWorktreeReadModelService:
                 label=str(item.get("name") or item.get("id")),
                 path=str(item.get("path") or ""),
                 archived=bool(item.get("archived")),
+                archive_state="archived" if bool(item.get("archived")) else "active",
                 is_pinned=bool(item.get("is_pinned")),
                 destination_id=(
                     item.get("destination_id")
@@ -596,6 +597,7 @@ class RepoWorktreeReadModelService:
                 path=str(item.get("path") or ""),
                 branch=str(item.get("branch")) if item.get("branch") else None,
                 archived=bool(item.get("archived")),
+                archive_state="archived" if bool(item.get("archived")) else "active",
                 destination_id=(
                     item.get("destination_id")
                     if isinstance(item.get("destination_id"), str)

--- a/src/codex_autorunner/web_frontend/src/lib/actions/repoWorktreeActions.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/actions/repoWorktreeActions.ts
@@ -21,6 +21,12 @@ export type RetireWorktreeTarget = {
   cleanupBlockedByChatBinding: boolean;
 };
 
+export type ArchiveWorktreeTarget = {
+  id: string;
+  label: string;
+  archived: boolean;
+};
+
 export type RetireStateTarget = {
   kind: 'repo' | 'worktree';
   id: string;
@@ -74,6 +80,22 @@ export async function confirmAndRetireWorktree(target: RetireWorktreeTarget): Pr
     readModelEntityTags.worktree(target.id)
   ]);
   return { tone: 'success', message: `Retired worktree ${target.label}.` };
+}
+
+export async function archiveWorktree(target: ArchiveWorktreeTarget): Promise<ActionNotice> {
+  const result = await webApi.hub.archiveWorktree({
+    worktreeRepoId: target.id,
+    archived: !target.archived
+  });
+  if (!result.ok) return { tone: 'danger', message: result.error.message };
+  await invalidateReadModelTags([
+    readModelEntityTags.repoWorktreeIndex,
+    readModelEntityTags.worktree(target.id)
+  ]);
+  return {
+    tone: 'success',
+    message: target.archived ? `Unarchived worktree ${target.label}.` : `Archived worktree ${target.label}.`
+  };
 }
 
 export async function confirmAndRetireState(target: RetireStateTarget): Promise<ActionNotice | null> {

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -108,6 +108,11 @@ export type WorktreeRetireRequest = {
   retireNote?: string | null;
 };
 
+export type WorktreeArchiveRequest = {
+  worktreeRepoId: string;
+  archived: boolean;
+};
+
 export type RepoStateRetireRequest = {
   kind: 'repo' | 'worktree';
   id: string;
@@ -844,6 +849,14 @@ export class WebApiClient {
           forceAttestation: request.forceAttestation ?? null,
           forceRetire: request.forceRetire ?? false,
           retireNote: request.retireNote ?? null
+        }
+      }),
+    archiveWorktree: async (request: WorktreeArchiveRequest): Promise<ApiResult<JsonRecord>> =>
+      this.requestJson<JsonRecord>('/hub/worktrees/archive', {
+        method: 'POST',
+        body: {
+          worktreeRepoId: request.worktreeRepoId,
+          archived: request.archived
         }
       }),
     retireState: async (request: RepoStateRetireRequest): Promise<ApiResult<JsonRecord>> => {

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -387,6 +387,7 @@ export type RepoTopology = {
   label: string;
   path: string;
   archived: boolean;
+  archiveState?: 'active' | 'archived';
   isPinned?: boolean;
   destinationId?: string | null;
   childWorktreeIds: string[];
@@ -404,6 +405,7 @@ export type WorktreeTopology = {
   path: string;
   branch?: string | null;
   archived: boolean;
+  archiveState?: 'active' | 'archived';
   destinationId?: string | null;
   chatBound?: boolean;
   chatBindingCount?: number;

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeIndex.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeIndex.svelte
@@ -15,6 +15,7 @@
     index,
     sectionIssues = [],
     onRetry = undefined,
+    onArchiveWorktree = undefined,
     onRetireWorktree = undefined,
     onRetireState = undefined,
     onRepoPin = undefined,
@@ -25,6 +26,7 @@
     index: RepoWorktreeIndexViewModel;
     sectionIssues?: PartialPageIssue[];
     onRetry?: (() => void) | undefined;
+    onArchiveWorktree?: ((worktree: { id: string; label: string; archived: boolean }) => void | Promise<void>) | undefined;
     onRetireWorktree?: ((worktree: { id: string; label: string; chatBound: boolean; cleanupBlockedByChatBinding: boolean }) => void | Promise<void>) | undefined;
     onRetireState?: ((target: { kind: 'repo' | 'worktree'; id: string; label: string; hasCarState: boolean; unboundManagedThreadCount: number }) => void | Promise<void>) | undefined;
     onRepoPin?: ((target: { id: string; pinned: boolean }) => void | Promise<void>) | undefined;
@@ -36,7 +38,7 @@
   const currentRunIssues = $derived(sectionIssues.filter((issue) => issue.id === 'current_run'));
   const ticketIssues = $derived(sectionIssues.filter((issue) => issue.id === 'tickets'));
 
-  const REPO_FILTERS: RepoWorktreeIndexFilter[] = ['all', 'waiting', 'active', 'chat_bound'];
+  const REPO_FILTERS: RepoWorktreeIndexFilter[] = ['all', 'waiting', 'active', 'chat_bound', 'archived'];
   let search = $state('');
   let filter = $state<RepoWorktreeIndexFilter>('all');
 
@@ -78,11 +80,13 @@
     if (key === 'all') return countRepoWorktreeIndexEntities(indexRows);
     if (key === 'active') return index.activeCount;
     if (key === 'chat_bound') return index.chatBoundCount;
+    if (key === 'archived') return index.archivedCount;
     return index.waitingCount;
   }
 
   function repoFilterLabel(key: RepoWorktreeIndexFilter): string {
     if (key === 'chat_bound') return 'Chat-bound';
+    if (key === 'archived') return 'Archived';
     return key === 'all' ? 'All' : key.charAt(0).toUpperCase() + key.slice(1);
   }
 
@@ -106,6 +110,15 @@
     event.preventDefault();
     event.stopPropagation();
     void onRetireWorktree?.(worktree);
+  }
+
+  function handleArchiveClick(
+    event: MouseEvent,
+    worktree: { id: string; label: string; archiveState: 'active' | 'archived' }
+  ): void {
+    event.preventDefault();
+    event.stopPropagation();
+    void onArchiveWorktree?.({ id: worktree.id, label: worktree.label, archived: worktree.archiveState === 'archived' });
   }
 
   function handleRetireStateClick(
@@ -217,7 +230,7 @@
           {@const accent = repoAccent(row.label)}
           {@const collapsible = row.kind === 'repo' && row.totalWorktrees > 0}
           {@const collapsed = collapsible && isRepoCollapsed(row.id)}
-          <div class={`repo-item status-${row.status}`} class:has-children={row.childWorktrees.length > 0} class:is-collapsed={collapsed} role="listitem" style={`--repo-accent: ${accent};`}>
+          <div class={`repo-item status-${row.status}`} class:has-children={row.childWorktrees.length > 0} class:is-collapsed={collapsed} class:is-archived={row.archiveState === 'archived'} role="listitem" style={`--repo-accent: ${accent};`}>
             <div
               class="repo-head row-click-target"
               role="link"
@@ -276,6 +289,9 @@
                       <span class="chat-binding-pill" title={chatBindingLabel(row)}>
                         Chat-bound
                       </span>
+                    {/if}
+                    {#if row.archiveState === 'archived'}
+                      <span class="archive-pill">Archived</span>
                     {/if}
                   </div>
                   <div class="repo-card-meta">
@@ -347,6 +363,7 @@
               {/if}
               {#if
                 (row.kind === 'repo' && onOpenRepoSettings) ||
+                (row.kind === 'worktree' && onArchiveWorktree) ||
                 (onRetireState && canRetireState(row)) ||
                 (row.kind === 'worktree' && onRetireWorktree)}
                 <span class="repo-head-icon-actions">
@@ -367,6 +384,17 @@
                       }}
                     >
                       {@render settingsIcon()}
+                    </button>
+                  {/if}
+                  {#if row.kind === 'worktree' && onArchiveWorktree}
+                    <button
+                      class="ghost-button archive-action"
+                      type="button"
+                      title={row.archiveState === 'archived' ? 'Unarchive worktree' : 'Archive worktree without deleting checkout'}
+                      aria-label={row.archiveState === 'archived' ? `Unarchive worktree ${row.label}` : `Archive worktree ${row.label}`}
+                      onclick={(event) => handleArchiveClick(event, row)}
+                    >
+                      {row.archiveState === 'archived' ? 'Unarchive' : 'Archive'}
                     </button>
                   {/if}
                   {#if onRetireState && canRetireState(row)}
@@ -432,7 +460,7 @@
                   scrollable={false}
                 >
                   {#snippet children(worktree)}
-                    <div class={`worktree-item status-${worktree.status}`} role="listitem">
+                    <div class={`worktree-item status-${worktree.status}`} class:is-archived={worktree.archiveState === 'archived'} role="listitem">
                     <div
                       class="worktree-card row-click-target"
                       role="link"
@@ -455,6 +483,9 @@
                             <span class="chat-binding-pill" title={chatBindingLabel(worktree)}>
                               Chat-bound
                             </span>
+                          {/if}
+                          {#if worktree.archiveState === 'archived'}
+                            <span class="archive-pill">Archived</span>
                           {/if}
                         </div>
                         {#if (worktree.branch && worktree.branch !== worktree.label) || worktree.currentRunTitle || worktree.chatBound}
@@ -503,8 +534,19 @@
                           data-sveltekit-preload-data="tap"
                           onclick={(event) => event.stopPropagation()}
                         >+ Chat</a>
-                        {#if (onRetireState && canRetireState(worktree)) || onRetireWorktree}
+                        {#if onArchiveWorktree || (onRetireState && canRetireState(worktree)) || onRetireWorktree}
                           <span class="worktree-row-icon-actions">
+                            {#if onArchiveWorktree}
+                              <button
+                                class="ghost-button archive-action"
+                                type="button"
+                                title={worktree.archiveState === 'archived' ? 'Unarchive worktree' : 'Archive worktree without deleting checkout'}
+                                aria-label={worktree.archiveState === 'archived' ? `Unarchive worktree ${worktree.label}` : `Archive worktree ${worktree.label}`}
+                                onclick={(event) => handleArchiveClick(event, worktree)}
+                              >
+                                {worktree.archiveState === 'archived' ? 'Unarchive' : 'Archive'}
+                              </button>
+                            {/if}
                             {#if onRetireState && canRetireState(worktree)}
                               <button
                                 class="icon-action retire-state"

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.css
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.css
@@ -111,6 +111,11 @@
     box-shadow: var(--shadow-card-hover);
   }
 
+  .repo-item.is-archived,
+  .worktree-item.is-archived {
+    opacity: 0.72;
+  }
+
   .repo-head {
     position: relative;
     display: flex;
@@ -337,6 +342,20 @@
     border-color: color-mix(in srgb, var(--color-danger) 40%, var(--color-border));
   }
 
+  .archive-action {
+    min-height: 28px;
+    padding: 0 8px;
+    border-radius: 6px;
+    font-size: 11px;
+    line-height: 1;
+    color: var(--color-ink-muted);
+  }
+
+  .archive-action:hover {
+    color: var(--color-ink);
+    border-color: var(--color-border-strong);
+  }
+
   .icon-action svg {
     width: 16px;
     height: 16px;
@@ -473,6 +492,20 @@
     border-radius: 4px;
     background: var(--color-accent-soft);
     color: var(--color-accent);
+    font-size: 10px;
+    font-weight: 650;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .archive-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 18px;
+    padding: 0 6px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border-subtle);
+    color: var(--color-ink-faint);
     font-size: 10px;
     font-weight: 650;
     line-height: 1;

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
@@ -13,6 +13,7 @@
     errorMessage = null,
     sectionIssues = [],
     onRetry = undefined,
+    onArchiveWorktree = undefined,
     onRetireWorktree = undefined,
     onRetireState = undefined,
     onRepoPin = undefined,
@@ -29,6 +30,7 @@
     errorMessage?: string | null;
     sectionIssues?: PartialPageIssue[];
     onRetry?: (() => void) | undefined;
+    onArchiveWorktree?: ((worktree: { id: string; label: string; archived: boolean }) => void | Promise<void>) | undefined;
     onRetireWorktree?: ((worktree: { id: string; label: string; chatBound: boolean; cleanupBlockedByChatBinding: boolean }) => void | Promise<void>) | undefined;
     onRetireState?: ((target: { kind: 'repo' | 'worktree'; id: string; label: string; hasCarState: boolean; unboundManagedThreadCount: number }) => void | Promise<void>) | undefined;
     onRepoPin?: ((target: { id: string; pinned: boolean }) => void | Promise<void>) | undefined;
@@ -51,6 +53,7 @@
     {index}
     {sectionIssues}
     {onRetry}
+    {onArchiveWorktree}
     {onRetireWorktree}
     {onRetireState}
     {onRepoPin}

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -314,6 +314,8 @@ export function selectRepoSummaries(state: ReadModelEntityState): RepoSummary[] 
         kind: 'base',
         worktree_count: repo.childWorktreeIds.length,
         is_pinned: Boolean(repo.isPinned),
+        archiveState: repo.archiveState,
+        archived: Boolean(repo.archived),
         ...(Array.isArray(repo.worktreeSetupCommands)
           ? { worktree_setup_commands: repo.worktreeSetupCommands }
           : {}),
@@ -338,6 +340,8 @@ export function selectWorktreeSummaries(state: ReadModelEntityState): WorktreeSu
         kind: 'worktree',
         worktree_of: worktree.repoId,
         branch: worktree.branch,
+        archiveState: worktree.archiveState,
+        archived: Boolean(worktree.archived),
         ...runtimeRaw(state.runtime[`worktree:${worktree.worktreeId}`]),
         chat_bound: Boolean(worktree.chatBound),
         chat_bound_thread_count: worktree.chatBindingCount ?? 0,

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
@@ -255,6 +255,7 @@ export type RepoSummary = {
   activeRuns: number;
   openTickets: number;
   lastActivityAt: string | null;
+  archiveState?: 'active' | 'archived';
   gitStatus?: GitStatusSummary | null;
   raw: JsonRecord;
 };
@@ -270,6 +271,7 @@ export type WorktreeSummary = {
   activeRuns: number;
   openTickets: number;
   lastActivityAt: string | null;
+  archiveState?: 'active' | 'archived';
   gitStatus?: GitStatusSummary | null;
   raw: JsonRecord;
 };
@@ -599,6 +601,7 @@ export function mapRepoSummary(raw: JsonRecord): RepoSummary {
       numberOrNull(raw.open_tickets ?? raw.open_ticket_count) ??
       (totalTickets !== null && doneTickets !== null ? Math.max(0, totalTickets - doneTickets) : 0),
     lastActivityAt: dateString(raw.last_activity_at ?? raw.updated_at ?? runState.last_event_at ?? raw.last_run_started_at),
+    archiveState: raw.archived === true || raw.archive_state === 'archived' || raw.archiveState === 'archived' ? 'archived' : 'active',
     gitStatus: mapGitStatusSummary(raw),
     raw
   };
@@ -626,6 +629,7 @@ export function mapWorktreeSummary(raw: JsonRecord): WorktreeSummary {
       numberOrNull(raw.open_tickets ?? raw.open_ticket_count) ??
       (totalTickets !== null && doneTickets !== null ? Math.max(0, totalTickets - doneTickets) : 0),
     lastActivityAt: dateString(raw.last_activity_at ?? raw.updated_at ?? runState.last_event_at ?? raw.last_run_started_at),
+    archiveState: raw.archived === true || raw.archive_state === 'archived' || raw.archiveState === 'archived' ? 'archived' : 'active',
     gitStatus: mapGitStatusSummary(raw),
     raw
   };

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/mockData.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/mockData.ts
@@ -92,6 +92,7 @@ export const mockRepoSummary: RepoSummary = {
   activeRuns: 1,
   openTickets: 3,
   lastActivityAt: '2026-05-04T00:02:00Z',
+  archiveState: 'active',
   gitStatus: null,
   raw: {}
 };
@@ -106,6 +107,7 @@ export const mockWorktreeSummary: WorktreeSummary = {
   activeRuns: 1,
   openTickets: 1,
   lastActivityAt: '2026-05-04T00:02:00Z',
+  archiveState: 'active',
   gitStatus: null,
   raw: {}
 };

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
@@ -191,6 +191,31 @@ describe('repo/worktree view models', () => {
     expect(filterRepoWorktreeIndexRows(vm.rows, '', 'chat_bound')[0].childWorktrees[0].id).toBe('worktree-1');
   });
 
+  it('hides archived worktrees from normal index filters and exposes them through archived', () => {
+    const vm = buildRepoWorktreeIndexViewModel({
+      repos: [mockRepoSummary],
+      worktrees: [
+        {
+          ...mockWorktreeSummary,
+          archiveState: 'archived',
+          raw: { archived: true }
+        }
+      ],
+      runs: [],
+      chats: [],
+      tickets: [],
+      artifacts: []
+    });
+
+    expect(vm.archivedCount).toBe(1);
+    expect(filterRepoWorktreeIndexRows(vm.rows, '', 'all').map((row) => row.id)).toEqual(['repo-1']);
+    expect(visibleRepoWorktreeChildren(vm.rows[0], '', 'all')).toEqual([]);
+    expect(filterRepoWorktreeIndexRows(vm.rows, '', 'archived')[0].childWorktrees[0]).toMatchObject({
+      id: 'worktree-1',
+      archiveState: 'archived'
+    });
+  });
+
   it('keeps known child worktrees under their owning repo and only promotes orphan worktrees', () => {
     const vm = buildRepoWorktreeIndexViewModel({
       repos: [mockRepoSummary],

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
@@ -35,7 +35,8 @@ import {
 } from './ticketFlowStatus';
 
 export type RepoWorktreeKind = 'repo' | 'worktree';
-export type RepoWorktreeIndexFilter = 'all' | 'active' | 'waiting' | 'chat_bound';
+export type RepoWorktreeArchiveState = 'active' | 'archived';
+export type RepoWorktreeIndexFilter = 'all' | 'active' | 'waiting' | 'chat_bound' | 'archived';
 
 export type RepoWorktreeIndexRow = {
   id: string;
@@ -43,6 +44,7 @@ export type RepoWorktreeIndexRow = {
   label: string;
   detail: string | null;
   status: WorkStatus;
+  archiveState: RepoWorktreeArchiveState;
   branch: string | null;
   path: string | null;
   activeRuns: number;
@@ -87,6 +89,7 @@ export type RepoWorktreeChildRow = {
   id: string;
   label: string;
   status: WorkStatus;
+  archiveState: RepoWorktreeArchiveState;
   branch: string | null;
   path: string | null;
   activeRuns: number;
@@ -219,6 +222,7 @@ export type RepoWorktreeIndexViewModel = {
   activeCount: number;
   waitingCount: number;
   chatBoundCount: number;
+  archivedCount: number;
   openTicketCount: number;
   /**
    * When false, ticket quantity chips and progress are hidden (hub ticket list did not load).
@@ -376,6 +380,7 @@ export function buildRepoWorktreeIndexViewModel(
     activeCount: countRepoWorktreeIndexEntities(rows, 'active'),
     waitingCount: countRepoWorktreeIndexEntities(rows, 'waiting'),
     chatBoundCount: countRepoWorktreeIndexEntities(rows, 'chat_bound'),
+    archivedCount: countRepoWorktreeIndexEntities(rows, 'archived'),
     ticketIndexMetricsAvailable,
     openTicketCount: ticketIndexMetricsAvailable
       ? rows.reduce(
@@ -728,6 +733,7 @@ function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source:
       ? `${childWorktrees.length} worktree${childWorktrees.length === 1 ? '' : 's'}`
       : null,
     status: repo.status,
+    archiveState: repo.archiveState ?? 'active',
     branch: repo.defaultBranch,
     path: repo.path,
     activeRuns: repo.activeRuns,
@@ -788,6 +794,7 @@ function worktreeToNavChildRow(
     id: worktree.id,
     label: shortenWorktreeLabel(worktree.name, repoName),
     status: worktree.status,
+    archiveState: worktree.archiveState ?? 'active',
     branch: worktree.branch,
     path: worktree.path,
     activeRuns: worktree.activeRuns,
@@ -833,6 +840,7 @@ function worktreeToIndexRow(worktree: WorktreeSummary, source: RepoWorktreeSourc
     label: worktree.name,
     detail: null,
     status: worktree.status,
+    archiveState: worktree.archiveState ?? 'active',
     branch: worktree.branch,
     path: worktree.path,
     activeRuns: worktree.activeRuns,
@@ -1431,6 +1439,8 @@ function childMatchesNeedle(child: RepoWorktreeChildRow, needle: string): boolea
 }
 
 function rowMatchesFilter(row: RepoWorktreeIndexRow, filter: RepoWorktreeIndexFilter): boolean {
+  if (filter === 'archived') return row.archiveState === 'archived';
+  if (row.archiveState === 'archived') return false;
   if (filter === 'active') return row.activeRuns > 0 || row.status === 'running' || row.signalActive > 0;
   if (filter === 'waiting') return row.status === 'waiting' || row.status === 'blocked' || row.signalWaiting > 0;
   if (filter === 'chat_bound') return row.chatBound;
@@ -1438,6 +1448,8 @@ function rowMatchesFilter(row: RepoWorktreeIndexRow, filter: RepoWorktreeIndexFi
 }
 
 function childMatchesFilter(child: RepoWorktreeChildRow, filter: RepoWorktreeIndexFilter): boolean {
+  if (filter === 'archived') return child.archiveState === 'archived';
+  if (child.archiveState === 'archived') return false;
   if (filter === 'active') return child.activeRuns > 0 || child.status === 'running' || child.signalActive > 0;
   if (filter === 'waiting') return child.status === 'waiting' || child.status === 'blocked' || child.signalWaiting > 0;
   if (filter === 'chat_bound') return child.chatBound;

--- a/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
@@ -6,7 +6,7 @@
   import NewRepoDialog from '$lib/components/NewRepoDialog.svelte';
   import NewWorktreeDialog from '$lib/components/NewWorktreeDialog.svelte';
   import RepoSettingsDialog, { type RepoSettingsTarget } from '$lib/components/RepoSettingsDialog.svelte';
-  import { confirmAndRetireState, confirmAndRetireWorktree, type ActionNotice } from '$lib/actions/repoWorktreeActions';
+  import { archiveWorktree, confirmAndRetireState, confirmAndRetireWorktree, type ActionNotice } from '$lib/actions/repoWorktreeActions';
   import { webApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
   import {
     ensureChatIndexLoaded,
@@ -98,6 +98,12 @@
     if (result.tone === 'success') await loadRepos();
   }
 
+  async function handleArchiveWorktree(target: Parameters<typeof archiveWorktree>[0]): Promise<void> {
+    const result = await archiveWorktree(target);
+    notice = result;
+    if (result.tone === 'success') await loadRepos();
+  }
+
   async function handleRetireState(target: Parameters<typeof confirmAndRetireState>[0]): Promise<void> {
     const result = await confirmAndRetireState(target);
     if (!result) return;
@@ -151,6 +157,7 @@
   {index}
   {sectionIssues}
   onRetry={loadRepos}
+  onArchiveWorktree={handleArchiveWorktree}
   onRetireWorktree={handleRetireWorktree}
   onRetireState={handleRetireState}
   onRepoPin={handleRepoPin}

--- a/tests/surfaces/web/test_hub_repo_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_repo_read_model_routes.py
@@ -79,6 +79,47 @@ def test_repo_worktree_topology_and_runtime_snapshots_are_windowed(hub_env) -> N
     assert len(runtime_payload["runtime"]) == 7
 
 
+def test_archive_worktree_is_non_destructive_and_projects_archive_state(
+    hub_env,
+) -> None:
+    worktree_root = _add_workspace(
+        hub_env.hub_root,
+        repo_id="repo-00--archive-me",
+        kind="worktree",
+        worktree_of=hub_env.repo_id,
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    archive = client.post(
+        "/hub/worktrees/archive",
+        json={"worktreeRepoId": "repo-00--archive-me", "archived": True},
+    )
+    assert archive.status_code == 200
+    assert archive.json()["archive_state"] == "archived"
+    assert worktree_root.exists()
+
+    topology = client.get(
+        "/hub/read-models/repo-worktree/topology",
+        params={"kind": "worktree", "limit": 20},
+    )
+    topology.raise_for_status()
+    worktree = next(
+        item
+        for item in topology.json()["worktrees"]
+        if item["worktreeId"] == "repo-00--archive-me"
+    )
+    assert worktree["archived"] is True
+    assert worktree["archiveState"] == "archived"
+
+    unarchive = client.post(
+        "/hub/worktrees/archive",
+        json={"worktreeRepoId": "repo-00--archive-me", "archived": False},
+    )
+    assert unarchive.status_code == 200
+    assert unarchive.json()["archive_state"] == "active"
+    assert worktree_root.exists()
+
+
 def test_repo_worktree_topology_surfaces_chat_bound_channel_display(
     hub_env,
 ) -> None:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -1279,6 +1279,39 @@ def test_cleanup_all_skips_worktree_when_binding_lookup_raises_runtime_error(
     assert worktree.path.exists()
 
 
+def test_cleanup_all_skips_archived_worktree(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = _default_hub_config()
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id=base.id,
+        branch="feature/archived-cleanup-skip",
+        start_point="HEAD",
+    )
+    supervisor.set_worktree_archived(worktree_repo_id=worktree.id, archived=True)
+
+    preview = supervisor.cleanup_all(dry_run=True)
+    result = supervisor.cleanup_all(dry_run=False)
+
+    assert preview["worktrees"]["retired_count"] == 0
+    assert result["worktrees"]["retired_count"] == 0
+    assert result["message"] == "Nothing to clean up"
+    assert worktree.path.exists()
+    manifest = load_manifest(hub_root / ".codex-autorunner" / "manifest.yml", hub_root)
+    entry = manifest.get(worktree.id)
+    assert entry is not None
+    assert entry.archived is True
+
+
 def test_cleanup_all_repairs_legacy_worktree_entries_before_cleanup(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- persist a non-destructive archived state for worktree manifest entries and expose `/hub/worktrees/archive` for archive/unarchive
- project `archiveState` through repo/worktree read models and frontend summaries
- add Repos index Archive/Unarchive controls and an Archived filter while keeping Retire as the destructive trash action

## Validation
- `.venv/bin/python -m pytest -q tests/surfaces/web/test_hub_repo_read_model_routes.py`
- `pnpm web:lint`
- `pnpm web:test -- repoWorktree.test.ts`
- `pnpm web:test`
- commit hook aggregate validation: guardrails, mypy, full pytest, web build/tests, SPA shell check

Closes #2001