### PR TITLE
[codex] Improve repo and chat detail projections

### DIFF
--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -523,6 +523,9 @@ class HubSupervisor:
     def sync_main(self, repo_id: str) -> RepoSnapshot:
         return self._repo_manager.sync_main(repo_id)
 
+    def sync_worktree(self, worktree_repo_id: str) -> RepoSnapshot:
+        return self._worktree_manager.sync_worktree(worktree_repo_id)
+
     def create_repo(
         self,
         repo_id: str,

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("codex_autorunner.hub_worktree_manager")
 
 _GIT_FETCH_TIMEOUT_SECONDS = 120
+_GIT_PULL_TIMEOUT_SECONDS = 120
 _GIT_WORKTREE_TIMEOUT_SECONDS = 120
 _GIT_PUSH_DELETE_TIMEOUT_SECONDS = 120
 _DOCKER_INSPECT_TIMEOUT_SECONDS = 15
@@ -242,6 +243,77 @@ class WorktreeManager:
             worktree_path, base.worktree_setup_commands, base_repo_id=base_repo_id
         )
         return self._ctx.snapshot_for_repo(repo_id)
+
+    def sync_worktree(self, worktree_repo_id: str) -> RepoSnapshot:
+        self._ctx.invalidate_cache()
+        resolved = self._resolve_worktree_entry(worktree_repo_id)
+        worktree_path = resolved.worktree_path
+        if not worktree_path.exists():
+            raise ValueError(f"Worktree {worktree_repo_id} missing on disk")
+        if not git_available(worktree_path):
+            raise ValueError(f"Worktree {worktree_repo_id} is not a git repository")
+        if not git_is_clean(worktree_path):
+            raise ValueError("Worktree has uncommitted changes; commit or stash first")
+
+        with git_mutation_lock(worktree_path):
+            try:
+                upstream_proc = run_git(
+                    [
+                        "rev-parse",
+                        "--abbrev-ref",
+                        "--symbolic-full-name",
+                        "@{u}",
+                    ],
+                    worktree_path,
+                    check=False,
+                )
+            except GitError as exc:
+                raise ValueError(f"git upstream lookup failed: {exc}") from exc
+            if upstream_proc.returncode != 0:
+                branch = git_branch(worktree_path) or resolved.entry.branch or "current"
+                raise ValueError(
+                    f"Worktree branch {branch} has no upstream; set upstream before syncing"
+                )
+            upstream_ref = (upstream_proc.stdout or "").strip()
+            if not upstream_ref:
+                raise ValueError("Unable to resolve worktree upstream")
+            remote = upstream_ref.split("/", 1)[0] if "/" in upstream_ref else "origin"
+
+            try:
+                fetch_proc = run_git(
+                    ["fetch", "--prune", remote],
+                    worktree_path,
+                    check=False,
+                    timeout_seconds=_GIT_FETCH_TIMEOUT_SECONDS,
+                )
+            except GitError as exc:
+                raise ValueError(f"git fetch failed: {exc}") from exc
+            if fetch_proc.returncode != 0:
+                raise ValueError(f"git fetch failed: {git_failure_detail(fetch_proc)}")
+
+            try:
+                pull_proc = run_git(
+                    ["pull", "--ff-only"],
+                    worktree_path,
+                    check=False,
+                    timeout_seconds=_GIT_PULL_TIMEOUT_SECONDS,
+                )
+            except GitError as exc:
+                raise ValueError(f"git pull failed: {exc}") from exc
+            if pull_proc.returncode != 0:
+                raise ValueError(f"git pull failed: {git_failure_detail(pull_proc)}")
+
+            local_sha = git_head_sha(worktree_path)
+            if not local_sha:
+                raise ValueError("Unable to resolve local HEAD after sync")
+            upstream_sha = resolve_ref_sha(worktree_path, upstream_ref)
+            if local_sha != upstream_sha:
+                raise ValueError(
+                    "Sync worktree did not land on %s: local=%s upstream=%s. "
+                    "Local branch may contain extra commits; resolve divergence first."
+                    % (upstream_ref, local_sha[:12], upstream_sha[:12])
+                )
+        return self._ctx.snapshot_for_repo(worktree_repo_id)
 
     def set_worktree_setup_commands(
         self, repo_id: str, commands: List[str]

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
         HubCreateWorktreeRequest,
         HubRetireWorktreeRequest,
     )
+    from .cache_coordinator import HubCacheCoordinator
     from .mount_manager import HubMountManager
     from .services import HubRepoEnricher
 
@@ -25,11 +26,13 @@ class HubWorktreeService:
         mount_manager: HubMountManager,
         enricher: HubRepoEnricher,
         build_force_attestation_payload: Callable[..., Optional[dict[str, str]]],
+        cache_coordinator: Optional[HubCacheCoordinator] = None,
     ) -> None:
         self._context = context
         self._mount_manager = mount_manager
         self._enricher = enricher
         self._build_force_attestation_payload = build_force_attestation_payload
+        self._cache_coordinator = cache_coordinator
 
     async def create_worktree(
         self,
@@ -85,6 +88,28 @@ class HubWorktreeService:
             request_id=self._get_request_id(),
         )
         return job.to_dict()
