### PR TITLE
Fix pytest temp leakage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ done)
 PYTHON := $(shell if [ -x $(VENV_PYTHON) ] && $(VENV_PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= $(MIN_PYTHON) else 1)' >/dev/null 2>&1; then echo $(VENV_PYTHON); elif [ -n "$(BOOTSTRAP_PYTHON)" ]; then echo $(BOOTSTRAP_PYTHON); else echo python3; fi)
 PYTHON_ABS := $(abspath $(PYTHON))
 PYTEST_FAST_WORKERS ?= $(shell $(PYTHON) -c "import os;print(os.cpu_count() or 4)")
+CAR_PYTEST_RUN_TOKEN ?= $(shell $(PYTHON) -c 'import uuid; print("make-" + uuid.uuid4().hex[:8])')
+export CAR_PYTEST_RUN_TOKEN
+PYTEST_BASETEMP ?= $(shell CAR_PYTEST_RUN_TOKEN="$(CAR_PYTEST_RUN_TOKEN)" $(PYTHON) scripts/pytest_basetemp.py)
 
 export PATH := $(CURDIR)/$(VENV)/bin:$(PATH)
 HOST ?= 127.0.0.1
@@ -116,15 +119,15 @@ hooks:
 test: test-fast
 
 test-fast:
-	$(PYTHON) -m pytest -m "not integration and not slow" -n $(PYTEST_FAST_WORKERS) --dist loadfile --ignore=tests/chat_surface_integration
+	$(PYTHON) -m pytest -m "not integration and not slow" -n $(PYTEST_FAST_WORKERS) --dist loadfile --basetemp "$(PYTEST_BASETEMP)" --ignore=tests/chat_surface_integration
 
 test-full:
-	$(PYTHON) -m pytest -m "not integration"
+	$(PYTHON) -m pytest -m "not integration" --basetemp "$(PYTEST_BASETEMP)"
 
 # Cross-platform chat contract/shape guardrails.
 # Add additional platform suites here as new chat adapters land.
 test-chat-platform-contract:
-	$(PYTHON) -m pytest -q \
+	$(PYTHON) -m pytest -q --basetemp "$(PYTEST_BASETEMP)" \
 		tests/adapters/chat/test_command_contract.py \
 		tests/adapters/chat/test_command_ingress_parity.py \
 		tests/adapters/discord/test_service_routing.py \
@@ -135,7 +138,7 @@ test-chat-platform-contract:
 		tests/test_doctor_checks.py::test_chat_doctor_checks_failures_are_actionable
 
 test-chat-surface-lab:
-	$(PYTHON) -m pytest -q \
+	$(PYTHON) -m pytest -q --basetemp "$(PYTEST_BASETEMP)" \
 		tests/chat_surface_lab/test_scenario_corpus.py \
 		tests/chat_surface_lab/test_artifact_manifest.py \
 		tests/chat_surface_lab/test_latency_budgets.py \
@@ -144,7 +147,7 @@ test-chat-surface-lab:
 	$(PYTHON) scripts/chat_surface_latency_budgets.py --profile check-chat-surface-lab
 
 test-managed-thread-cutover:
-	$(PYTHON) -m pytest -q \
+	$(PYTHON) -m pytest -q --basetemp "$(PYTEST_BASETEMP)" \
 		tests/test_backend_run_event_contract.py \
 		tests/test_hub_supervisor.py \
 		tests/test_pma_managed_threads_lifecycle.py \
@@ -160,7 +163,7 @@ test-managed-thread-cutover:
 		tests/test_redaction.py
 
 test-integration:
-	$(PYTHON) -m pytest -m integration
+	$(PYTHON) -m pytest -m integration --basetemp "$(PYTEST_BASETEMP)"
 
 typecheck-strict:
 	$(PYTHON) -m mypy src/codex_autorunner
@@ -178,13 +181,13 @@ check-extended: check-full
 	$(MAKE) test-chat-platform-contract PYTHON="$(PYTHON)"
 
 preflight-hub-startup:
-	$(PYTHON) -m pytest -q tests/test_hub_app_context.py::test_hub_lifespan_reaper_uses_config_root
+	$(PYTHON) -m pytest -q --basetemp "$(PYTEST_BASETEMP)" tests/test_hub_app_context.py::test_hub_lifespan_reaper_uses_config_root
 
 protocol-schemas-check:
 	$(MAKE) agent-compatibility-check PYTHON="$(PYTHON)"
 
 agent-compatibility-check:
-	$(PYTHON) -m pytest tests/test_protocol_schemas.py -q
+	$(PYTHON) -m pytest tests/test_protocol_schemas.py -q --basetemp "$(PYTEST_BASETEMP)"
 	$(PYTHON) scripts/check_protocol_drift.py
 
 protocol-schemas-refresh:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -96,6 +96,8 @@ FAST_TEST_IGNORES='--ignore=tests/chat_surface_integration'
 FAST_TEST_ENFORCE_BUDGET="${CODEX_FAST_TEST_ENFORCE_BUDGET:-0}"
 _AUTO_WORKERS="$("$PYTHON_BIN" -c 'import os;print(os.cpu_count() or 4)' 2>/dev/null || echo 4)"
 FAST_TEST_WORKERS="${CODEX_FAST_TEST_WORKERS:-$_AUTO_WORKERS}"
+export CAR_PYTEST_RUN_TOKEN="${CAR_PYTEST_RUN_TOKEN:-check-$("$PYTHON_BIN" -c 'import uuid; print(uuid.uuid4().hex[:8])')}"
+FAST_TEST_BASETEMP="$("$PYTHON_BIN" scripts/pytest_basetemp.py --repo-root "$REPO_ROOT")"
 STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACMRD 2>/dev/null || true)"
 
 # --- Lane detection (if not explicitly set) ----------------------------------
