### PR TITLE
Improve agent availability UX

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/agents.py
+++ b/src/codex_autorunner/surfaces/web/routes/agents.py
@@ -5,12 +5,16 @@ Agent harness support routes (models + event streaming).
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any, AsyncIterator, Iterable, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from ....agents.registry import get_agent_descriptor, get_available_agents
+from ....agents.registry import (
+    get_agent_descriptor,
+    get_registered_agents,
+)
 from ....core.agent_capability_projection import project_agent_capabilities
 from ....core.orchestration.catalog import map_agent_capabilities
 from ....core.sse import format_sse
@@ -28,66 +32,126 @@ _logger = logging.getLogger(__name__)
 _serialize_model_catalog = serialize_model_catalog
 
 
-def _available_agents(request: Request) -> tuple[list[dict[str, Any]], str]:
-    agents: list[dict[str, Any]] = []
-    default_agent: Optional[str] = None
+@dataclass(frozen=True)
+class AgentCatalogSnapshot:
+    agents: list[dict[str, Any]]
+    statuses: list[dict[str, Any]]
+    default_agent: str
 
-    available = get_available_agents(request.app.state)
 
-    for agent_id, descriptor in available.items():
-        agent_data: dict[str, Any] = {
-            "id": agent_id,
-            "name": descriptor.name,
-            "capabilities": sorted(map_agent_capabilities(descriptor.capabilities)),
-        }
-        projection = project_agent_capabilities(
-            agent_id,
-            agent_data["capabilities"],
+def _serialize_agent_payload(
+    request: Request,
+    agent_id: str,
+    descriptor: Any,
+) -> dict[str, Any]:
+    agent_data: dict[str, Any] = {
+        "id": agent_id,
+        "name": descriptor.name,
+        "capabilities": sorted(map_agent_capabilities(descriptor.capabilities)),
+    }
+    projection = project_agent_capabilities(
+        agent_id,
+        agent_data["capabilities"],
+    )
+    agent_data["capability_projection"] = projection.to_dict()
+    agent_profiles = _serialize_agent_profiles(request, agent_id)
+    if agent_profiles["profiles"]:
+        agent_data.update(agent_profiles)
+    if agent_id == "codex":
+        agent_data["protocol_version"] = "2.0"
+    if agent_id == "opencode":
+        supervisor = getattr(request.app.state, "opencode_supervisor", None)
+        if supervisor and hasattr(supervisor, "_handles"):
+            handles = supervisor._handles
+            if handles:
+                first_handle = next(iter(handles.values()), None)
+                if first_handle:
+                    version = getattr(first_handle, "version", None)
+                    if version:
+                        agent_data["version"] = str(version)
+    return agent_data
+
+
+def _agent_health_status(
+    agent_id: str, descriptor: Any, context: Any
+) -> dict[str, Any]:
+    capabilities = sorted(map_agent_capabilities(descriptor.capabilities))
+    if descriptor.healthcheck is None:
+        status = "configured"
+        label = "Configured"
+        detail = "This agent is configured, but CAR cannot verify it yet."
+        reachable: bool | None = None
+        usable = False
+    else:
+        try:
+            reachable = bool(descriptor.healthcheck(context))
+        except (
+            Exception
+        ):  # intentional: status endpoint must not expose raw backend faults
+            reachable = False
+        usable = reachable
+        status = "ready" if reachable else "offline"
+        label = "Ready" if reachable else "Offline"
+        detail = (
+            "Runtime is reachable."
+            if reachable
+            else "This agent is not reachable right now."
         )
-        agent_data["capability_projection"] = projection.to_dict()
-        agent_profiles = _serialize_agent_profiles(request, agent_id)
-        if agent_profiles["profiles"]:
-            agent_data.update(agent_profiles)
-        if agent_id == "codex":
-            agent_data["protocol_version"] = "2.0"
-        if agent_id == "opencode":
-            supervisor = getattr(request.app.state, "opencode_supervisor", None)
-            if supervisor and hasattr(supervisor, "_handles"):
-                handles = supervisor._handles
-                if handles:
-                    first_handle = next(iter(handles.values()), None)
-                    if first_handle:
-                        version = getattr(first_handle, "version", None)
-                        if version:
-                            agent_data["version"] = str(version)
+    payload: dict[str, Any] = {
+        "id": agent_id,
+        "name": descriptor.name,
+        "capabilities": capabilities,
+        "reachable": reachable,
+        "usable": usable,
+        "status": status,
+        "status_label": label,
+        "status_detail": detail,
+    }
+    payload["capability_projection"] = project_agent_capabilities(
+        agent_id,
+        capabilities,
+    ).to_dict()
+    return payload
+
+
+def _agent_is_usable(agent_id: str, descriptor: Any, context: Any) -> bool:
+    return bool(_agent_health_status(agent_id, descriptor, context)["usable"])
+
+
+def build_agent_catalog_snapshot(request: Request) -> AgentCatalogSnapshot:
+    agents: list[dict[str, Any]] = []
+    statuses: list[dict[str, Any]] = []
+    default_agent: Optional[str] = None
+    context = request.app.state
+
+    registered = get_registered_agents(context)
+    for agent_id, descriptor in registered.items():
+        status = _agent_health_status(agent_id, descriptor, context)
+        statuses.append(status)
+        if not status["usable"]:
+            continue
+        agent_data = _serialize_agent_payload(request, agent_id, descriptor)
         agents.append(agent_data)
         if default_agent is None:
             default_agent = agent_id
 
-    if not agents:
-        fallback_descriptor = get_agent_descriptor("codex", request.app.state)
-        if fallback_descriptor is not None:
-            agents = [
-                {
-                    "id": fallback_descriptor.id,
-                    "name": fallback_descriptor.name,
-                    "protocol_version": "2.0",
-                    "capabilities": [],
-                }
-            ]
-            default_agent = fallback_descriptor.id
-        else:
-            agents = [
-                {
-                    "id": "codex",
-                    "name": "Codex",
-                    "protocol_version": "2.0",
-                    "capabilities": [],
-                }
-            ]
-            default_agent = "codex"
+    return AgentCatalogSnapshot(
+        agents=agents,
+        statuses=statuses,
+        default_agent=default_agent or "",
+    )
 
-    return agents, default_agent or "codex"
+
+def _available_agents(request: Request) -> tuple[list[dict[str, Any]], str]:
+    snapshot = build_agent_catalog_snapshot(request)
+    return snapshot.agents, snapshot.default_agent
+
+
+def serialize_agent_statuses(context: Any) -> list[dict[str, Any]]:
+    statuses: list[dict[str, Any]] = []
+    for agent_id, descriptor in get_registered_agents(context).items():
+        statuses.append(_agent_health_status(agent_id, descriptor, context))
+    return statuses
 
 
 def _serialize_agent_profiles(request: Request, agent_id: str) -> dict[str, Any]:
@@ -126,8 +190,12 @@ def build_agents_routes() -> APIRouter:
 
     @router.get("/api/agents")
     def list_agents(request: Request) -> dict[str, Any]:
-        agents, default_agent = _available_agents(request)
-        return {"agents": agents, "default": default_agent}
+        snapshot = build_agent_catalog_snapshot(request)
+        return {
+            "agents": snapshot.agents,
+            "agent_statuses": snapshot.statuses,
+            "default": snapshot.default_agent,
+        }
 
     @router.get("/api/agents/{agent}/models")
     async def list_agent_models(agent: str, request: Request):
@@ -139,6 +207,11 @@ def build_agents_routes() -> APIRouter:
         descriptor = get_agent_descriptor(agent_id, request.app.state)
         if descriptor is None:
             raise HTTPException(status_code=404, detail="Unknown agent")
+        if not _agent_is_usable(agent_id, descriptor, request.app.state):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Agent '{agent_id}' is not reachable",
+            )
         if "model_listing" not in descriptor.capabilities:
             gate = project_agent_capabilities(
                 agent_id,
@@ -222,4 +295,8 @@ def build_agents_routes() -> APIRouter:
     return router
 
 
-__all__ = ["build_agents_routes"]
+__all__ = [
+    "build_agent_catalog_snapshot",
+    "build_agents_routes",
+    "serialize_agent_statuses",
+]

--- a/src/codex_autorunner/surfaces/web/routes/agents.py
+++ b/src/codex_autorunner/surfaces/web/routes/agents.py
@@ -79,9 +79,9 @@ def _agent_health_status(
     if descriptor.healthcheck is None:
         status = "configured"
         label = "Configured"
-        detail = "This agent is configured, but CAR cannot verify it yet."
+        detail = "This agent is configured; CAR cannot verify live reachability yet."
         reachable: bool | None = None
-        usable = False
+        usable = True
     else:
         try:
             reachable = bool(descriptor.healthcheck(context))

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/meta.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/meta.py
@@ -4,16 +4,16 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
-from .....agents.registry import get_agent_descriptor, get_available_agents
+from .....agents.registry import get_agent_descriptor
 from .....agents.runtime_options import resolve_agent_runtime_options
 from .....core.agent_capability_projection import project_agent_capabilities
 from .....core.orchestration.catalog import map_agent_capabilities
 from .....core.state import load_state
 from ...services.pma import get_pma_request_context
 from ..agents import (
-    _available_agents,
     _serialize_agent_profiles,
     _serialize_model_catalog,
+    build_agent_catalog_snapshot,
 )
 from .hermes_supervisors import resolve_cached_hermes_supervisor
 
@@ -121,27 +121,28 @@ def build_pma_meta_routes(
 
     @router.get("/agents")
     async def list_pma_agents(request: Request) -> dict[str, Any]:
-        context = get_pma_request_context(request)
-        available_descriptors = get_available_agents(context.agent_context)
-        if not available_descriptors:
-            raise HTTPException(status_code=404, detail="PMA unavailable")
+        catalog_snapshot = build_agent_catalog_snapshot(request)
+        agents = catalog_snapshot.agents
+        if not agents:
+            return {
+                "agents": [],
+                "agent_statuses": catalog_snapshot.statuses,
+                "default": "",
+                "defaults": {},
+                "setup_prompt": _agent_setup_prompt(),
+            }
         default_eligible_agent_ids = [
-            str(agent_id or "").strip().lower()
-            for agent_id in available_descriptors.keys()
-            if str(agent_id or "").strip().lower()
+            str(agent.get("id") or "").strip().lower()
+            for agent in agents
+            if isinstance(agent, dict) and str(agent.get("id") or "").strip().lower()
         ]
         default_eligible_agent_id_set = set(default_eligible_agent_ids)
-        agents, default_agent = _available_agents(request)
+        default_agent = catalog_snapshot.default_agent
         defaults = _get_pma_config(request)
         configured_default_agent = (
             str(defaults.get("default_agent") or "").strip().lower() or None
         )
         default_profile = str(defaults.get("profile") or "").strip().lower() or None
-        available_agent_ids = {
-            str(agent.get("id") or "").strip().lower()
-            for agent in agents
-            if isinstance(agent, dict)
-        }
         enriched_agents: list[dict[str, Any]] = []
         for agent in agents:
             if not isinstance(agent, dict):
@@ -156,18 +157,6 @@ def build_pma_meta_routes(
                     include_supervisor_metadata=True,
                 )
             enriched_agents.append(agent_payload)
-        if "hermes" not in available_agent_ids:
-            hermes_payload = _build_registered_hermes_payload(request)
-            if hermes_payload is not None:
-                enriched_agents.append(
-                    await _enrich_hermes_payload(
-                        request,
-                        hermes_payload,
-                        default_agent=default_agent,
-                        default_profile=default_profile,
-                        include_supervisor_metadata=False,
-                    )
-                )
         fallback_default_agent = next(
             (
                 str(agent.get("id") or "").strip().lower()
@@ -202,6 +191,7 @@ def build_pma_meta_routes(
         default_model = runtime_options.model
         payload: dict[str, Any] = {
             "agents": enriched_agents,
+            "agent_statuses": catalog_snapshot.statuses,
             "default": effective_default_agent,
         }
         if (
@@ -256,6 +246,17 @@ def build_pma_meta_routes(
         descriptor = get_agent_descriptor(agent_id, context.agent_context)
         if descriptor is None:
             raise HTTPException(status_code=404, detail="Unknown agent")
+        catalog_snapshot = build_agent_catalog_snapshot(request)
+        usable_agent_ids = {
+            str(row.get("id") or "").strip().lower()
+            for row in catalog_snapshot.agents
+            if isinstance(row, dict)
+        }
+        if agent_id not in usable_agent_ids:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Agent '{agent_id}' is not reachable",
+            )
         model_gate = project_agent_capabilities(
             agent_id,
             descriptor.capabilities,
@@ -277,3 +278,13 @@ def build_pma_meta_routes(
             Exception
         ) as exc:  # intentional: agent harness/model_catalog errors are unpredictable
             raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+def _agent_setup_prompt() -> str:
+    return (
+        "Help me finish setting up CAR agents for this Web Hub. Inspect the hub "
+        "configuration and runtime state, identify which Codex, OpenCode, or "
+        "Hermes backend should be enabled, check required binaries, servers, "
+        "auth, and agent profiles, then make the smallest safe config changes. "
+        "Do not start or restart services without asking me first."
+    )

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -4365,6 +4365,27 @@ textarea:hover {
   gap: var(--space-3);
 }
 
+.agent-setup-modal {
+  display: grid;
+  gap: var(--space-3);
+  width: min(100%, 560px);
+}
+
+.agent-setup-modal pre {
+  max-height: min(36vh, 260px);
+  margin: 0;
+  overflow: auto;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-2);
+  background: var(--color-surface-sunken);
+  color: var(--color-ink);
+  font: inherit;
+  font-size: var(--font-size-0);
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .link-attachment-field {
   display: grid;
   gap: var(--space-1);

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -693,11 +693,13 @@ export class WebApiClient {
       this.filebox.deleteFile({ kind: 'hub' }, box, filename),
     deleteFileBox: async (box: FileBoxName): Promise<ApiResult<JsonRecord>> =>
       this.filebox.deleteBox({ kind: 'hub' }, box),
-    listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; default: string; defaults: JsonRecord }>> =>
+    listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; agentStatuses: JsonRecord[]; default: string; defaults: JsonRecord; setupPrompt: string }>> =>
       mapResult(await this.getJson<JsonRecord>('/hub/pma/agents'), (payload) => ({
         agents: asArray(payload.agents),
+        agentStatuses: asArray(payload.agent_statuses ?? payload.agentStatuses),
         default: typeof payload.default === 'string' ? payload.default : '',
-        defaults: asRecord(payload.defaults)
+        defaults: asRecord(payload.defaults),
+        setupPrompt: typeof payload.setup_prompt === 'string' ? payload.setup_prompt : ''
       })),
     listAgentModels: async (agentId: string): Promise<ApiResult<JsonRecord[]>> =>
       mapResult(await this.getJson<JsonRecord>(`/hub/pma/agents/${encodeURIComponent(agentId)}/models`), (payload) =>

--- a/src/codex_autorunner/web_frontend/src/lib/application/agentModelCatalogStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/agentModelCatalogStore.test.ts
@@ -45,18 +45,18 @@ describe('agent model catalog store', () => {
   });
 
   it('ignores stale agent and model responses after a newer refresh starts', async () => {
-    const firstAgents = deferred<ApiResult<{ agents: JsonRecord[]; default: string; defaults: JsonRecord }>>();
+    const firstAgents = deferred<ApiResult<{ agents: JsonRecord[]; agentStatuses: JsonRecord[]; default: string; defaults: JsonRecord; setupPrompt: string }>>();
     const api = createApi({ agents: [listCapableAgent('fresh')] });
     api.listAgents
       .mockReturnValueOnce(firstAgents.promise)
-      .mockResolvedValueOnce(ok({ agents: [listCapableAgent('fresh')], default: 'fresh', defaults: {} }));
+      .mockResolvedValueOnce(agentResult([listCapableAgent('fresh')], 'fresh'));
     api.listAgentModels.mockResolvedValue(ok([{ id: 'fresh-model' }]));
     const store = createAgentModelCatalogStore(api);
 
     const staleLoad = store.ensureLoaded();
     const freshLoad = store.refresh();
     await freshLoad;
-    firstAgents.resolve(ok({ agents: [listCapableAgent('stale')], default: 'stale', defaults: {} }));
+    firstAgents.resolve(agentResult([listCapableAgent('stale')], 'stale'));
     await staleLoad;
 
     expect(store.snapshot().agents.map((agent) => agent.id)).toEqual(['fresh']);
@@ -73,7 +73,7 @@ function createApi(options: {
   listAgentModels: ReturnType<typeof vi.fn>;
 } {
   return {
-    listAgents: vi.fn().mockResolvedValue(ok({ agents: options.agents, default: 'codex', defaults: {} })),
+    listAgents: vi.fn().mockResolvedValue(agentResult(options.agents, 'codex')),
     listAgentModels: vi.fn((agentId: string) =>
       Promise.resolve(options.modelsByAgent?.[agentId] ?? ok([{ id: `${agentId}-model` }]))
     )
@@ -82,6 +82,10 @@ function createApi(options: {
 
 function listCapableAgent(id: string): JsonRecord {
   return { id, capability_projection: { actions: { list_models: { allowed: true } } } };
+}
+
+function agentResult(agents: JsonRecord[], defaultAgent: string): ApiResult<{ agents: JsonRecord[]; agentStatuses: JsonRecord[]; default: string; defaults: JsonRecord; setupPrompt: string }> {
+  return ok({ agents, agentStatuses: agents, default: defaultAgent, defaults: {}, setupPrompt: '' });
 }
 
 function ok<T>(data: T): ApiResult<T> {

--- a/src/codex_autorunner/web_frontend/src/lib/application/agentModelCatalogStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/agentModelCatalogStore.ts
@@ -14,8 +14,10 @@ export type AgentModelCatalogAgentState = {
 export type AgentModelCatalogState = {
   status: AgentModelCatalogStatus;
   agents: JsonRecord[];
+  agentStatuses: JsonRecord[];
   defaultAgent: string;
   defaults: JsonRecord;
+  setupPrompt: string;
   error: ApiError | null;
   modelCatalogs: Record<string, JsonRecord[] | null>;
   modelStates: Record<string, AgentModelCatalogAgentState>;
@@ -81,8 +83,10 @@ export class AgentModelCatalogStore implements Readable<AgentModelCatalogState> 
     this.commit({
       status: 'ready',
       agents,
+      agentStatuses: agentsResult.data.agentStatuses,
       defaultAgent: agentsResult.data.default,
       defaults: agentsResult.data.defaults,
+      setupPrompt: agentsResult.data.setupPrompt,
       error: null,
       modelCatalogs,
       modelStates
@@ -136,8 +140,10 @@ function initialAgentModelCatalogState(): AgentModelCatalogState {
   return {
     status: 'idle',
     agents: [],
+    agentStatuses: [],
     defaultAgent: '',
     defaults: {},
+    setupPrompt: '',
     error: null,
     modelCatalogs: {},
     modelStates: {}

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
@@ -54,7 +54,7 @@ describe('ChatDetailPageController', () => {
       onCreateInitialDraft: createInitialDraft,
       supportApi: {
         ...supportApi(),
-        listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; defaults: JsonRecord; default: string }>> =>
+        listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; agentStatuses: JsonRecord[]; defaults: JsonRecord; default: string; setupPrompt: string }>> =>
           ({ ok: false, error: { kind: 'http', status: 500, code: 'agents_failed', message: 'agents failed' } })
       }
     });
@@ -280,8 +280,8 @@ function route(chatId?: string) {
 function supportApi() {
   return {
     listFiles: async (): Promise<ApiResult<SurfaceArtifact[]>> => ok([]),
-    listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; defaults: JsonRecord; default: string }>> =>
-      ok({ agents: [{ id: 'codex' }], defaults: { agent: 'codex', profile: '' }, default: 'codex' }),
+    listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; agentStatuses: JsonRecord[]; defaults: JsonRecord; default: string; setupPrompt: string }>> =>
+      ok({ agents: [{ id: 'codex' }], agentStatuses: [{ id: 'codex' }], defaults: { agent: 'codex', profile: '' }, default: 'codex', setupPrompt: '' }),
     repoWorktreeTopology: async (): Promise<ApiResult<RepoWorktreeTopologySnapshot>> => ok({
       contractVersion: READ_MODEL_CONTRACT_VERSION,
       kind: 'repo_worktree.topology.snapshot',

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.ts
@@ -70,7 +70,7 @@ export type ChatDetailPageRoute = {
 
 export type ChatDetailPageSupportApi = {
   listFiles: () => Promise<ApiResult<SurfaceArtifact[]>>;
-  listAgents: () => Promise<ApiResult<{ agents: JsonRecord[]; defaults: JsonRecord; default: string }>>;
+  listAgents: () => Promise<ApiResult<{ agents: JsonRecord[]; agentStatuses: JsonRecord[]; defaults: JsonRecord; default: string; setupPrompt: string }>>;
   repoWorktreeTopology: (filter?: 'repo' | 'worktree' | 'all', limit?: number) => Promise<ApiResult<unknown>>;
   repoWorktreeRuntime: (filter?: 'repo' | 'worktree' | 'all', limit?: number) => Promise<ApiResult<unknown>>;
   repoDetail: (repoId: string) => Promise<ApiResult<RepoWorktreeDetailSnapshot>>;
@@ -79,8 +79,12 @@ export type ChatDetailPageSupportApi = {
 
 export type ChatDetailPageSupportData = {
   agents: JsonRecord[];
+  agentStatuses: JsonRecord[];
+  agentCatalogStatus: 'ready' | 'empty' | 'error';
+  agentCatalogError: string | null;
   defaults: JsonRecord;
   defaultAgent: string;
+  setupPrompt: string;
   scopeOptions: ChatScopeOption[];
 };
 
@@ -304,8 +308,16 @@ export class ChatDetailPageController {
     }
     this.deps.onSupportDataLoaded({
       agents: agentResult.ok ? agentResult.data.agents : [],
+      agentStatuses: agentResult.ok ? agentResult.data.agentStatuses : [],
+      agentCatalogStatus: agentResult.ok
+        ? agentResult.data.agents.length > 0
+          ? 'ready'
+          : 'empty'
+        : 'error',
+      agentCatalogError: agentResult.ok ? null : agentResult.error.message,
       defaults: agentResult.ok ? agentResult.data.defaults : {},
       defaultAgent: agentResult.ok ? agentResult.data.default : 'codex',
+      setupPrompt: agentResult.ok ? agentResult.data.setupPrompt : '',
       scopeOptions: buildChatScopeOptions(
         topologyResult.ok || exactRouteScope ? repoSummaries : [],
         topologyResult.ok || exactRouteScope ? worktreeSummaries : []

--- a/src/codex_autorunner/web_frontend/src/lib/application/scopedTicketDetailController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/scopedTicketDetailController.test.ts
@@ -160,7 +160,7 @@ function createHarness(options: {
       updateTicket: vi.fn().mockResolvedValue(ok({}))
     },
     pma: {
-      listAgents: vi.fn().mockResolvedValue(ok({ agents: options.agents ?? [], default: 'codex', defaults: {} })),
+      listAgents: vi.fn().mockResolvedValue(ok({ agents: options.agents ?? [], agentStatuses: options.agents ?? [], default: 'codex', defaults: {}, setupPrompt: '' })),
       listAgentModels: vi.fn().mockResolvedValue(ok([{ id: 'gpt-5.5' }])),
       createChat: vi.fn().mockResolvedValue(ok({ id: 'chat-1' })),
       sendMessage: vi.fn().mockResolvedValue(ok({ id: 'turn-1' }))

--- a/src/codex_autorunner/web_frontend/src/lib/components/AgentModelReasoningPicker.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/AgentModelReasoningPicker.svelte
@@ -76,11 +76,7 @@
     return fallbackAgentIds.map((id) => ({ id, label: id }));
   });
   const agentOptions = $derived.by<DropdownSelectOption[]>(() => {
-    const entries = agentPickerEntries.map((entry) => ({ value: entry.id, label: entry.label }));
-    if (agentValue && !agentPickerEntries.some((entry) => entry.id === agentValue)) {
-      return [{ value: agentValue, label: agentValue }, ...entries];
-    }
-    return entries;
+    return agentPickerEntries.map((entry) => ({ value: entry.id, label: entry.label }));
   });
 
   const resolvedShowAgent = $derived(showAgent ?? agentPickerEntries.length > 0);

--- a/src/codex_autorunner/web_frontend/src/lib/components/SettingsView.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/SettingsView.test.ts
@@ -118,7 +118,7 @@ describe('settings page shell', () => {
     expect(body).toContain('Codex');
     expect(body).toContain('Default model');
     expect(body).toContain('Use built-in default');
-    expect(body).toContain('Model selection unavailable');
+    expect(body).toContain('Model listing unsupported');
     expect(body).toContain('Saved');
     expect(body).not.toContain('6 models');
     expect(body).not.toContain('Sensitive CAR approval');

--- a/src/codex_autorunner/web_frontend/src/lib/components/TicketViews.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/TicketViews.svelte
@@ -158,7 +158,7 @@
     return scopedNewTicketRoute(owner.kind, owner.id, owner.parentRepoId ?? null);
   });
 
-  const agentOptions = $derived(agents.length > 0 ? agentIdsFromPmaAgentsPayload(agents) : supportedAgentIds);
+  const agentOptions = $derived(agentIdsFromPmaAgentsPayload(agents));
   const selectedAgentRecord = $derived(agentRecordForId(agents, editAgent));
   const selectedAgentCanListModels = $derived(agentCanListModels(selectedAgentRecord));
   const catalogRaw = $derived(selectedAgentCanListModels ? modelCatalogs[editAgent] : undefined);
@@ -184,7 +184,7 @@
     lastSettingsSignature = sig;
     editTicketId = detail.id;
     editTitle = detail.title;
-    const fallbackAgent = agentOptions[0] ?? 'codex';
+    const fallbackAgent = agentOptions[0] ?? '';
     const rawAgent = detail.agentRaw.trim();
     editAgent = rawAgent || fallbackAgent;
     editModel = detail.modelRaw;

--- a/src/codex_autorunner/web_frontend/src/lib/components/settings/AgentsRunnerSection.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/settings/AgentsRunnerSection.svelte
@@ -142,8 +142,8 @@
   <h2 class="settings-section-title">Agents</h2>
   {#if agents.length === 0}
     <div class="state-panel empty-state compact-empty">
-      <strong>No agents visible</strong>
-      <p>No agents are visible from the server.</p>
+      <strong>No agents configured</strong>
+      <p>This Web Hub has not found any agent backends yet.</p>
     </div>
   {:else}
     <div class="agent-status-list">
@@ -151,6 +151,8 @@
         <article class="agent-status-row">
           <div class="agent-status-id">
             <strong>{agent.name}</strong>
+            <span class:ok={agent.usable} class:warning={!agent.usable}>{agent.statusLabel}</span>
+            <small>{agent.statusDetail}</small>
           </div>
           {#if agent.modelStatus === 'available'}
             <div class="agent-model-control">
@@ -165,9 +167,9 @@
               />
             </div>
           {:else if agent.modelStatus === 'unavailable'}
-            <span class="agent-model-muted">Models unavailable</span>
+            <span class="agent-model-muted">{agent.modelLabel}</span>
           {:else}
-            <span class="agent-model-muted">Model selection unavailable</span>
+            <span class="agent-model-muted">{agent.modelLabel}</span>
           {/if}
         </article>
       {/each}
@@ -179,6 +181,39 @@
   .agent-status-id strong {
     font-size: var(--font-size-1);
     font-weight: 600;
+  }
+
+  .agent-status-id {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .agent-status-id span {
+    width: fit-content;
+    padding: 1px 6px;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 999px;
+    color: var(--color-ink-muted);
+    font-size: var(--font-size--1);
+    line-height: 1.4;
+  }
+
+  .agent-status-id span.ok {
+    border-color: var(--color-accent-soft);
+    color: var(--color-accent);
+    background: var(--color-accent-soft);
+  }
+
+  .agent-status-id span.warning {
+    color: var(--color-warning);
+  }
+
+  .agent-status-id small {
+    color: var(--color-ink-muted);
+    font-size: var(--font-size-0);
+    line-height: 1.35;
   }
 
   .checkbox-field {

--- a/src/codex_autorunner/web_frontend/src/lib/components/tickets/TicketPackTicketEditor.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/tickets/TicketPackTicketEditor.svelte
@@ -52,7 +52,7 @@
   let lastTicketKey = $state<string | null>(null);
 
   const numberLabel = $derived(ticketPackNumberLabel(ticket.path, index));
-  const agentOptions = $derived(agents.length > 0 ? agentIdsFromPmaAgentsPayload(agents) : ['codex']);
+  const agentOptions = $derived(agentIdsFromPmaAgentsPayload(agents));
   const selectedAgentRecord = $derived(agentRecordForId(agents, editAgent));
   const selectedAgentCanListModels = $derived(agentCanListModels(selectedAgentRecord));
   const bodyHtml = $derived(renderMarkdownToHtml(editBody));

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -344,6 +344,10 @@
   let archiving = $state(false);
   let bulkRetireRequestedCount = $state<number | null>(null);
   let bulkRetireModal: HTMLDivElement | null = $state(null);
+  let showAgentSetupModal = $state(false);
+  let agentSetupPrompt = $state('');
+  let agentSetupCopyState = $state('Copy prompt');
+  let agentCatalogNotice = $state<string | null>(null);
   let loadingModels = $state(false);
   /** Invalidates in-flight `listAgentModels` results when the user switches agents quickly. */
   let loadModelsSeq = 0;
@@ -1218,6 +1222,13 @@
     }
     if (!canStartCodingAgentChat) newChatKind = 'pma';
     agents = data.agents;
+    agentSetupPrompt = data.setupPrompt || defaultAgentSetupPrompt();
+    agentCatalogNotice =
+      data.agentCatalogStatus === 'error'
+        ? 'Could not check agent availability. Refresh the page, or check hub logs if this keeps happening.'
+        : null;
+    if (data.agentCatalogStatus === 'empty' && !agentSetupDismissed()) showAgentSetupModal = true;
+    if (data.agentCatalogStatus === 'ready') showAgentSetupModal = false;
     const defaults = data.defaults;
     const defaultAgent =
       typeof defaults.agent === 'string' && defaults.agent.trim()
@@ -1312,6 +1323,37 @@
         });
       }
     });
+  }
+
+  function defaultAgentSetupPrompt(): string {
+    return [
+      'Help me finish setting up CAR agents for this Web Hub.',
+      'Inspect the hub configuration and runtime state, identify which Codex, OpenCode, or Hermes backend should be enabled, check required binaries, servers, auth, and agent profiles, then make the smallest safe config changes.',
+      'Do not start or restart services without asking me first.'
+    ].join(' ');
+  }
+
+  function agentSetupDismissed(): boolean {
+    if (typeof sessionStorage === 'undefined') return false;
+    return sessionStorage.getItem('car.agentSetup.dismissed') === '1';
+  }
+
+  function closeAgentSetupModal(): void {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('car.agentSetup.dismissed', '1');
+    }
+    showAgentSetupModal = false;
+  }
+
+  async function copyAgentSetupPrompt(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(agentSetupPrompt || defaultAgentSetupPrompt());
+      agentSetupCopyState = 'Copied';
+      window.setTimeout(() => (agentSetupCopyState = 'Copy prompt'), 1600);
+    } catch {
+      agentSetupCopyState = 'Copy failed';
+      window.setTimeout(() => (agentSetupCopyState = 'Copy prompt'), 1800);
+    }
   }
 
   function applyLastNewChatPreference(): boolean {
@@ -3475,6 +3517,31 @@
         {sending ? (composerWillQueue ? 'Queueing' : 'Sending') : composerWillQueue ? 'Queue' : 'Send'}
       </button>
     </form>
+    {#if showAgentSetupModal}
+      <div class="modal-backdrop" role="presentation" onclick={closeAgentSetupModal}>
+        <div
+          class="approval-modal agent-setup-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="agent-setup-title"
+          tabindex="-1"
+          onclick={(event) => event.stopPropagation()}
+          onkeydown={(event) => {
+            if (event.key === 'Escape') closeAgentSetupModal();
+            event.stopPropagation();
+          }}
+        >
+          <span class="artifact-type">Setup</span>
+          <h2 id="agent-setup-title">Set up your first agent</h2>
+          <p>This Web Hub cannot find a working agent yet. Open Codex or OpenCode on the computer running this Web Hub, paste the prompt below, and let it inspect the setup.</p>
+          <pre>{agentSetupPrompt || defaultAgentSetupPrompt()}</pre>
+          <div class="modal-actions">
+            <button type="button" class="ghost-button" onclick={closeAgentSetupModal}>Dismiss</button>
+            <button type="button" class="send-button" onclick={copyAgentSetupPrompt}>{agentSetupCopyState}</button>
+          </div>
+        </div>
+      </div>
+    {/if}
     {#if linkDialogOpen}
       <div class="modal-backdrop" role="presentation" onclick={cancelLinkDialog}>
         <div
@@ -3538,6 +3605,7 @@
       </div>
     {/if}
     <AutoDismissNotice message={composeError?.message ?? null} tone="danger" />
+    <AutoDismissNotice message={agentCatalogNotice} tone="warning" />
     <AutoDismissNotice message={voiceNotice} tone="warning" />
     <AutoDismissNotice message={commandNotice} tone="success" />
   </div>

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.test.ts
@@ -73,4 +73,45 @@ describe('settings view model', () => {
       runner_stop_after_runs: 3
     });
   });
+
+  it('uses configured copy for agents whose reachability is unknown', () => {
+    const view = buildSettingsViewModel({
+      agents: [
+        {
+          id: 'plugin',
+          name: 'Plugin Agent',
+          capabilities: ['model_listing'],
+          reachable: null,
+          usable: true,
+          capability_projection: projection('plugin', true)
+        },
+        {
+          id: 'legacy',
+          name: 'Legacy Agent',
+          capabilities: ['model_listing'],
+          reachable: null,
+          usable: false,
+          capability_projection: projection('legacy', true)
+        }
+      ],
+      modelCatalogs: {}
+    });
+
+    expect(view.agents).toMatchObject([
+      {
+        id: 'plugin',
+        usable: true,
+        statusLabel: 'Configured',
+        modelStatus: 'unavailable',
+        modelLabel: 'Model selection not verified yet'
+      },
+      {
+        id: 'legacy',
+        usable: false,
+        statusLabel: 'Configured',
+        modelStatus: 'unavailable',
+        modelLabel: 'Model selection not verified yet'
+      }
+    ]);
+  });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.ts
@@ -237,11 +237,11 @@ function mapAgentStatus(agent: JsonRecord, modelCatalogs: Record<string, JsonRec
   const capabilities = stringArray(agent.capabilities);
   const reachable = typeof agent.reachable === 'boolean' ? agent.reachable : null;
   const usable = agent.usable !== false && reachable !== false;
-  const status = stringValue(agent.status) || (usable ? 'ready' : reachable === null ? 'configured' : 'offline');
-  const statusLabel = stringValue(agent.status_label ?? agent.statusLabel) || (usable ? 'Ready' : reachable === null ? 'Configured' : 'Offline');
+  const status = stringValue(agent.status) || (reachable === null ? 'configured' : usable ? 'ready' : 'offline');
+  const statusLabel = stringValue(agent.status_label ?? agent.statusLabel) || (reachable === null ? 'Configured' : usable ? 'Ready' : 'Offline');
   const statusDetail =
     stringValue(agent.status_detail ?? agent.statusDetail) ||
-    (usable ? 'Runtime is reachable.' : reachable === null ? 'This agent is configured, but CAR cannot verify it yet.' : 'This agent is not reachable right now.');
+    (reachable === null ? 'This agent is configured; CAR cannot verify live reachability yet.' : usable ? 'Runtime is reachable.' : 'This agent is not reachable right now.');
   const models = modelCatalogs[id] ?? modelCatalogs[stringValue(agent.id)] ?? null;
   const modelGate = capabilityGate(agent, 'list_models');
   const modelStatus = !usable ? 'unavailable' : modelGate.allowed ? (models ? 'available' : 'unavailable') : 'unsupported';
@@ -263,10 +263,10 @@ function mapAgentStatus(agent: JsonRecord, modelCatalogs: Record<string, JsonRec
         ? `${modelCount} models`
         : modelStatus === 'unsupported'
           ? modelGate.reason || 'Model selection not supported'
-          : !usable
-            ? reachable === null
-              ? 'Runtime not verified; models unavailable'
-              : 'Agent offline; models unavailable'
+          : reachable === null
+            ? 'Model selection not verified yet'
+            : !usable
+              ? 'Agent offline; models unavailable'
             : 'Could not load models',
     modelOptions
   };

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.ts
@@ -264,7 +264,9 @@ function mapAgentStatus(agent: JsonRecord, modelCatalogs: Record<string, JsonRec
         : modelStatus === 'unsupported'
           ? modelGate.reason || 'Model selection not supported'
           : !usable
-            ? 'Agent offline; models unavailable'
+            ? reachable === null
+              ? 'Runtime not verified; models unavailable'
+              : 'Agent offline; models unavailable'
             : 'Could not load models',
     modelOptions
   };

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/settings.ts
@@ -14,6 +14,11 @@ export type SettingsAgentStatus = {
   id: string;
   name: string;
   capabilities: string[];
+  reachable: boolean | null;
+  usable: boolean;
+  status: string;
+  statusLabel: string;
+  statusDetail: string;
   modelStatus: 'available' | 'unsupported' | 'unavailable';
   modelCount: number;
   modelLabel: string;
@@ -54,12 +59,14 @@ export type SettingsVoiceStatus = {
 export type SettingsBuildInput = {
   session?: JsonRecord | null;
   agents?: JsonRecord[];
+  agentStatuses?: JsonRecord[];
   modelCatalogs?: Record<string, JsonRecord[] | null>;
   voiceConfig?: JsonRecord | null;
 };
 
 export function buildSettingsViewModel(input: SettingsBuildInput): SettingsViewModel {
-  const agents = input.agents ?? [];
+  const selectableAgents = input.agents ?? [];
+  const agents = input.agentStatuses?.length ? input.agentStatuses : selectableAgents;
   const modelCatalogs = input.modelCatalogs ?? {};
   const agentStatuses = agents.map((agent) => mapAgentStatus(agent, modelCatalogs));
   const session = mapSession(input.session ?? {});
@@ -83,8 +90,13 @@ export function buildSettingsViewModel(input: SettingsBuildInput): SettingsViewM
     integrations: [
       {
         label: 'Agent capability discovery',
-        value: agents.length > 0 ? `${agents.length} agents detected` : 'No agents detected',
-        tone: agents.length > 0 ? 'ok' : 'warning'
+        value:
+          selectableAgents.length > 0
+            ? `${selectableAgents.length} ready agents`
+            : agents.length > 0
+              ? 'No ready agents'
+              : 'No agents configured',
+        tone: selectableAgents.length > 0 ? 'ok' : 'warning'
       },
       {
         label: 'Chat setup',
@@ -223,23 +235,37 @@ function mapSession(raw: JsonRecord): SettingsSessionState {
 function mapAgentStatus(agent: JsonRecord, modelCatalogs: Record<string, JsonRecord[] | null>): SettingsAgentStatus {
   const id = (stringValue(agent.id) || 'agent').toLowerCase();
   const capabilities = stringArray(agent.capabilities);
+  const reachable = typeof agent.reachable === 'boolean' ? agent.reachable : null;
+  const usable = agent.usable !== false && reachable !== false;
+  const status = stringValue(agent.status) || (usable ? 'ready' : reachable === null ? 'configured' : 'offline');
+  const statusLabel = stringValue(agent.status_label ?? agent.statusLabel) || (usable ? 'Ready' : reachable === null ? 'Configured' : 'Offline');
+  const statusDetail =
+    stringValue(agent.status_detail ?? agent.statusDetail) ||
+    (usable ? 'Runtime is reachable.' : reachable === null ? 'This agent is configured, but CAR cannot verify it yet.' : 'This agent is not reachable right now.');
   const models = modelCatalogs[id] ?? modelCatalogs[stringValue(agent.id)] ?? null;
   const modelGate = capabilityGate(agent, 'list_models');
-  const modelStatus = modelGate.allowed ? (models ? 'available' : 'unavailable') : 'unsupported';
+  const modelStatus = !usable ? 'unavailable' : modelGate.allowed ? (models ? 'available' : 'unavailable') : 'unsupported';
   const modelCount = models?.length ?? 0;
   const modelOptions = modelCatalogOptions(models);
   return {
     id,
     name: stringValue(agent.name) || id,
     capabilities,
+    reachable,
+    usable,
+    status,
+    statusLabel,
+    statusDetail,
     modelStatus,
     modelCount,
     modelLabel:
       modelStatus === 'available'
         ? `${modelCount} models`
         : modelStatus === 'unsupported'
-          ? modelGate.reason || 'Model listing unsupported'
-          : 'Model listing unavailable',
+          ? modelGate.reason || 'Model selection not supported'
+          : !usable
+            ? 'Agent offline; models unavailable'
+            : 'Could not load models',
     modelOptions
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/settings/[[sectionId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/settings/[[sectionId]]/+page.svelte
@@ -133,6 +133,7 @@
     view = buildSettingsViewModel({
       session: currentSession,
       agents: catalog.agents,
+      agentStatuses: catalog.agentStatuses,
       modelCatalogs: catalog.modelCatalogs,
       voiceConfig: settingsVoiceRaw
     });

--- a/tests/adapters/discord/test_dispatch_validation.py
+++ b/tests/adapters/discord/test_dispatch_validation.py
@@ -299,6 +299,7 @@ async def test_service_attempts_fallback_reply_when_initial_response_fails(
 
 
 @pytest.mark.anyio
+@pytest.mark.slow
 async def test_service_routes_slash_command_timeout_followup_through_runner(
     tmp_path: Path,
 ) -> None:

--- a/tests/adapters/discord/test_flow_command_routing.py
+++ b/tests/adapters/discord/test_flow_command_routing.py
@@ -128,6 +128,7 @@ async def test_service_flow_run_autocomplete_filters_for_action_and_query(
 
 
 @pytest.mark.anyio
+@pytest.mark.slow
 async def test_car_flow_resume_with_partial_run_id_prompts_filtered_picker(
     tmp_path: Path,
 ) -> None:

--- a/tests/routes/test_agents_routes.py
+++ b/tests/routes/test_agents_routes.py
@@ -220,16 +220,20 @@ def test_list_agents_includes_expected_capabilities() -> None:
         assert "review" in opencode_caps
 
 
-def test_list_agents_fallback_does_not_advertise_unavailable_capabilities(
+def test_list_agents_does_not_advertise_unavailable_fallback(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(agents_routes, "get_available_agents", lambda _state: {})
     monkeypatch.setattr(
         agents_routes,
-        "get_agent_descriptor",
-        lambda agent_id, _state=None: (
-            SimpleNamespace(id="codex", name="Codex") if agent_id == "codex" else None
-        ),
+        "get_registered_agents",
+        lambda _state: {
+            "codex": SimpleNamespace(
+                id="codex",
+                name="Codex",
+                capabilities=frozenset(),
+                healthcheck=lambda _state: False,
+            )
+        },
     )
     client = _build_client(with_supervisors=True)
 
@@ -237,14 +241,19 @@ def test_list_agents_fallback_does_not_advertise_unavailable_capabilities(
 
     assert response.status_code == 200
     data = response.json()
-    assert data["agents"] == [
-        {
-            "id": "codex",
-            "name": "Codex",
-            "protocol_version": "2.0",
-            "capabilities": [],
-        }
-    ]
+    assert data["agents"] == []
+    assert data["default"] == ""
+    assert data["agent_statuses"][0] | {"capability_projection": {}} == {
+        "id": "codex",
+        "name": "Codex",
+        "capabilities": [],
+        "reachable": False,
+        "usable": False,
+        "status": "offline",
+        "status_label": "Offline",
+        "status_detail": "This agent is not reachable right now.",
+        "capability_projection": {},
+    }
 
 
 def test_list_agents_includes_hermes_when_available(monkeypatch) -> None:
@@ -382,9 +391,14 @@ def test_list_agents_merges_alias_only_hermes_profiles(monkeypatch) -> None:
         _fake_options,
     )
     monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.agents.get_available_agents",
+        "codex_autorunner.surfaces.web.routes.agents.get_registered_agents",
         lambda _state: {
-            "hermes": SimpleNamespace(name="Hermes", capabilities=set()),
+            "hermes": SimpleNamespace(
+                id="hermes",
+                name="Hermes",
+                capabilities=set(),
+                healthcheck=lambda _state: True,
+            ),
         },
     )
 

--- a/tests/routes/test_agents_routes.py
+++ b/tests/routes/test_agents_routes.py
@@ -256,6 +256,84 @@ def test_list_agents_does_not_advertise_unavailable_fallback(
     }
 
 
+def test_list_agents_keeps_healthcheckless_agents_selectable(monkeypatch) -> None:
+    descriptor = SimpleNamespace(
+        id="plugin",
+        name="Plugin Agent",
+        capabilities=frozenset({"model_listing"}),
+        healthcheck=None,
+    )
+    monkeypatch.setattr(
+        agents_routes,
+        "get_registered_agents",
+        lambda _state: {"plugin": descriptor},
+    )
+    client = _build_client(with_supervisors=True)
+
+    response = client.get("/api/agents")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [agent["id"] for agent in data["agents"]] == ["plugin"]
+    assert data["default"] == "plugin"
+    assert data["agent_statuses"][0] | {"capability_projection": {}} == {
+        "id": "plugin",
+        "name": "Plugin Agent",
+        "capabilities": ["model_listing"],
+        "reachable": None,
+        "usable": True,
+        "status": "configured",
+        "status_label": "Configured",
+        "status_detail": "This agent is configured; CAR cannot verify live reachability yet.",
+        "capability_projection": {},
+    }
+
+
+def test_agent_models_route_allows_healthcheckless_agents(monkeypatch) -> None:
+    class _Harness:
+        async def model_catalog(self, _repo_root):
+            return ModelCatalog(
+                default_model="plugin-default",
+                models=[
+                    ModelSpec(
+                        id="plugin-default",
+                        display_name="Plugin Default",
+                        supports_reasoning=False,
+                        reasoning_options=[],
+                    )
+                ],
+            )
+
+    descriptor = SimpleNamespace(
+        id="plugin",
+        name="Plugin Agent",
+        capabilities=frozenset({"model_listing"}),
+        healthcheck=None,
+        make_harness=lambda _state: _Harness(),
+    )
+    monkeypatch.setattr(
+        agents_routes,
+        "get_agent_descriptor",
+        lambda agent_id, _state: descriptor if agent_id == "plugin" else None,
+    )
+    client = _build_client(with_supervisors=True)
+
+    response = client.get("/api/agents/plugin/models")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "default_model": "plugin-default",
+        "models": [
+            {
+                "id": "plugin-default",
+                "display_name": "Plugin Default",
+                "supports_reasoning": False,
+                "reasoning_options": [],
+            }
+        ],
+    }
+
+
 def test_list_agents_includes_hermes_when_available(monkeypatch) -> None:
     monkeypatch.setattr(
         "codex_autorunner.agents.registry.hermes_runtime_preflight",

--- a/tests/surfaces/web/routes/pma_routes/test_meta.py
+++ b/tests/surfaces/web/routes/pma_routes/test_meta.py
@@ -77,6 +77,31 @@ def test_pma_agents_includes_hermes_when_available(monkeypatch) -> None:
         ] == ["model_listing"]
 
 
+def test_pma_agents_keeps_healthcheckless_agents_selectable(monkeypatch) -> None:
+    descriptor = AgentDescriptor(
+        id="plugin",
+        name="Plugin Agent",
+        capabilities=frozenset(),
+        make_harness=lambda _ctx: object(),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.routes.agents.get_registered_agents",
+        lambda _state: {"plugin": descriptor},
+    )
+    client = _build_client(with_supervisors=True)
+
+    response = client.get("/agents")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [agent["id"] for agent in payload["agents"]] == ["plugin"]
+    assert payload["default"] == "plugin"
+    assert payload["agent_statuses"][0]["status"] == "configured"
+    assert payload["agent_statuses"][0]["reachable"] is None
+    assert payload["agent_statuses"][0]["usable"] is True
+    assert "setup_prompt" not in payload
+
+
 def test_pma_models_endpoint_returns_capability_error_for_hermes(monkeypatch) -> None:
     monkeypatch.setattr(
         "codex_autorunner.agents.registry.hermes_runtime_preflight",

--- a/tests/surfaces/web/routes/pma_routes/test_meta.py
+++ b/tests/surfaces/web/routes/pma_routes/test_meta.py
@@ -220,37 +220,30 @@ def test_pma_agents_honors_configured_default_agent(tmp_path) -> None:
 def test_pma_agents_does_not_default_to_unavailable_synthetic_hermes(
     monkeypatch, tmp_path
 ) -> None:
-    opencode_descriptor = AgentDescriptor(
-        id="opencode",
-        name="OpenCode",
-        capabilities=frozenset(),
-        make_harness=lambda _ctx: object(),
-    )
     hermes_descriptor = AgentDescriptor(
         id="hermes",
         name="Hermes",
         capabilities=frozenset(),
         make_harness=lambda _ctx: object(),
     )
-    _only_opencode = {"opencode": opencode_descriptor}
-
-    def _mock_get_available(_context):
-        return _only_opencode
 
     def _descriptor_for(agent_id, _context):
         return hermes_descriptor if agent_id == "hermes" else None
 
     monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.pma_routes.meta.get_available_agents",
-        _mock_get_available,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.agents.get_available_agents",
-        _mock_get_available,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.agents.registry.get_available_agents",
-        _mock_get_available,
+        "codex_autorunner.surfaces.web.routes.pma_routes.meta.build_agent_catalog_snapshot",
+        lambda _request: SimpleNamespace(
+            agents=[
+                {
+                    "id": "opencode",
+                    "name": "OpenCode",
+                    "capabilities": [],
+                    "capability_projection": {},
+                }
+            ],
+            statuses=[],
+            default_agent="opencode",
+        ),
     )
     monkeypatch.setattr(
         "codex_autorunner.surfaces.web.routes.pma_routes.meta.get_agent_descriptor",
@@ -259,30 +252,6 @@ def test_pma_agents_does_not_default_to_unavailable_synthetic_hermes(
     monkeypatch.setattr(
         "codex_autorunner.agents.registry.get_agent_descriptor",
         _descriptor_for,
-    )
-
-    def _mock_available_agents(_request):
-        return (
-            [
-                {
-                    "id": "opencode",
-                    "name": "OpenCode",
-                    "capabilities": [],
-                    "capability_projection": {},
-                }
-            ],
-            "opencode",
-        )
-
-    # Patch both modules: `meta` keeps its own binding from `from ..agents import
-    # _available_agents`, so patching only `agents` is not enough under xdist.
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.pma_routes.meta._available_agents",
-        _mock_available_agents,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.agents._available_agents",
-        _mock_available_agents,
     )
 
     app = FastAPI()
@@ -328,47 +297,19 @@ def test_pma_agents_does_not_default_to_unavailable_synthetic_hermes(
     assert response.status_code == 200
     payload = response.json()
     agent_ids = {agent["id"] for agent in payload["agents"]}
-    assert "hermes" in agent_ids
+    assert "hermes" not in agent_ids
     assert payload["default"] == "opencode"
     assert payload["defaults"]["agent"] == "opencode"
+    assert "agent_statuses" in payload
 
 
 def test_pma_agents_default_uses_registry_availability_over_serialized_hint(
     monkeypatch, tmp_path
 ) -> None:
-    opencode_descriptor = AgentDescriptor(
-        id="opencode",
-        name="OpenCode",
-        capabilities=frozenset(),
-        make_harness=lambda _ctx: object(),
-    )
-    _only_opencode = {"opencode": opencode_descriptor}
-
-    def _mock_get_available(_context):
-        return _only_opencode
-
     monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.pma_routes.meta.get_available_agents",
-        _mock_get_available,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.agents.get_available_agents",
-        _mock_get_available,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.agents.registry.get_available_agents",
-        _mock_get_available,
-    )
-
-    def _mock_serialized_agents(_request):
-        return (
-            [
-                {
-                    "id": "codex",
-                    "name": "Codex",
-                    "capabilities": [],
-                    "capability_projection": {},
-                },
+        "codex_autorunner.surfaces.web.routes.pma_routes.meta.build_agent_catalog_snapshot",
+        lambda _request: SimpleNamespace(
+            agents=[
                 {
                     "id": "opencode",
                     "name": "OpenCode",
@@ -376,16 +317,9 @@ def test_pma_agents_default_uses_registry_availability_over_serialized_hint(
                     "capability_projection": {},
                 },
             ],
-            "codex",
-        )
-
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.pma_routes.meta._available_agents",
-        _mock_serialized_agents,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.agents._available_agents",
-        _mock_serialized_agents,
+            statuses=[],
+            default_agent="opencode",
+        ),
     )
 
     app = FastAPI()

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -1550,6 +1550,7 @@ def test_hub_read_models_chats_patch_stream_does_not_replay_historical_events(
     assert repairs[0]["envelope"]["cursor"]["sequence"] > 0
 
 
+@pytest.mark.slow
 def test_hub_read_models_chats_patch_stream_bulk_archive_is_bounded(
     hub_env,
 ) -> None:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -748,6 +748,7 @@ def test_opencode_summary_prefers_persisted_turn_usage(tmp_path):
 def test_usage_aggregation_read_model_reports_confidence_and_session_totals(tmp_path):
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
+    codex_home = tmp_path / "codex"
     usage_path = repo_root / ".codex-autorunner" / "usage"
     usage_path.mkdir(parents=True)
     (usage_path / "opencode_turn_usage.jsonl").write_text(
@@ -773,7 +774,7 @@ def test_usage_aggregation_read_model_reports_confidence_and_session_totals(tmp_
         usage={"inputTokens": 9, "outputTokens": 3, "totalTokens": 12},
     )
 
-    read_model = get_repo_usage_aggregation_read_model(repo_root)
+    read_model = get_repo_usage_aggregation_read_model(repo_root, codex_home=codex_home)
     payload = read_model.to_dict()
 
     assert payload["totals"]["total_tokens"] == 12


### PR DESCRIPTION
## Summary
- expose selectable-only agent catalogs with diagnostic agent status rows
- gate model catalogs and ticket/chat pickers to verified usable agents
- add no-agent onboarding modal and friendlier settings/status copy
- make fast validation less flaky by hermeticizing the usage aggregation test and marking wall-clock/stress tests as slow

## Subagent Review
- used a read-only subagent audit for the flaky/time-sensitive tests
- audit confirmed `make check` already excludes `slow`/`integration` tests and identified unmarked slow tests plus one non-hermetic `CODEX_HOME` dependency

## Tests
- normal pre-commit hook / `scripts/check.sh` aggregate lane passed
- `.venv/bin/python -m pytest tests/routes/test_agents_routes.py tests/surfaces/web/routes/pma_routes/test_meta.py tests/test_usage.py::test_usage_aggregation_read_model_reports_confidence_and_session_totals -q`
- `.venv/bin/python -m pytest tests/adapters/discord/test_dispatch_validation.py::test_service_routes_slash_command_timeout_followup_through_runner tests/adapters/discord/test_flow_command_routing.py::test_car_flow_resume_with_partial_run_id_prompts_filtered_picker tests/surfaces/web/test_hub_chat_read_model_routes.py::test_hub_read_models_chats_patch_stream_bulk_archive_is_bounded -q`
- `.venv/bin/python -m pytest -m "not integration and not slow" --collect-only -q tests/adapters/discord/test_dispatch_validation.py::test_service_routes_slash_command_timeout_followup_through_runner tests/adapters/discord/test_flow_command_routing.py::test_car_flow_resume_with_partial_run_id_prompts_filtered_picker tests/surfaces/web/test_hub_chat_read_model_routes.py::test_hub_read_models_chats_patch_stream_bulk_archive_is_bounded` (expected exit 5: all three tests deselected as slow)
- `pnpm web:lint`
- `pnpm run build`