+
+    async def sync_worktree(self, worktree_repo_id: str) -> dict[str, Any]:
+        from .....core.logging_utils import safe_log
+
+        safe_log(
+            self._context.logger,
+            logging.INFO,
+            "Hub sync worktree id=%s" % (worktree_repo_id,),
+        )
+        try:
+            snapshot = await asyncio.to_thread(
+                self._context.supervisor.sync_worktree,
+                worktree_repo_id=str(worktree_repo_id),
+            )
+        except (RuntimeError, OSError, ValueError, TypeError, KeyError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if self._cache_coordinator is not None:
+            await self._cache_coordinator.invalidate_caches()
+        else:
+            self._enricher.invalidate_runtime_caches()
+        await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
+        return cast(dict[str, Any], self._enricher.enrich_repo(snapshot))
 
     def _get_request_id(self) -> Optional[str]:
         from .....core.request_context import get_request_id

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -93,7 +93,11 @@ def build_hub_repo_routes(
         }
 
     worktree = HubWorktreeService(
-        context, mount_manager, enricher, _build_force_attestation_payload
+        context,
+        mount_manager,
+        enricher,
+        _build_force_attestation_payload,
+        cache_coordinator=cache,
     )
     destination = HubDestinationService(context, mount_manager)
 
@@ -117,6 +121,10 @@ def build_hub_repo_routes(
     @router.post("/hub/jobs/worktrees/create", response_model=HubJobResponse)
     async def create_worktree_job(payload: HubCreateWorktreeRequest):
         return await worktree.create_worktree_job(payload)
+
+    @router.post("/hub/worktrees/{worktree_repo_id}/sync")
+    async def sync_worktree(worktree_repo_id: str):
+        return await worktree.sync_worktree(worktree_repo_id)
 
     @router.post("/hub/worktrees/retire")
     async def retire_worktree(payload: HubRetireWorktreeRequest):

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -487,6 +487,9 @@ def build_managed_thread_crud_routes(
                         active_work_summary=active_work_by_thread.get(
                             thread.thread_target_id
                         ),
+                        latest_execution=latest_execution_by_thread[
+                            thread.thread_target_id
+                        ],
                     ),
                     service=service,
                     managed_thread_id=thread.thread_target_id,
@@ -505,13 +508,18 @@ def build_managed_thread_crud_routes(
         binding_metadata = _load_chat_binding_metadata_by_thread(
             get_pma_request_context(request).hub_root
         )
+        latest_execution = _resolve_running_or_latest_execution(
+            service, managed_thread_id
+        )
         serialized_thread = _attach_latest_execution_fields(
             _serialize_thread_target(
                 thread,
                 binding_metadata_by_thread=binding_metadata,
+                latest_execution=latest_execution,
             ),
             service=service,
             managed_thread_id=managed_thread_id,
+            execution=latest_execution,
         )
         return {
             "thread": serialized_thread,

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_read_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from fastapi import HTTPException
 
@@ -22,6 +22,10 @@ from .....core.managed_thread_kinds import infer_managed_thread_chat_kind
 from .....core.managed_thread_status import derive_managed_thread_operator_status
 from .....core.orchestration import ActiveWorkSummary, ManagedThreadExecutionStore
 from .....core.orchestration.models import Binding, ThreadTarget
+from .....core.runtime_identity import (
+    RuntimeIdentityContractError,
+    RuntimeIdentityEnvelope,
+)
 from .....core.text_utils import _truncate_text
 from .....tickets.files import ticket_is_done
 from ..chat_status_contract import normalize_chat_effective_status
@@ -409,6 +413,7 @@ def _serialize_thread_target(
     *,
     binding_metadata_by_thread: Optional[dict[str, dict[str, Any]]] = None,
     active_work_summary: Optional[ActiveWorkSummary] = None,
+    latest_execution: Any = None,
 ) -> dict[str, Any]:
     target_runtime_status = normalize_optional_text(thread.status)
     execution_status = (
@@ -425,31 +430,16 @@ def _serialize_thread_target(
         or "idle"
     )
     model = normalize_optional_text(getattr(thread, "model", None))
-    runtime = {
-        "stage": "unknown",
-        "source": "thread_target" if model else "unknown",
-        "runtime_source": "thread_target" if model else "unknown",
-        "agent": normalize_optional_text(thread.agent_id),
-        "profile": normalize_optional_text(thread.agent_profile),
-        "model": model,
-        "provider_id": None,
-        "provider_model_id": None,
-        "reasoning": None,
-        "backend_runtime_id": normalize_optional_text(
+    runtime = _runtime_projection_from_execution(
+        latest_execution,
+        default_agent=normalize_optional_text(thread.agent_id),
+        default_profile=normalize_optional_text(thread.agent_profile),
+        default_model=model,
+        default_backend_runtime_id=normalize_optional_text(
             getattr(thread, "backend_runtime_instance_id", None)
         ),
-        "model_unknown": model is None,
-        "reasoning_unknown": True,
-        "agent_unknown": normalize_optional_text(thread.agent_id) is None,
-        "profile_unknown": normalize_optional_text(thread.agent_profile) is None,
-        "provider_unknown": True,
-        "backend_runtime_unknown": normalize_optional_text(
-            getattr(thread, "backend_runtime_instance_id", None)
-        )
-        is None,
-        "model_source": "thread_target.model" if model else "unknown",
-        "reasoning_source": "unknown",
-    }
+    )
+    model = normalize_optional_text(runtime.get("model"))
     payload = {
         "managed_thread_id": thread.thread_target_id,
         "agent": thread.agent_id,
@@ -523,6 +513,118 @@ def _serialize_thread_target(
         managed_thread_id=thread.thread_target_id,
         binding_metadata_by_thread=binding_metadata_by_thread,
     )
+
+
+def _runtime_projection_from_execution(
+    execution: Any,
+    *,
+    default_agent: Optional[str],
+    default_profile: Optional[str],
+    default_model: Optional[str],
+    default_backend_runtime_id: Optional[str],
+) -> dict[str, Any]:
+    envelope = _runtime_identity_from_execution(execution)
+    for stage_name in ("effective", "launch", "resolved", "requested"):
+        stage = getattr(envelope, stage_name)
+        if stage is None:
+            continue
+        model = normalize_optional_text(stage.canonical_model_label)
+        reasoning = normalize_optional_text(stage.reasoning)
+        agent = (
+            normalize_optional_text(stage.logical_agent)
+            or normalize_optional_text(stage.runtime_agent)
+            or default_agent
+        )
+        profile = normalize_optional_text(stage.profile) or default_profile
+        provider_id = normalize_optional_text(stage.provider_id)
+        provider_model_id = normalize_optional_text(stage.provider_model_id)
+        backend_runtime_id = (
+            normalize_optional_text(stage.backend_runtime_id)
+            or default_backend_runtime_id
+        )
+        source = normalize_optional_text(stage.source) or stage_name
+        runtime_source = (
+            f"{stage_name}:{source}" if source != stage_name else stage_name
+        )
+        return {
+            "stage": stage_name,
+            "source": source,
+            "runtime_source": runtime_source,
+            "agent": agent,
+            "profile": profile,
+            "model": model,
+            "provider_id": provider_id,
+            "provider_model_id": provider_model_id,
+            "reasoning": reasoning,
+            "backend_runtime_id": backend_runtime_id,
+            "model_unknown": model is None,
+            "reasoning_unknown": reasoning is None,
+            "agent_unknown": agent is None,
+            "profile_unknown": profile is None,
+            "provider_unknown": provider_id is None and provider_model_id is None,
+            "backend_runtime_unknown": backend_runtime_id is None,
+            "model_source": (
+                f"{stage_name}.canonical_model_label"
+                if model is not None
+                else "unknown"
+            ),
+            "reasoning_source": (
+                f"{stage_name}.reasoning" if reasoning is not None else "unknown"
+            ),
+        }
+    return {
+        "stage": "unknown",
+        "source": "thread_target" if default_model else "unknown",
+        "runtime_source": "thread_target" if default_model else "unknown",
+        "agent": default_agent,
+        "profile": default_profile,
+        "model": default_model,
+        "provider_id": None,
+        "provider_model_id": None,
+        "reasoning": None,
+        "backend_runtime_id": default_backend_runtime_id,
+        "model_unknown": default_model is None,
+        "reasoning_unknown": True,
+        "agent_unknown": default_agent is None,
+        "profile_unknown": default_profile is None,
+        "provider_unknown": True,
+        "backend_runtime_unknown": default_backend_runtime_id is None,
+        "model_source": "thread_target.model" if default_model else "unknown",
+        "reasoning_source": "unknown",
+    }
+
+
+def _runtime_identity_from_execution(execution: Any) -> RuntimeIdentityEnvelope:
+    raw = _runtime_identity_payload_from_execution(execution)
+    if isinstance(raw, RuntimeIdentityEnvelope):
+        return raw
+    try:
+        if isinstance(raw, str):
+            return RuntimeIdentityEnvelope.from_json(raw)
+        if isinstance(raw, Mapping):
+            return RuntimeIdentityEnvelope.from_mapping(raw)
+    except RuntimeIdentityContractError:
+        _logger.warning("ignoring invalid managed thread runtime identity")
+    return RuntimeIdentityEnvelope()
+
+
+def _runtime_identity_payload_from_execution(execution: Any) -> Any:
+    if execution is None:
+        return None
+    if isinstance(execution, Mapping):
+        metadata = execution.get("metadata")
+        if (
+            isinstance(metadata, Mapping)
+            and metadata.get("runtime_identity") is not None
+        ):
+            return metadata.get("runtime_identity")
+        return execution.get("runtime_identity") or execution.get(
+            "runtime_identity_json"
+        )
+    metadata = getattr(execution, "metadata", None)
+    if isinstance(metadata, Mapping) and metadata.get("runtime_identity") is not None:
+        return metadata.get("runtime_identity")
+    return getattr(execution, "runtime_identity", None)
 
 
 def resolve_managed_thread_list_query(

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -2859,45 +2859,90 @@ textarea:hover {
   color: var(--color-ink-muted);
 }
 
-.tool-call-bar ol {
+/* Compact status glyph used both on the group summary and on each tool row.
+   A spinner while running, a faint check when done (calm — completed work is
+   terminal), a red cross on failure. The state word is kept for screen readers
+   via an adjacent .sr-only span. */
+.tool-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.tool-status-started::before {
+  content: '';
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-border-strong);
+  border-top-color: var(--color-ink-muted);
+  animation: chat-files-spin 0.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-status-started::before { animation: none; }
+}
+
+.tool-status-completed::before {
+  content: '✓';
+  color: var(--color-ink-faint);
+}
+
+.tool-status-failed::before {
+  content: '✕';
+  color: var(--color-danger);
+  font-weight: 700;
+}
+
+.tool-status-unknown::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-ink-faint);
+}
+
+.tool-call-bar .tool-row-list {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   margin: 0;
   padding: var(--space-1) 0 var(--space-2) calc(8px + var(--space-2));
   list-style: none;
 }
 
-.tool-call-bar li {
+.tool-call-bar li.tool-row {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-2);
   min-width: 0;
   color: var(--color-ink-muted);
   font-size: 13px;
 }
 
-.tool-call-bar li span {
-  display: inline-block;
-  margin-right: var(--space-2);
-  color: var(--color-ink-faint);
-  font-size: 11px;
-  font-weight: 760;
-  text-transform: uppercase;
+.tool-call-bar li.tool-row .tool-status {
+  margin-top: 1px;
 }
 
-.tool-call-bar li.failed span {
-  color: var(--color-danger);
+.tool-call-bar .tool-row-body {
+  min-width: 0;
 }
 
-.tool-call-bar li.completed span {
-  color: var(--color-success);
-}
-
-.tool-call-bar li strong {
+.tool-call-bar .tool-row-body > strong {
   color: var(--color-ink);
+  font-weight: 500;
   overflow-wrap: anywhere;
 }
 
-.tool-call-bar li small {
+.tool-call-bar .tool-row-body > small {
   display: block;
   margin-top: 2px;
+  color: var(--color-ink-muted);
   overflow-wrap: anywhere;
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
@@ -385,6 +385,17 @@ describe('API client error handling', () => {
     expect(fetcher).toHaveBeenCalledWith('/hub/repos/demo/pin', expect.objectContaining({ method: 'POST', body: JSON.stringify({ pinned: true }) }));
   });
 
+  it('calls repo and worktree sync endpoints separately', async () => {
+    const fetcher = vi.fn(async () => Response.json({ status: 'ok' })) as unknown as typeof fetch;
+    const client = new WebApiClient(fetcher);
+
+    await client.hub.syncRepoMain('demo');
+    await client.hub.syncWorktree('demo--feature');
+
+    expect(fetcher).toHaveBeenCalledWith('/hub/repos/demo/sync-main', expect.objectContaining({ method: 'POST' }));
+    expect(fetcher).toHaveBeenCalledWith('/hub/worktrees/demo--feature/sync', expect.objectContaining({ method: 'POST' }));
+  });
+
   it('prefixes API requests with the runtime hub base path when configured', async () => {
     const fetcher = vi.fn(async () =>
       Response.json({

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -879,6 +879,10 @@ export class WebApiClient {
       this.requestJson<JsonRecord>(`/hub/repos/${encodeURIComponent(repoId)}/sync-main`, {
         method: 'POST'
       }),
+    syncWorktree: async (worktreeId: string): Promise<ApiResult<JsonRecord>> =>
+      this.requestJson<JsonRecord>(`/hub/worktrees/${encodeURIComponent(worktreeId)}/sync`, {
+        method: 'POST'
+      }),
     setWorktreeSetup: async (repoId: string, commands: string[]): Promise<ApiResult<JsonRecord>> =>
       this.requestJson<JsonRecord>(`/hub/repos/${encodeURIComponent(repoId)}/worktree-setup`, {
         method: 'POST',

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
@@ -5,6 +5,7 @@ import {
   READ_MODEL_CONTRACT_VERSION,
   type ChatIndexRow,
   type ProjectionCursor,
+  type RepoWorktreeDetailSnapshot,
   type RepoWorktreeRuntimeSnapshot,
   type RepoWorktreeTopologySnapshot
 } from '$lib/api/readModelContracts';
@@ -33,8 +34,7 @@ describe('ChatDetailPageController', () => {
       currentRequest: { filter: 'all', limit: 50 },
       ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
     });
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsyncWork();
 
     expect(harness.session.activate).toHaveBeenCalledWith({
       primaryRequest: { filter: 'all', limit: 50 },
@@ -64,8 +64,7 @@ describe('ChatDetailPageController', () => {
       currentRequest: { filter: 'all', limit: 50 },
       ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
     });
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsyncWork();
 
     expect(harness.supportData.at(-1)).toMatchObject({
       agents: [],
@@ -73,6 +72,61 @@ describe('ChatDetailPageController', () => {
       defaultAgent: 'codex'
     });
     expect(createInitialDraft).toHaveBeenCalledOnce();
+  });
+
+  it('loads a route-requested repo scope that is outside the first topology window', async () => {
+    const repoDetail = vi.fn(async (repoId: string) => ok(repoDetailSnapshot(repoId)));
+    const harness = createHarness({
+      supportApi: {
+        ...supportApi(),
+        repoDetail
+      }
+    });
+
+    harness.controller.mount({
+      route: { ...route(), searchParams: new URLSearchParams('new=repo:repo-99&kind=pma') },
+      currentRequest: { filter: 'all', limit: 50 },
+      ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
+    });
+    await flushAsyncWork();
+
+    expect(repoDetail).toHaveBeenCalledWith('repo-99');
+    expect(harness.supportData.at(-1)?.scopeOptions).toContainEqual(
+      expect.objectContaining({
+        id: 'repo:repo-99',
+        kind: 'repo',
+        resourceId: 'repo-99',
+        scopeUrn: 'repo:repo-99'
+      })
+    );
+  });
+
+  it('loads a route-requested worktree scope that is outside the first topology window', async () => {
+    const worktreeDetail = vi.fn(async (worktreeId: string) => ok(worktreeDetailSnapshot(worktreeId, 'repo-parent')));
+    const harness = createHarness({
+      supportApi: {
+        ...supportApi(),
+        worktreeDetail
+      }
+    });
+
+    harness.controller.mount({
+      route: { ...route(), searchParams: new URLSearchParams('new=worktree:wt-99&kind=agent') },
+      currentRequest: { filter: 'all', limit: 50 },
+      ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
+    });
+    await flushAsyncWork();
+
+    expect(worktreeDetail).toHaveBeenCalledWith('wt-99');
+    expect(harness.supportData.at(-1)?.scopeOptions).toContainEqual(
+      expect.objectContaining({
+        id: 'worktree:wt-99',
+        kind: 'worktree',
+        resourceId: 'wt-99',
+        parentRepoId: 'repo-parent',
+        scopeUrn: 'worktree:repo-parent/wt-99'
+      })
+    );
   });
 
   it('activates a route replacement and delegates active transcript runtime to the live projection', () => {
@@ -96,8 +150,7 @@ describe('ChatDetailPageController', () => {
       currentRequest: { filter: 'all', limit: 50 },
       ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
     });
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsyncWork();
     expect(harness.sessionState.activeChatId).toBe('previous-chat');
     harness.liveProjection.activate.mockClear();
 
@@ -245,7 +298,10 @@ function supportApi() {
       window: windowInfo(),
       runtime: [],
       repair: repairPolicy()
-    })
+    }),
+    repoDetail: async (repoId: string): Promise<ApiResult<RepoWorktreeDetailSnapshot>> => ok(repoDetailSnapshot(repoId)),
+    worktreeDetail: async (worktreeId: string): Promise<ApiResult<RepoWorktreeDetailSnapshot>> =>
+      ok(worktreeDetailSnapshot(worktreeId, 'repo-1'))
   };
 }
 
@@ -302,6 +358,63 @@ function repairPolicy() {
   };
 }
 
+function repoDetailSnapshot(repoId: string): RepoWorktreeDetailSnapshot {
+  return detailSnapshot({
+    ownerKind: 'repo',
+    ownerId: repoId,
+    identity: { id: repoId, name: `Repo ${repoId}`, path: `/repos/${repoId}`, kind: 'base', worktree_count: 0 },
+    topology: {}
+  });
+}
+
+function worktreeDetailSnapshot(worktreeId: string, repoId: string | null): RepoWorktreeDetailSnapshot {
+  return detailSnapshot({
+    ownerKind: 'worktree',
+    ownerId: worktreeId,
+    identity: {
+      id: worktreeId,
+      name: `Worktree ${worktreeId}`,
+      path: `/repos/${repoId ?? 'unknown'}/${worktreeId}`,
+      kind: 'worktree',
+      worktree_of: repoId
+    },
+    topology: {}
+  });
+}
+
+function detailSnapshot(input: {
+  ownerKind: 'repo' | 'worktree';
+  ownerId: string;
+  identity: Record<string, unknown>;
+  topology: Record<string, unknown>;
+}): RepoWorktreeDetailSnapshot {
+  return {
+    contractVersion: READ_MODEL_CONTRACT_VERSION,
+    kind: 'repo_worktree.detail.snapshot',
+    cursor: projectionCursor(1),
+    ownerKind: input.ownerKind,
+    ownerId: input.ownerId,
+    identity: input.identity,
+    parentLinks: {},
+    topology: input.topology,
+    runtime: {},
+    ticketQueue: [],
+    runQueue: [],
+    chatQueue: [],
+    contextspaceSummary: [],
+    currentArtifacts: [],
+    ticketWindow: windowInfo(),
+    runWindow: windowInfo(),
+    chatWindow: windowInfo(),
+    artifactWindow: windowInfo(),
+    repair: repairPolicy()
+  };
+}
+
 function ok<T>(data: T): ApiResult<T> {
   return { ok: true, data };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
 }

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.ts
@@ -25,10 +25,12 @@ import {
   type PinnedChatMap
 } from './chatDetailSession';
 import type { ChatSummary, SurfaceArtifact } from '$lib/viewModels/domain';
+import { mapRepoSummary, mapWorktreeSummary } from '$lib/viewModels/domain';
 import {
   buildChatScopeOptions,
   type ChatScopeOption
 } from '$lib/viewModels/chat';
+import type { RepoWorktreeDetailSnapshot } from '$lib/api/readModelContracts';
 
 type ChatIndexSessionState = {
   status: 'idle' | 'loading' | 'connected' | 'interrupted' | 'closed';
@@ -71,6 +73,8 @@ export type ChatDetailPageSupportApi = {
   listAgents: () => Promise<ApiResult<{ agents: JsonRecord[]; defaults: JsonRecord; default: string }>>;
   repoWorktreeTopology: (filter?: 'repo' | 'worktree' | 'all', limit?: number) => Promise<ApiResult<unknown>>;
   repoWorktreeRuntime: (filter?: 'repo' | 'worktree' | 'all', limit?: number) => Promise<ApiResult<unknown>>;
+  repoDetail: (repoId: string) => Promise<ApiResult<RepoWorktreeDetailSnapshot>>;
+  worktreeDetail: (worktreeId: string) => Promise<ApiResult<RepoWorktreeDetailSnapshot>>;
 };
 
 export type ChatDetailPageSupportData = {
@@ -287,15 +291,66 @@ export class ChatDetailPageController {
     if (topologyResult.ok) this.deps.readModelStore.applyRepoWorktreeTopologySnapshot(topologyResult.data as Parameters<ReadModelEntityStore['applyRepoWorktreeTopologySnapshot']>[0]);
     if (runtimeResult.ok) this.deps.readModelStore.applyRepoWorktreeRuntimeSnapshot(runtimeResult.data as Parameters<ReadModelEntityStore['applyRepoWorktreeRuntimeSnapshot']>[0]);
     const scopeState = this.deps.readModelStore.snapshot();
+    const exactRouteScope = await this.loadExactRouteScope(scopeState);
+    const repoSummaries = selectRepoSummaries(scopeState);
+    const worktreeSummaries = selectWorktreeSummaries(scopeState);
+    if (exactRouteScope?.ownerKind === 'repo' && !repoSummaries.some((repo) => repo.id === exactRouteScope.ownerId)) {
+      repoSummaries.push(mapRepoSummary({ ...exactRouteScope.identity, id: exactRouteScope.ownerId }));
+    } else if (
+      exactRouteScope?.ownerKind === 'worktree' &&
+      !worktreeSummaries.some((worktree) => worktree.id === exactRouteScope.ownerId)
+    ) {
+      worktreeSummaries.push(mapWorktreeSummary({ ...exactRouteScope.identity, id: exactRouteScope.ownerId }));
+    }
     this.deps.onSupportDataLoaded({
       agents: agentResult.ok ? agentResult.data.agents : [],
       defaults: agentResult.ok ? agentResult.data.defaults : {},
       defaultAgent: agentResult.ok ? agentResult.data.default : 'codex',
       scopeOptions: buildChatScopeOptions(
-        topologyResult.ok ? selectRepoSummaries(scopeState) : [],
-        topologyResult.ok ? selectWorktreeSummaries(scopeState) : []
+        topologyResult.ok || exactRouteScope ? repoSummaries : [],
+        topologyResult.ok || exactRouteScope ? worktreeSummaries : []
       )
     });
+  }
+
+  private requestedNewScope(): { kind: 'repo' | 'worktree'; id: string } | null {
+    const raw = this.route?.searchParams.get('new')?.trim();
+    if (!raw) return null;
+    let decoded = raw;
+    try {
+      decoded = decodeURIComponent(raw);
+    } catch {
+      decoded = raw;
+    }
+    if (decoded.startsWith('repo:')) {
+      const id = decoded.slice('repo:'.length).trim();
+      return id ? { kind: 'repo', id } : null;
+    }
+    if (decoded.startsWith('worktree:')) {
+      const id = decoded.slice('worktree:'.length).trim();
+      return id ? { kind: 'worktree', id } : null;
+    }
+    return null;
+  }
+
+  private async loadExactRouteScope(
+    scopeState: ReadModelEntityState
+  ): Promise<RepoWorktreeDetailSnapshot | null> {
+    const requested = this.requestedNewScope();
+    if (!requested) return null;
+    const existing =
+      requested.kind === 'repo'
+        ? scopeState.repos[requested.id]
+        : scopeState.worktrees[requested.id];
+    if (existing) return null;
+    const result =
+      requested.kind === 'repo'
+        ? await this.deps.supportApi.repoDetail(requested.id)
+        : await this.deps.supportApi.worktreeDetail(requested.id);
+    if (!result.ok) return null;
+    if (requested.kind === 'repo') this.deps.readModelStore.applyRepoDetailSnapshot(result.data);
+    else this.deps.readModelStore.applyWorktreeDetailSnapshot(result.data);
+    return result.data;
   }
 
   private requestedDetailFromUrl(): string | null {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
@@ -46,6 +46,7 @@ export type ChatDetailDisplayReadModel = {
   canInterruptWithDraft: boolean;
   composerWillQueue: boolean;
   queueDepthForCommands: number;
+  runActive: boolean;
 };
 
 export function visibleChatDetailTranscriptCards(
@@ -106,7 +107,8 @@ export function buildChatDetailDisplayReadModel(
       input.activeChat && input.displayedProgress?.status === 'running' && hasRunnableDraft
     ),
     composerWillQueue,
-    queueDepthForCommands: input.queuedTurns.length || input.displayedProgress?.queueDepth || 0
+    queueDepthForCommands: input.queuedTurns.length || input.displayedProgress?.queueDepth || 0,
+    runActive: input.displayedProgress?.status === 'running' && !input.displayedProgress.terminal
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
@@ -108,8 +108,30 @@ export function buildChatDetailDisplayReadModel(
     ),
     composerWillQueue,
     queueDepthForCommands: input.queuedTurns.length || input.displayedProgress?.queueDepth || 0,
-    runActive: input.displayedProgress?.status === 'running' && !input.displayedProgress.terminal
+    runActive: isRunActiveForToolDisplay(input.displayedProgress, input.activeChat, activeCards)
   };
+}
+
+function isRunActiveForToolDisplay(
+  progress: ChatRunProgress | null,
+  chat: ChatSummary | null,
+  cards: ChatTranscriptCard[]
+): boolean {
+  if (progress?.status === 'running' && !progress.terminal) return true;
+  if (progress?.terminal || progress?.status === 'done' || progress?.status === 'failed') return false;
+  if (!transcriptHasStartedTool(cards)) return false;
+  const status = progress?.status ?? chat?.status;
+  if (status === 'done' || status === 'failed' || status === 'idle') return false;
+  if (status === 'running' || status === 'waiting' || status === 'blocked') return true;
+  return !progress && !chat;
+}
+
+function transcriptHasStartedTool(cards: ChatTranscriptCard[]): boolean {
+  for (const card of cards) {
+    if (card.kind === 'tool_group' && card.tools.some((tool) => tool.state === 'started')) return true;
+    if (card.kind === 'turn_summary' && transcriptHasStartedTool(card.cards)) return true;
+  }
+  return false;
 }
 
 function buildLiveProgressTranscriptCards(

--- a/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.test.ts
@@ -84,10 +84,13 @@ describe('repo worktree detail session', () => {
     const store = new ReadModelEntityStore();
     store.applyWorktreeDetailSnapshot(worktreeDetailSnapshot('wt-1', 'repo-1'));
     const invalidateTags = vi.fn(async () => undefined);
+    const syncRepoMain = vi.fn(async () => ({ ok: true as const }));
+    const syncWorktree = vi.fn(async () => ({ ok: true as const }));
     const session = createSession('worktree', 'wt-1', {
       store,
       invalidateTags,
-      syncRepoMain: vi.fn(async () => ({ ok: true as const })),
+      syncRepoMain,
+      syncWorktree,
       loadWorktreeDetail: vi.fn(async (worktreeId: string) => {
         store.applyWorktreeDetailSnapshot(worktreeDetailSnapshot(worktreeId, 'repo-1'));
         return { status: 'fetched' as const, tags: [`entity:worktree:${worktreeId}`] };
@@ -98,11 +101,14 @@ describe('repo worktree detail session', () => {
     await session.syncRepo();
 
     expect(session.state.backingRepoId).toBe('repo-1');
+    expect(syncRepoMain).not.toHaveBeenCalled();
+    expect(syncWorktree).toHaveBeenCalledWith('wt-1');
     expect(invalidateTags).toHaveBeenCalledWith([
       'entity:repo-worktree:index',
       'entity:repo:repo-1',
       'entity:worktree:wt-1'
     ]);
+    expect(session.state.notice).toEqual({ tone: 'success', message: 'Synced worktree branch with upstream.' });
   });
 
   it('redirects legacy worktree paths when the parent repo can be resolved', async () => {
@@ -213,6 +219,7 @@ function createSession(
       loadRepoDetail: vi.fn(async () => ({ status: 'cold' as const, tags: [] })),
       loadWorktreeDetail: vi.fn(async () => ({ status: 'cold' as const, tags: [] })),
       syncRepoMain: vi.fn(async () => ({ ok: true as const })),
+      syncWorktree: vi.fn(async () => ({ ok: true as const })),
       invalidateTags: vi.fn(async () => undefined),
       retireWorktree: vi.fn(async () => null),
       retireState: vi.fn(async () => null),

--- a/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.ts
@@ -54,6 +54,7 @@ export type RepoWorktreeDetailSessionDependencies = {
   loadRepoDetail?: typeof ensureRepoDetailLoaded;
   loadWorktreeDetail?: typeof ensureWorktreeDetailLoaded;
   syncRepoMain: (repoId: string) => Promise<{ ok: true } | { ok: false; error: ApiError }>;
+  syncWorktree: (worktreeId: string) => Promise<{ ok: true } | { ok: false; error: ApiError }>;
   invalidateTags?: typeof invalidateReadModelTags;
   retireWorktree: (target: RetireWorktreeTarget) => Promise<ActionNotice | null>;
   retireState: (target: RetireStateTarget) => Promise<ActionNotice | null>;
@@ -186,20 +187,32 @@ export class RepoWorktreeDetailSession {
   async syncRepo(): Promise<void> {
     if (this.state.syncRepoBusy) return;
     const repoId = this.state.ownerKind === 'repo' ? this.state.ownerId : this.state.backingRepoId;
-    if (!repoId) {
+    if (this.state.ownerKind === 'worktree' && !repoId) {
       this.state = { ...this.state, notice: { tone: 'danger', message: 'Could not resolve parent repo for sync.' } };
       return;
     }
 
     this.state = { ...this.state, syncRepoBusy: true };
     try {
-      const result = await this.dependencies.syncRepoMain(repoId);
+      const result =
+        this.state.ownerKind === 'repo'
+          ? await this.dependencies.syncRepoMain(this.state.ownerId)
+          : await this.dependencies.syncWorktree(this.state.ownerId);
       if (!result.ok) {
         this.state = { ...this.state, notice: { tone: 'danger', message: result.error.message } };
         return;
       }
-      await this.dependencies.invalidateTags(this.syncInvalidationTags(repoId));
-      this.state = { ...this.state, notice: { tone: 'success', message: 'Synced default branch with origin.' } };
+      await this.dependencies.invalidateTags(this.syncInvalidationTags(repoId ?? this.state.ownerId));
+      this.state = {
+        ...this.state,
+        notice: {
+          tone: 'success',
+          message:
+            this.state.ownerKind === 'repo'
+              ? 'Synced default branch with origin.'
+              : 'Synced worktree branch with upstream.'
+        }
+      };
       await this.load(false);
     } finally {
       this.state = { ...this.state, syncRepoBusy: false };

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -15,11 +15,13 @@
     cards,
     assistantLabel = 'Assistant',
     streamingMessageId = null,
+    runActive = false,
     sharedFiles = []
   }: {
     cards: ChatTranscriptCard[];
     assistantLabel?: string;
     streamingMessageId?: string | null;
+    runActive?: boolean;
     sharedFiles?: ArtifactDelivery[];
   } = $props();
 
@@ -79,11 +81,31 @@
     return trimmed.startsWith('{') || trimmed.startsWith('[');
   }
 
+  // Collapsed disclosure summaries should read as a calm one-line teaser, not a
+  // wall of raw markdown (`**bold**`, backticks, headings). Strip the syntax so
+  // the rendered body — not the summary — carries the formatting.
+  function plainTextPreview(value: string | null | undefined, max = 80): string {
+    if (!value) return '';
+    const stripped = value
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      .replace(/[*_~]{1,3}([^*_~]+)[*_~]{1,3}/g, '$1')
+      .replace(/^#{1,6}\s+/gm, '')
+      .replace(/^\s*[-*+]\s+/gm, '')
+      .replace(/^\s*>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!stripped) return '';
+    return stripped.length > max ? `${stripped.slice(0, max).trimEnd()}…` : stripped;
+  }
+
   function traceSummaryLabel(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): string {
     const detail = card.detail?.split('·', 1)[0]?.trim();
     if (detail && !looksLikeJson(detail)) return detail;
-    const text = card.text.trim().replace(/\s+/g, ' ');
-    if (text) return text.length > 80 ? `${text.slice(0, 80).trimEnd()}…` : text;
+    const text = plainTextPreview(card.text);
+    if (text) return text;
     return traceKindLabel(card);
   }
 
@@ -118,11 +140,8 @@
     }
     const count = card.detail?.split('·', 1)[0]?.trim();
     if (count && !looksLikeJson(count)) return count;
-    const text = card.text?.trim();
-    if (text) {
-      const oneLine = text.replace(/\s+/g, ' ');
-      return oneLine.length > 80 ? `${oneLine.slice(0, 80).trimEnd()}…` : oneLine;
-    }
+    const text = plainTextPreview(card.text);
+    if (text) return text;
     return 'Reasoning trace';
   }
 
@@ -141,11 +160,57 @@
     userToggled[cardId] = el.open;
   }
 
-  function toolHeadlineText(tool: ChatToolCallCard | undefined): string {
+  function cleanToolLabel(value: string | null | undefined): string {
+    if (!value) return '';
+    // Backend labels frequently arrive as "tool: <command>"; the "tool:" prefix
+    // is noise once the row is already visually marked as a tool call.
+    return value.replace(/^\s*tool:\s*/i, '').trim();
+  }
+
+  function toolPrimaryLabel(tool: ChatToolCallCard | undefined): string {
     if (!tool) return 'Tool call';
-    const summary = tool.summary?.trim();
-    if (summary) return summary;
-    return tool.title;
+    const title = cleanToolLabel(tool.title);
+    if (title) return title;
+    return cleanToolLabel(tool.summary) || 'Tool call';
+  }
+
+  // Only surface the summary line when it carries information beyond the title;
+  // otherwise it is just "tool: <title>" duplicated under the title.
+  function toolSecondaryLabel(tool: ChatToolCallCard): string | null {
+    const summary = cleanToolLabel(tool.summary);
+    if (summary && summary !== toolPrimaryLabel(tool)) return summary;
+    return null;
+  }
+
+  function toolGroupHeadline(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>): string {
+    const tools = card.tools;
+    if (!tools.length) return 'Tool call';
+    const label = toolPrimaryLabel(tools[0]);
+    if (tools.length === 1) return label;
+    if (tools.every((tool) => toolPrimaryLabel(tool) === label)) return `${label} ×${tools.length}`;
+    return `${label} · +${tools.length - 1} more`;
+  }
+
+  // A tool stuck in `started` after the run has ended never received its
+  // terminal event; show it as indeterminate rather than spinning forever.
+  function effectiveToolState(state: ChatToolCallCard['state']): ChatToolCallCard['state'] {
+    if (state === 'started' && !runActive) return 'unknown';
+    return state;
+  }
+
+  function toolGroupState(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>): ChatToolCallCard['state'] {
+    const states = card.tools.map((tool) => effectiveToolState(tool.state));
+    if (states.some((state) => state === 'started')) return 'started';
+    if (states.some((state) => state === 'failed')) return 'failed';
+    if (states.length > 0 && states.every((state) => state === 'completed')) return 'completed';
+    return 'unknown';
+  }
+
+  function toolStateLabel(state: ChatToolCallCard['state']): string {
+    if (state === 'started') return 'Running';
+    if (state === 'completed') return 'Completed';
+    if (state === 'failed') return 'Failed';
+    return 'Finished';
   }
 
   function visibleToolGroupItems(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>): ChatToolCallCard[] {
@@ -203,6 +268,43 @@
 
   const displayCards = $derived(displayCardsFor(cards));
 </script>
+
+{#snippet toolGroupCard(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>, nested: boolean)}
+  {@const groupState = toolGroupState(card)}
+  <details
+    class={`tool-call-bar tool-group${nested ? ' nested-trace' : ''}`}
+    open={toolGroupOpen(card)}
+    ontoggle={(e) => handleToolToggle(card.id, e)}
+  >
+    <summary>
+      <span class={`tool-status tool-status-${groupState}`} aria-hidden="true"></span>
+      <strong>{toolGroupHeadline(card)}</strong>
+      <span class="sr-only">{toolStateLabel(groupState)}</span>
+    </summary>
+    <ol class="tool-row-list">
+      {#each visibleToolGroupItems(card) as tool (tool.id)}
+        {@const secondary = toolSecondaryLabel(tool)}
+        {@const rowState = effectiveToolState(tool.state)}
+        <li class={`tool-row ${rowState}`}>
+          <span class={`tool-status tool-status-${rowState}`} aria-hidden="true"></span>
+          <span class="tool-row-body">
+            <strong>{toolPrimaryLabel(tool)}</strong>
+            {#if secondary}
+              <small>{secondary}</small>
+            {/if}
+            {#if tool.detail}
+              <pre class="timeline-detail">{tool.detail}</pre>
+            {/if}
+          </span>
+          <span class="sr-only">{toolStateLabel(rowState)}</span>
+        </li>
+      {/each}
+    </ol>
+    {#if omittedToolGroupItemCount(card) > 0}
+      <p class="trace-omitted">{omittedToolGroupItemCount(card)} additional tool calls omitted</p>
+    {/if}
+  </details>
+{/snippet}
 
 {#each displayCards as card (card.id)}
   {#if card.kind === 'message'}
@@ -315,32 +417,7 @@
       </details>
     {/if}
   {:else if card.kind === 'tool_group'}
-    {@const headlineTool = card.tools[0]}
-    {@const isOpen = toolGroupOpen(card)}
-    <details class="tool-call-bar" open={isOpen} ontoggle={(e) => handleToolToggle(card.id, e)}>
-      <summary>
-        <strong>
-          {toolHeadlineText(headlineTool)}{card.tools.length > 1 ? ` · +${card.tools.length - 1} more` : ''}
-        </strong>
-      </summary>
-      <ol>
-        {#each visibleToolGroupItems(card) as tool (tool.id)}
-          <li class={tool.state}>
-            <span>{tool.state}</span>
-            <strong>{tool.title}</strong>
-            {#if tool.summary && tool.summary !== tool.title}
-              <small>{tool.summary}</small>
-            {/if}
-            {#if tool.detail}
-              <pre class="timeline-detail">{tool.detail}</pre>
-            {/if}
-          </li>
-        {/each}
-      </ol>
-      {#if omittedToolGroupItemCount(card) > 0}
-        <p class="trace-omitted">{omittedToolGroupItemCount(card)} additional tool calls omitted</p>
-      {/if}
-    </details>
+    {@render toolGroupCard(card, false)}
   {:else if card.kind === 'turn_summary'}
     <details class="tool-call-bar turn-summary-card">
       <summary>
@@ -378,32 +455,7 @@
               </details>
             {/if}
           {:else if traceCard.kind === 'tool_group'}
-            {@const traceHeadlineTool = traceCard.tools[0]}
-            {@const isNestedOpen = toolGroupOpen(traceCard)}
-            <details class="tool-call-bar nested-trace" open={isNestedOpen} ontoggle={(e) => handleToolToggle(traceCard.id, e)}>
-              <summary>
-                <strong>
-                  {toolHeadlineText(traceHeadlineTool)}{traceCard.tools.length > 1 ? ` · +${traceCard.tools.length - 1} more` : ''}
-                </strong>
-              </summary>
-              <ol>
-                {#each visibleToolGroupItems(traceCard) as tool (tool.id)}
-                  <li class={tool.state}>
-                    <span>{tool.state}</span>
-                    <strong>{tool.title}</strong>
-                    {#if tool.summary && tool.summary !== tool.title}
-                      <small>{tool.summary}</small>
-                    {/if}
-                    {#if tool.detail}
-                      <pre class="timeline-detail">{tool.detail}</pre>
-                    {/if}
-                  </li>
-                {/each}
-              </ol>
-              {#if omittedToolGroupItemCount(traceCard) > 0}
-                <p class="trace-omitted">{omittedToolGroupItemCount(traceCard)} additional tool calls omitted</p>
-              {/if}
-            </details>
+            {@render toolGroupCard(traceCard, true)}
           {:else if traceCard.kind === 'approval'}
             <details class="approval-card nested-trace">
               <summary>

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -442,6 +442,68 @@ describe('ChatTranscriptCards', () => {
     expect(body).toContain('Reasoning through the request');
   });
 
+  function toolGroupCard(states: Array<'started' | 'completed' | 'failed'>): ChatTranscriptCard {
+    return {
+      kind: 'tool_group',
+      id: 'tools-1',
+      turnId: 'turn-1',
+      orderKey: '00000003|tools',
+      timestamp: '2026-05-10T00:00:00.000Z',
+      tools: states.map((state, index) => ({
+        id: `tool-${index}`,
+        title: 'bash',
+        summary: 'tool: bash',
+        detail: null,
+        state,
+        eventIds: []
+      }))
+    };
+  }
+
+  it('strips the redundant "tool:" prefix and same-tool count in the headline', () => {
+    const { body } = render(ChatTranscriptCards, {
+      props: { cards: [toolGroupCard(['completed', 'completed', 'completed'])] }
+    });
+    expect(body).toContain('bash ×3');
+    expect(body).not.toContain('tool: bash');
+    expect(body).not.toContain('· +2 more');
+  });
+
+  it('stops spinning tool calls once the run is no longer active', () => {
+    const { body } = render(ChatTranscriptCards, {
+      props: { cards: [toolGroupCard(['completed', 'started'])], runActive: false }
+    });
+    // The stale "started" tool downgrades to an indeterminate marker, not a spinner.
+    expect(body).not.toContain('tool-status-started');
+    expect(body).toContain('tool-status-unknown');
+  });
+
+  it('keeps the spinner while the run is genuinely active', () => {
+    const { body } = render(ChatTranscriptCards, {
+      props: { cards: [toolGroupCard(['completed', 'started'])], runActive: true }
+    });
+    expect(body).toContain('tool-status-started');
+  });
+
+  it('renders thinking summaries as plain text, not raw markdown', () => {
+    const { body } = render(ChatTranscriptCards, {
+      props: {
+        cards: [
+          intermediateCard(
+            'thinking-md',
+            'thinking',
+            'No. This branch has **zero commits** ahead of `origin/main`.'
+          )
+        ]
+      }
+    });
+    expect(body).toContain('zero commits ahead of origin/main');
+    // Summary teaser must not leak markdown syntax.
+    const summary = body.slice(0, body.indexOf('thinking-trace-body'));
+    expect(summary).not.toContain('**zero commits**');
+    expect(summary).not.toContain('`origin/main`');
+  });
+
   it('renders assistant shared delivery files as downloadable pills', () => {
     const { body } = render(ChatTranscriptCards, {
       props: {

--- a/src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte
@@ -3,12 +3,22 @@
 
   let {
     title,
+    titleTail = null,
+    titleFull = null,
     subtitle = null,
     stats = undefined,
     actions = undefined,
     meta = undefined
   }: {
     title: string;
+    /**
+     * When set, the title is middle-truncated: `title` is the head (ellipsized
+     * on overflow) and `titleTail` is pinned to the end so a trailing
+     * disambiguator (e.g. a worktree hash) always stays visible.
+     */
+    titleTail?: string | null;
+    /** Full, untruncated title for the hover/`title` tooltip. */
+    titleFull?: string | null;
     subtitle?: string | null;
     stats?: Snippet | undefined;
     actions?: Snippet | undefined;
@@ -18,7 +28,13 @@
 
 <header class="page-hero">
   <div class="page-hero-copy">
-    <h1>{title}</h1>
+    {#if titleTail}
+      <h1 class="is-truncated" title={titleFull ?? `${title}${titleTail}`}>
+        <span class="page-hero-title-head">{title}</span><span class="page-hero-title-tail">{titleTail}</span>
+      </h1>
+    {:else}
+      <h1>{title}</h1>
+    {/if}
     {#if subtitle}
       <p class="page-hero-sub">{subtitle}</p>
     {/if}
@@ -61,6 +77,26 @@
     font-weight: 650;
     letter-spacing: -0.022em;
     line-height: 1.18;
+  }
+
+  /* Middle-truncated title: head flexes and ellipsizes, tail stays pinned so
+     the trailing disambiguator (worktree hash) never gets clipped. */
+  .page-hero h1.is-truncated {
+    display: flex;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .page-hero-title-head {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .page-hero-title-tail {
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .page-hero-sub {

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeDetail.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeDetail.svelte
@@ -45,12 +45,57 @@
     return detail.title;
   });
 
-  const detailSubtitle = $derived.by(() => {
-    const parts: string[] = [];
-    if (detail.branch) parts.push(detail.branch);
-    if (detail.path) parts.push(detail.path);
-    return parts.join(' · ');
+  /**
+   * Middle-truncation split for the worktree title. The leading category
+   * (`automation-…`) and the trailing hash (`…-1f96854c-c39`) are the
+   * disambiguators, so we pin a short tail and let the middle ellipsize.
+   * Snaps the cut to a `-` boundary near the end to avoid slicing mid-token.
+   */
+  const titleSplit = $derived.by(() => {
+    const full = shortDetailTitle;
+    if (detail.kind !== 'worktree' || full.length <= 28) {
+      return { head: full, tail: '' };
+    }
+    const minTail = 8;
+    const maxTail = 18;
+    let cut = -1;
+    for (let i = full.length - minTail; i >= full.length - maxTail && i > 0; i--) {
+      if (full[i] === '-') {
+        cut = i;
+        break;
+      }
+    }
+    if (cut === -1) cut = full.length - maxTail;
+    return { head: full.slice(0, cut), tail: full.slice(cut) };
   });
+
+  /**
+   * Branch chip split on `/` so the namespace prefix and the trailing segment
+   * stay visible (`automation/…/1f96854c-c39`) while the long middle ellipsizes.
+   */
+  const branchSplit = $derived.by(() => {
+    const branch = detail.branch ?? '';
+    const lastSlash = branch.lastIndexOf('/');
+    if (lastSlash <= 0) return { head: branch, tail: '' };
+    return { head: branch.slice(0, lastSlash), tail: branch.slice(lastSlash) };
+  });
+
+  let pathCopied = $state(false);
+  let pathCopyTimer: ReturnType<typeof setTimeout> | undefined;
+
+  async function handleCopyPath(): Promise<void> {
+    if (!detail.path) return;
+    try {
+      await navigator.clipboard.writeText(detail.path);
+      pathCopied = true;
+      clearTimeout(pathCopyTimer);
+      pathCopyTimer = setTimeout(() => {
+        pathCopied = false;
+      }, 1600);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  }
 
   const contextspaceHasContent = $derived(detail.contextspace.some((doc) => doc.status === 'present'));
 
@@ -116,7 +161,39 @@
         </div>
       </section>
     {:else}
-    <PageHero title={shortDetailTitle} subtitle={detailSubtitle}>
+    <PageHero
+      title={titleSplit.head}
+      titleTail={titleSplit.tail || null}
+      titleFull={shortDetailTitle}
+    >
+      {#snippet meta()}
+        {#if detail.branch}
+          <span class="detail-branch" title={detail.branch}>
+            <span class="branch-glyph" aria-hidden="true">⎇</span>
+            {#if branchSplit.tail}
+              <span class="detail-branch-head">{branchSplit.head}</span><span class="detail-branch-tail">{branchSplit.tail}</span>
+            {:else}
+              <span class="detail-branch-head">{branchSplit.head}</span>
+            {/if}
+          </span>
+        {/if}
+        {#if detail.path}
+          <button
+            type="button"
+            class="detail-copy-path"
+            class:is-copied={pathCopied}
+            onclick={handleCopyPath}
+            title={detail.path}
+            aria-label={`Copy path: ${detail.path}`}
+          >
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="9" y="9" width="11" height="11" rx="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <span>{pathCopied ? 'Copied' : 'Copy path'}</span>
+          </button>
+        {/if}
+      {/snippet}
       {#snippet actions()}
         <a class="ghost-button is-primary" href={href(detail.chatHref)} data-sveltekit-preload-data="tap">+ New chat</a>
         <a class="ghost-button" href={href(detail.newTicketHref)} data-sveltekit-preload-data="tap">+ New ticket</a>
@@ -428,7 +505,9 @@
                 disabled={syncRepoBusy || git.dirty}
                 title={git.dirty
                   ? 'Commit or stash changes before syncing'
-                  : 'Fetch and fast-forward the default branch from origin'}
+                  : detail.kind === 'repo'
+                    ? 'Fetch and fast-forward the default branch from origin'
+                    : 'Fetch and fast-forward this worktree branch from its upstream'}
                 aria-busy={syncRepoBusy ? 'true' : undefined}
                 onclick={(event) => {
                   event.preventDefault();

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.css
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.css
@@ -1634,3 +1634,60 @@
     color: var(--color-ink-soft);
     transform: translateX(2px);
   }
+
+  /* Detail hero meta: a single quiet branch chip + copy-path button. Replaces
+     the old `branch · path` subtitle, which stacked the same slug three ways. */
+  .detail-branch {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    min-width: 0;
+    max-width: min(48ch, 100%);
+    font-family: var(--font-mono);
+    color: var(--color-ink-soft);
+  }
+
+  .detail-branch .branch-glyph {
+    flex-shrink: 0;
+  }
+
+  .detail-branch-head {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .detail-branch-tail {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .detail-copy-path {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 2px var(--space-2);
+    border: 1px solid transparent;
+    border-radius: var(--radius-2);
+    background: transparent;
+    color: var(--color-ink-muted);
+    font-size: var(--font-size-0);
+    cursor: pointer;
+    transition: background var(--transition-fast), color var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+
+  .detail-copy-path:hover {
+    background: var(--color-surface-muted);
+    border-color: var(--color-border-subtle);
+    color: var(--color-ink-soft);
+  }
+
+  .detail-copy-path.is-copied {
+    color: var(--color-success);
+  }
+
+  .detail-copy-path svg {
+    flex-shrink: 0;
+  }

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -374,7 +374,9 @@
       listFiles: () => webApi.filebox.listFiles({ kind: 'hub' }),
       listAgents: webApi.pma.listAgents,
       repoWorktreeTopology: webApi.readModels.repoWorktreeTopology,
-      repoWorktreeRuntime: webApi.readModels.repoWorktreeRuntime
+      repoWorktreeRuntime: webApi.readModels.repoWorktreeRuntime,
+      repoDetail: webApi.readModels.repoDetail,
+      worktreeDetail: webApi.readModels.worktreeDetail
     },
     readSessionState: readChatDetailSessionState,
     writeSessionState: writeChatDetailSessionState,
@@ -757,13 +759,13 @@
       setComposerAttachments(value, chatId ?? activeChatId);
     },
     getComposerEditVersion: () => composerEditVersion,
-    getSelectedScope: () => selectedScope,
-    getSelectedScopeSource: () => selectedScopeSource,
+    getSelectedScope: () => scopeOptionForChat(localDraftChat) ?? selectedScope,
+    getSelectedScopeSource: () => scopeSourceForChat(localDraftChat) ?? selectedScopeSource,
     getSelectedAgent: () => selectedAgent,
     getSelectedProfile: () => selectedProfile,
     getSelectedModel: () => selectedModel,
     getSelectedReasoning: () => selectedReasoning,
-    getNewChatKind: () => newChatKind,
+    getNewChatKind: () => draftKindForChat(localDraftChat) ?? newChatKind,
     canStartCodingAgentChat: () => canStartCodingAgentChat,
     newChatDisplayName,
     readSessionState: readChatDetailSessionState,
@@ -780,10 +782,14 @@
     confirm: confirmDialog
   });
   const streamingMessageId = $derived(chatDetailDisplay.streamingMessageId);
+  const runActive = $derived(chatDetailDisplay.runActive);
   const transcriptListItems = $derived<ChatTranscriptListItem[]>(chatDetailDisplay.transcriptListItems);
   const srStatusAnnouncement = $derived(chatDetailDisplay.statusAnnouncement);
   const srAlertAnnouncement = $derived(chatDetailDisplay.alertAnnouncement);
-  const activeChatBadges = $derived(chatBadgeViews(activeChat, { showManagerAgent: false }));
+  // Keep the detail header aligned with sidebar row badges. PMA is a manager-agent
+  // classification here, not the generic PMA transport facet, so it should remain
+  // visible alongside Coding agent when the backend projects both.
+  const activeChatBadges = $derived(chatBadgeViews(activeChat));
   const activeSharedFileCount = $derived(activeSurfaceDeliveries.length);
   const activeRepoIngress = $derived(repoIngressForChat(activeChat));
   const createChatLabel = $derived(creating ? 'Creating...' : '+ New');
@@ -1116,6 +1122,20 @@
   });
 
   $effect(() => {
+    const chat = localDraftChat;
+    if (!chat) return;
+    const scopeId = scopeIdForChat(chat);
+    if (!scopeId || !scopeOptions.some((scope) => scope.id === scopeId)) return;
+    selectedScopeId = scopeId;
+    const source = stringField(chat.raw, 'scope_source');
+    selectedScopeSource =
+      source === 'route_explicit' || source === 'picker_explicit' || source === 'inherited_continuation'
+        ? source
+        : scopeId === 'local' ? 'default_hub' : selectedScopeSource;
+    scopeLocked = selectedScopeSource === 'route_explicit' && scopeId !== 'local';
+  });
+
+  $effect(() => {
     const chat = activeChat;
     if (!chat) {
       artifactDeliveries = [];
@@ -1240,6 +1260,7 @@
     if (!raw) return;
     let decoded = raw;
     let appliedScope = false;
+    let routeScopeId: string | null = null;
     try {
       decoded = decodeURIComponent(raw);
     } catch {
@@ -1250,6 +1271,7 @@
       if (scopeOptions.some((scope) => scope.id === sid)) {
         selectedScopeId = sid;
         selectedScopeSource = 'route_explicit';
+        routeScopeId = sid;
         appliedScope = true;
       }
     } else if (decoded.startsWith('worktree:')) {
@@ -1257,15 +1279,18 @@
       if (scopeOptions.some((scope) => scope.id === sid)) {
         selectedScopeId = sid;
         selectedScopeSource = 'route_explicit';
+        routeScopeId = sid;
         appliedScope = true;
       }
     } else if (decoded === 'local' || decoded === 'hub') {
       selectedScopeId = 'local';
       selectedScopeSource = 'route_explicit';
+      routeScopeId = 'local';
       appliedScope = true;
     }
     const requestedKind = page.url.searchParams.get('kind');
     newChatKind = requestedKind === 'agent' && selectedScopeId !== 'local' ? 'agent' : 'pma';
+    const routeKind = newChatKind;
     // Any non-local `?new=` deep-link is the caller saying "this chat belongs to
     // that scope" — pin the scope picker so the user can't accidentally rescope
     // a chat they entered from a repo/worktree page.
@@ -1278,7 +1303,13 @@
       if (appliedScope) {
         pendingInitialDraftCreate = false;
         persistCurrentNewChatPreference();
-        void createChat({ preserveSelectedScope: true });
+        void createChat({
+          preserveSelectedScope: true,
+          preserveSelectedKind: true,
+          scopeId: routeScopeId,
+          scopeSource: 'route_explicit',
+          kind: routeKind
+        });
       }
     });
   }
@@ -1794,16 +1825,38 @@
     });
   }
 
+  function scopeOptionForScopeId(scopeId: string | null | undefined): ChatScopeOption | null {
+    if (!scopeId) return null;
+    return scopeOptions.find((scope) => scope.id === scopeId) ?? null;
+  }
+
+  function scopeSourceForChat(chat: ChatSummary | null): ChatScopeSource | null {
+    const source = stringField(chat?.raw ?? null, 'scope_source');
+    return source === 'route_explicit' || source === 'picker_explicit' || source === 'inherited_continuation'
+      ? source
+      : null;
+  }
+
+  function draftKindForChat(chat: ChatSummary | null): 'pma' | 'agent' | null {
+    if (!chat || chat.lifecycleStatus !== 'draft') return null;
+    return chatKind(chat) === 'coding_agent' ? 'agent' : 'pma';
+  }
+
   function newChatDisplayName(): string {
     return newChatKind === 'agent' && canStartCodingAgentChat
       ? 'New coding agent chat'
       : 'New chat';
   }
 
-  function newDraftChatSummary(): ChatSummary {
+  function newDraftChatSummary(options: {
+    scope?: ChatScopeOption;
+    scopeSource?: ChatScopeSource;
+    kind?: 'pma' | 'agent';
+  } = {}): ChatSummary {
     const now = new Date().toISOString();
-    const scope = selectedScope;
-    const chatKind = newChatKind === 'agent' && canStartCodingAgentChat ? 'coding_agent' : 'pma';
+    const scope = options.scope ?? selectedScope;
+    const kind = options.kind ?? newChatKind;
+    const chatKind = kind === 'agent' && scope.kind !== 'local' ? 'coding_agent' : 'pma';
     return {
       id: `pma:${crypto.randomUUID()}`,
       title: newChatDisplayName(),
@@ -1823,7 +1876,7 @@
         draft: true,
         origin: 'web',
         scope_urn: scope.scopeUrn,
-        scope_source: selectedScopeSource,
+        scope_source: options.scopeSource ?? selectedScopeSource,
         chat_kind: chatKind
       }
     };
@@ -1841,6 +1894,10 @@
     if (chat.worktreeId) return `worktree:${chat.worktreeId}`;
     if (chat.repoId) return `repo:${chat.repoId}`;
     return 'local';
+  }
+
+  function scopeOptionForChat(chat: ChatSummary | null): ChatScopeOption | null {
+    return scopeOptionForScopeId(scopeIdForChat(chat));
   }
 
   function repoIngressForChat(chat: ChatSummary | null): { href: string; label: string; detail: string } | null {
@@ -1898,11 +1955,17 @@
     followBottom = atBottom;
   }
 
-  async function createChat(options: { preserveSelectedScope?: boolean; preserveSelectedKind?: boolean } = {}): Promise<void> {
+  async function createChat(options: {
+    preserveSelectedScope?: boolean;
+    preserveSelectedKind?: boolean;
+    scopeId?: string | null;
+    scopeSource?: ChatScopeSource;
+    kind?: 'pma' | 'agent';
+  } = {}): Promise<void> {
     creating = true;
     composeError = null;
     try {
-      const requestedKind = newChatKind;
+      const requestedKind = options.kind ?? newChatKind;
       if (!options.preserveSelectedScope) {
         const applied = applyLastNewChatPreference();
         if (!applied) {
@@ -1912,12 +1975,21 @@
         }
         scopeLocked = false;
       }
+      const explicitScope = scopeOptionForScopeId(options.scopeId);
+      if (explicitScope) {
+        selectedScopeId = explicitScope.id;
+        selectedScopeSource = options.scopeSource ?? (explicitScope.kind === 'local' ? 'default_hub' : 'picker_explicit');
+      }
       if (options.preserveSelectedKind) {
         newChatKind = requestedKind;
         if (newChatKind === 'agent') ensureCodingAgentScope();
       }
       persistCurrentNewChatPreference();
-      const draftChat = newDraftChatSummary();
+      const draftChat = newDraftChatSummary({
+        scope: explicitScope ?? selectedScope,
+        scopeSource: options.scopeSource ?? selectedScopeSource,
+        kind: newChatKind
+      });
       // Persist the draft shell so the new chat survives navigation and reload,
       // then make it the active chat. The shell carries no managed thread, so
       // the live projection will not fetch it.
@@ -2943,6 +3015,7 @@
                 cards={[item.card]}
                 assistantLabel={chatAgentDisplayLabel}
                 {streamingMessageId}
+                {runActive}
               />
             {:else if item.kind === 'shared-files'}
               <ChatTranscriptCards

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -53,6 +53,45 @@ describe('/chats page', () => {
     expect(slashCommandBody).toContain("await createChat({ preserveSelectedKind: true });");
   });
 
+  it('keeps the global picker scope synced to the active unsent draft scope', () => {
+    const source = chatDetailPageSource();
+    const draftScopeSyncBody = source.match(
+      /\$effect\(\(\) => \{\n    const chat = localDraftChat;[\s\S]*?\n  \}\);/
+    )?.[0];
+
+    expect(draftScopeSyncBody).toBeTruthy();
+    expect(draftScopeSyncBody).toContain('const scopeId = scopeIdForChat(chat);');
+    expect(draftScopeSyncBody).toContain('selectedScopeId = scopeId;');
+    expect(draftScopeSyncBody).toContain("selectedScopeSource === 'route_explicit'");
+  });
+
+  it('sends unsent drafts using the draft-owned scope when present', () => {
+    const source = chatDetailPageSource();
+    const sendControllerDeps = source.match(
+      /const chatSendController = createChatSendController\(\{[\s\S]*?\n  \}\);/
+    )?.[0];
+
+    expect(sendControllerDeps).toBeTruthy();
+    expect(sendControllerDeps).toContain('getSelectedScope: () => scopeOptionForChat(localDraftChat) ?? selectedScope');
+    expect(sendControllerDeps).toContain('getSelectedScopeSource: () => scopeSourceForChat(localDraftChat) ?? selectedScopeSource');
+    expect(sendControllerDeps).toContain('getNewChatKind: () => draftKindForChat(localDraftChat) ?? newChatKind');
+  });
+
+  it('creates route-scoped drafts from the captured new-chat scope instead of ambient picker state', () => {
+    const source = chatDetailPageSource();
+    const routeNewChatBody = source.match(
+      /function applyNewChatQueryParam[\s\S]*?\n  function applyLastNewChatPreference/
+    )?.[0];
+
+    expect(routeNewChatBody).toBeTruthy();
+    expect(routeNewChatBody).toContain('let routeScopeId: string | null = null;');
+    expect(routeNewChatBody).toContain('routeScopeId = sid;');
+    expect(routeNewChatBody).toContain('const routeKind = newChatKind;');
+    expect(routeNewChatBody).toContain('scopeId: routeScopeId');
+    expect(routeNewChatBody).toContain("scopeSource: 'route_explicit'");
+    expect(routeNewChatBody).toContain('kind: routeKind');
+  });
+
   it('delegates terminal snapshot queue reconciliation to the live projection service', () => {
     const pageSource = chatDetailPageSource();
     const serviceSource = readFileSync(
@@ -380,15 +419,48 @@ describe('/chats page', () => {
     expect(pageSource).toContain('contextualFacetCounts.transport');
   });
 
-  it('renders the agent-kind badge (PMA or Coding agent) in the active header', () => {
+  it('renders the full agent-kind badge set in the active header', () => {
     const pageSource = chatDetailPageSource();
     const subtitleBody = pageSource.match(
       /<p class="chat-header-subtitle">[\s\S]*?<\/p>/
     )?.[0];
 
     expect(subtitleBody).toBeTruthy();
-    expect(pageSource).toContain('chatBadgeViews(activeChat, { showManagerAgent: false })');
+    expect(pageSource).toContain('chatBadgeViews(activeChat)');
+    expect(pageSource).not.toContain('chatBadgeViews(activeChat, { showManagerAgent: false })');
     expect(subtitleBody).toContain('{#each activeChatBadges as badge}');
+
+    readModelEntityStore.applyChatIndexSnapshot({
+      cursor: projectionCursor(),
+      rows: [
+        {
+          ...chatIndexRow(),
+          chatId: 'pma-coding-agent',
+          title: 'PMA managed coding agent chat',
+          chatKind: 'coding_agent',
+          facets: {
+            category: 'regular',
+            turnKinds: ['message'],
+            originKinds: ['surface'],
+            transports: ['pma'],
+            scopeKind: 'repo',
+            scopeId: 'repo-1',
+            agentKind: 'pma'
+          }
+        }
+      ],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 1, unread: 0, archived: 0 }
+    });
+    readModelEntityStore.setActiveChatId('pma-coding-agent');
+
+    const { body } = render(Page);
+    const renderedSubtitle = body.match(
+      /<p class="chat-header-subtitle">[\s\S]*?<\/p>/
+    )?.[0];
+
+    expect(renderedSubtitle).toContain('PMA');
+    expect(renderedSubtitle).toContain('Coding agent');
   });
 
   it('renders cached chat rows instead of the skeleton while the index cursor is still missing', () => {

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.svelte
@@ -18,6 +18,7 @@
     loaderResult: untrack(() => data.result),
     dependencies: {
       syncRepoMain: webApi.hub.syncRepoMain,
+      syncWorktree: webApi.hub.syncWorktree,
       retireWorktree: confirmAndRetireWorktree,
       retireState: confirmAndRetireState
     }

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.svelte
@@ -20,6 +20,7 @@
     loaderResult: untrack(() => data.result),
     dependencies: {
       syncRepoMain: webApi.hub.syncRepoMain,
+      syncWorktree: webApi.hub.syncWorktree,
       retireWorktree: confirmAndRetireWorktree,
       retireState: confirmAndRetireState,
       currentPath: () => stripRuntimeBasePath(page.url.pathname),

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_route_helpers.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_route_helpers.py
@@ -7,6 +7,11 @@ import pytest
 from fastapi import HTTPException
 
 from codex_autorunner.core.orchestration.models import ThreadTarget
+from codex_autorunner.core.runtime_identity import (
+    RUNTIME_STAGE_EFFECTIVE,
+    RuntimeIdentityEnvelope,
+    RuntimeIdentityStage,
+)
 from codex_autorunner.surfaces.web.schemas import ManagedThreadStartMessageRequest
 from codex_autorunner.surfaces.web.services.pma.managed_thread_read_models import (
     _apply_chat_binding_fields,
@@ -321,6 +326,46 @@ class TestApplyChatBindingFields:
         assert result["binding_count"] == 1
         assert result["chat_display_names"] == ["CAR Workspace / #hermes"]
         assert result["cleanup_protected"] is True
+
+
+class TestSerializeThreadTargetRuntimeProjection:
+    def test_uses_latest_effective_runtime_for_hermes_model(self) -> None:
+        thread = ThreadTarget.from_mapping(
+            {
+                "managed_thread_id": "thread-1",
+                "agent": "hermes",
+                "agent_profile": "m4-pma",
+                "lifecycle_status": "active",
+                "normalized_status": "idle",
+                "backend_runtime_instance_id": "hermes-session-1",
+            }
+        )
+        latest_execution = SimpleNamespace(
+            metadata={
+                "runtime_identity": RuntimeIdentityEnvelope(
+                    effective=RuntimeIdentityStage(
+                        stage=RUNTIME_STAGE_EFFECTIVE,
+                        logical_agent="hermes",
+                        runtime_agent="hermes",
+                        canonical_model_label="claude-opus-4.1",
+                        provider_model_id="claude-opus-4.1",
+                        backend_runtime_id="hermes-session-1",
+                        source="hermes_session_models",
+                    )
+                ).to_dict()
+            }
+        )
+
+        payload = _serialize_thread_target(
+            thread,
+            latest_execution=latest_execution,
+        )
+
+        assert payload["model"] == "claude-opus-4.1"
+        assert payload["model_source"] == "effective.canonical_model_label"
+        assert payload["runtime_source"] == "effective:hermes_session_models"
+        assert payload["runtime"]["model_unknown"] is False
+        assert payload["runtime"]["backend_runtime_id"] == "hermes-session-1"
 
 
 class TestAttachLatestExecutionFields:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -3321,6 +3321,67 @@ def test_sync_main_rejects_dirty_tree(tmp_path: Path) -> None:
         supervisor.sync_main("demo")
 
 
+def test_sync_worktree_uses_worktree_cleanliness_not_dirty_parent(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _write_default_hub_config(hub_root)
+    supervisor = _make_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    run_git(["branch", "-M", "main"], base.path, check=True)
+
+    origin = tmp_path / "origin.git"
+    origin.mkdir(parents=True, exist_ok=True)
+    run_git(["init", "--bare"], origin, check=True)
+    run_git(["remote", "add", "origin", str(origin)], base.path, check=True)
+    run_git(["push", "-u", "origin", "main"], base.path, check=True)
+    run_git(["symbolic-ref", "HEAD", "refs/heads/main"], origin, check=True)
+
+    worktree = supervisor.create_worktree(base_repo_id="base", branch="feature/test")
+    run_git(
+        ["branch", "--set-upstream-to", "origin/main", "feature/test"],
+        worktree.path,
+        check=True,
+    )
+    original_worktree_sha = _git_stdout(worktree.path, "rev-parse", "HEAD")
+
+    clone = tmp_path / "clone"
+    run_git(["clone", str(origin), str(clone)], tmp_path, check=True)
+    updated_origin_sha = _commit_file(clone, "origin.txt", "origin\n", "origin update")
+    run_git(["push", "origin", "main"], clone, check=True)
+    assert updated_origin_sha != original_worktree_sha
+
+    (base.path / "dirty-parent.txt").write_text("dirty\n", encoding="utf-8")
+    assert (
+        run_git(["status", "--porcelain"], base.path, check=True).stdout or ""
+    ).strip()
+    assert not (
+        run_git(["status", "--porcelain"], worktree.path, check=True).stdout or ""
+    ).strip()
+
+    synced = supervisor.sync_worktree(worktree.id)
+
+    assert synced.id == worktree.id
+    assert _git_stdout(worktree.path, "rev-parse", "HEAD") == updated_origin_sha
+    assert (base.path / "dirty-parent.txt").exists()
+
+
+def test_sync_worktree_rejects_dirty_worktree(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    _write_default_hub_config(hub_root)
+    supervisor = _make_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base", branch="feature/test", start_point="HEAD"
+    )
+    (worktree.path / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Worktree has uncommitted changes"):
+        supervisor.sync_worktree(worktree.id)
+
+
 def test_set_worktree_setup_commands_rejects_unknown_repo(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     _write_default_hub_config(hub_root)
@@ -3353,7 +3414,9 @@ def test_set_worktree_setup_commands_rejects_non_base_repo(tmp_path: Path) -> No
         check=True,
     )
     run_git(["push", "-u", "origin", "master"], base.path, check=False)
-    wt = supervisor.create_worktree(base_repo_id="base", branch="feature/test")
+    wt = supervisor.create_worktree(
+        base_repo_id="base", branch="feature/test", start_point="HEAD"
+    )
     with pytest.raises(ValueError, match="base repos"):
         supervisor.set_worktree_setup_commands(wt.id, ["echo hi"])
 


### PR DESCRIPTION
## Summary
- Add worktree branch sync through the hub supervisor, API route, and repo/worktree detail UI.
- Preserve route-scoped draft chat state for repo/worktree deep links and load exact out-of-window scopes.
- Project managed-thread runtime identity from latest execution metadata and polish chat transcript/tool-call rendering.

## Validation
- ./scripts/check.sh --lane web-ui
- commit hook: ./scripts/check.sh selected web-core-contract
- post-rebase: ./scripts/check.sh --lane web-core-contract