@@ -236,7 +238,7 @@ _run_pytest() {
         rm -f "$FAST_TEST_JUNIT" "${FAST_TEST_SELECTED:-}"
       }
       trap cleanup_fast_test_artifacts EXIT
-      "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" --dist loadfile $FAST_TEST_IGNORES -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
+      "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" --dist loadfile --basetemp "$FAST_TEST_BASETEMP" $FAST_TEST_IGNORES -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
       FAST_TEST_REPORT_ARGS=(
         "$FAST_TEST_JUNIT"
         --repo-root "$REPO_ROOT"
@@ -245,7 +247,7 @@ _run_pytest() {
       )
       if [[ "${CODEX_FAST_TEST_VERIFY_NODEIDS:-0}" == "1" ]]; then
         FAST_TEST_SELECTED="$(mktemp)"
-        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" --collect-only -q $FAST_TEST_IGNORES > "$FAST_TEST_SELECTED"
+        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" --collect-only -q --basetemp "$FAST_TEST_BASETEMP" $FAST_TEST_IGNORES > "$FAST_TEST_SELECTED"
         FAST_TEST_REPORT_ARGS+=(
           --selected-nodeids "$FAST_TEST_SELECTED"
           --verify-nodeids
@@ -265,7 +267,7 @@ _run_pytest() {
           rm -f "$FAST_TEST_JUNIT" "${FAST_TEST_SELECTED:-}"
         }
         trap cleanup_fast_test_artifacts EXIT
-        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" --dist loadfile $FAST_TEST_IGNORES -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
+        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" --dist loadfile --basetemp "$FAST_TEST_BASETEMP" $FAST_TEST_IGNORES -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
         FAST_TEST_REPORT_ARGS=(
           "$FAST_TEST_JUNIT"
           --repo-root "$REPO_ROOT"
@@ -275,7 +277,7 @@ _run_pytest() {
         )
         if [[ "${CODEX_FAST_TEST_VERIFY_NODEIDS:-0}" == "1" ]]; then
           FAST_TEST_SELECTED="$(mktemp)"
-          "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" --collect-only -q $FAST_TEST_IGNORES > "$FAST_TEST_SELECTED"
+          "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" --collect-only -q --basetemp "$FAST_TEST_BASETEMP" $FAST_TEST_IGNORES > "$FAST_TEST_SELECTED"
           FAST_TEST_REPORT_ARGS+=(
             --selected-nodeids "$FAST_TEST_SELECTED"
             --verify-nodeids
@@ -284,7 +286,7 @@ _run_pytest() {
         echo "Enforcing fast-test budget (CODEX_FAST_TEST_ENFORCE_BUDGET=1)."
         "$PYTHON_BIN" scripts/report_fast_test_budget.py "${FAST_TEST_REPORT_ARGS[@]}"
       else
-        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" --dist loadfile $FAST_TEST_IGNORES
+        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" --dist loadfile --basetemp "$FAST_TEST_BASETEMP" $FAST_TEST_IGNORES
       fi
   fi
 }

--- a/scripts/pytest_basetemp.py
+++ b/scripts/pytest_basetemp.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+for _path in (_REPO_ROOT / "src", _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from tests.support.hermetic_roots import HermeticTestRoots
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print the repo-scoped pytest --basetemp path."
+    )
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args()
+
+    roots = HermeticTestRoots.from_repo_root(Path(args.repo_root))
+    roots.pytest_basetemp_root.parent.mkdir(parents=True, exist_ok=True)
+    print(roots.pytest_basetemp_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,12 +133,35 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         return
 
     cleanup_module = roots.load_pytest_temp_cleanup_module()
-    summary = cleanup_module.cleanup_temp_paths((roots.pytest_basetemp_root,))
-    if not summary.active_paths:
-        try:
-            roots.pytest_temp_run_root.rmdir()
-        except OSError:
-            pass
+    basetemp_root = roots.pytest_basetemp_root
+    summary = cleanup_module.cleanup_temp_paths((basetemp_root,))
+    if basetemp_root.exists() and not summary.active_paths:
+        for _attempt in range(3):
+            try:
+                shutil.rmtree(basetemp_root)
+                break
+            except FileNotFoundError:
+                break
+            except OSError:
+                time.sleep(0.1)
+    failures: list[str] = []
+    if summary.active_paths:
+        failures.append(
+            "active processes remained under pytest basetemp root: "
+            + _format_temp_processes(summary.active_processes)
+        )
+    if summary.failed_paths:
+        failures.append("; ".join(summary.failed_paths))
+    if basetemp_root.exists():
+        failures.append(
+            f"pytest basetemp root still exists after cleanup: {basetemp_root}"
+        )
+    if failures:
+        raise AssertionError(" ; ".join(failures))
+    try:
+        roots.pytest_temp_run_root.rmdir()
+    except OSError:
+        pass
 
 
 def pytest_collection_modifyitems(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,28 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    _ = exitstatus
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return
+    roots = _get_hermetic_roots()
+    configured_basetemp = getattr(session.config.option, "basetemp", None)
+    if not configured_basetemp:
+        return
+    if Path(configured_basetemp).resolve(strict=False) != (
+        roots.pytest_basetemp_root.resolve(strict=False)
+    ):
+        return
+
+    cleanup_module = roots.load_pytest_temp_cleanup_module()
+    summary = cleanup_module.cleanup_temp_paths((roots.pytest_basetemp_root,))
+    if not summary.active_paths:
+        try:
+            roots.pytest_temp_run_root.rmdir()
+        except OSError:
+            pass
+
+
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
 ) -> None:

--- a/tests/core/test_hermetic_roots.py
+++ b/tests/core/test_hermetic_roots.py
@@ -26,6 +26,7 @@ def test_from_repo_root_builds_per_run_per_worker_paths(
     assert roots.process_token == "gw7"
     assert roots.temp_root_max_bytes == 2048
     assert roots.pytest_temp_run_root == roots.pytest_temp_root / "run-123"
+    assert roots.pytest_basetemp_root == roots.pytest_temp_run_root / "basetemp"
     assert roots.pytest_process_root == roots.pytest_temp_run_root / "gw7"
     assert roots.pytest_tmp_root == roots.pytest_process_root / "tmp"
     assert roots.pytest_home_root == roots.pytest_process_root / "home"

--- a/tests/support/hermetic_roots.py
+++ b/tests/support/hermetic_roots.py
@@ -52,6 +52,7 @@ class HermeticTestRoots:
     pytest_runtime_root: Path
     pytest_temp_root: Path
     pytest_temp_run_root: Path
+    pytest_basetemp_root: Path
     pytest_process_root: Path
     pytest_tmp_root: Path
     pytest_home_root: Path
@@ -79,6 +80,7 @@ class HermeticTestRoots:
         )
         pytest_temp_root = pytest_runtime_root / "t"
         pytest_temp_run_root = pytest_temp_root / run_token
+        pytest_basetemp_root = pytest_temp_run_root / "basetemp"
         pytest_process_root = pytest_temp_run_root / process_token
         pytest_tmp_root = pytest_process_root / "tmp"
         pytest_home_root = pytest_process_root / "home"
@@ -98,6 +100,7 @@ class HermeticTestRoots:
             pytest_runtime_root=pytest_runtime_root,
             pytest_temp_root=pytest_temp_root,
             pytest_temp_run_root=pytest_temp_run_root,
+            pytest_basetemp_root=pytest_basetemp_root,
             pytest_process_root=pytest_process_root,
             pytest_tmp_root=pytest_tmp_root,
             pytest_home_root=pytest_home_root,

--- a/tests/test_pytest_basetemp_script.py
+++ b/tests/test_pytest_basetemp_script.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_pytest_basetemp_script_prints_run_scoped_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    run_token = "script-run"
+    monkeypatch.setenv("CAR_PYTEST_RUN_TOKEN", run_token)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "pytest_basetemp.py"),
+            "--repo-root",
+            str(tmp_path / "repo"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    basetemp = Path(result.stdout.strip())
+    assert basetemp.name == "basetemp"
+    assert basetemp.parent.name == run_token
+    assert basetemp.parent.parent.name == "t"
+    assert basetemp.parent.parent.parent.name.startswith("cp-")


### PR DESCRIPTION
Closes #2013

## Summary
- route repo test runners through a CAR repo-scoped pytest --basetemp path
- add a shared helper for computing the run-scoped basetemp
- clean the CAR-owned basetemp at session finish from the xdist controller
- wire Makefile pytest targets and scripts/check.sh to the same temp path

## Validation
- python3.11 scripts/pytest_basetemp.py --repo-root .
- python3.11 -m py_compile scripts/pytest_basetemp.py tests/support/hermetic_roots.py tests/conftest.py tests/core/test_hermetic_roots.py tests/test_pytest_basetemp_script.py
- git diff --check

Full pytest/black were not run in this fresh worktree because dev extras are not installed and the machine is currently disk constrained. An attempted commit hook did start scripts/check.sh and confirmed the new pytest invocation used --basetemp /private/tmp/cp-1361961a7d/t/check-*/basetemp before I stopped it to avoid worsening disk pressure.