### PR TITLE
[codex] Bound update snapshot retention

### DIFF
--- a/docs/STATE_ROOTS.md
+++ b/docs/STATE_ROOTS.md
@@ -120,8 +120,10 @@ python -m codex_autorunner.core.update_transaction prune-snapshots \
   --snapshot-root ~/.codex-autorunner/update_snapshots
 ```
 
-The pruning helper skips the current update run when provided and skips
-candidate directories when `lsof` reports open files inside them.
+The pruning helper only deletes directories with valid
+`orchestration/snapshot.json` metadata, skips the current update run when
+provided, and skips candidate directories when `lsof` reports open files inside
+them or cannot prove they are closed.
 
 **Docker destination override**:
 - When a repo/worktree runs with effective destination `docker`, supervisor state root is forced to:

--- a/docs/STATE_ROOTS.md
+++ b/docs/STATE_ROOTS.md
@@ -98,8 +98,33 @@ CAR does not install third-party runtimes as part of the state-root contract.
 **Contents**:
 - `update_cache/` - Cached update artifacts
 - `update_status.json` - Update status
+- `update_snapshots/` - Timestamped update rollback snapshots, including
+  orchestration DB copies created by macOS safe refresh
 - `locks/` - Cross-repo locks (e.g., telegram bot lock)
 - `workspaces/` - App-server workspaces (default for non-docker destinations)
+
+**Update snapshot retention**:
+- macOS safe refresh stores update rollback snapshots under
+  `~/.codex-autorunner/update_snapshots/` when `UPDATE_STATUS_PATH` uses the
+  global state root.
+- Snapshot pruning runs after every `snapshot-db` update phase. Defaults keep
+  at most 5 snapshot directories, remove snapshots older than 14 days, and
+  enforce a 5 GiB total byte budget.
+- Override with `UPDATE_SNAPSHOT_MAX_COUNT`, `UPDATE_SNAPSHOT_MAX_AGE_DAYS`,
+  and `UPDATE_SNAPSHOT_MAX_TOTAL_BYTES` when running
+  `scripts/safe-refresh-local-mac-hub.sh`. Set a value to `0` to disable that
+  specific bound.
+- Manual inspection and pruning:
+
+```bash
+du -sh ~/.codex-autorunner/update_snapshots
+find ~/.codex-autorunner/update_snapshots -maxdepth 1 -mindepth 1 -type d -print
+python -m codex_autorunner.core.update_transaction prune-snapshots \
+  --snapshot-root ~/.codex-autorunner/update_snapshots
+```
+
+The pruning helper skips the current update run when provided and skips
+candidate directories when `lsof` reports open files inside them.
 
 **Docker destination override**:
 - When a repo/worktree runs with effective destination `docker`, supervisor state root is forced to:

--- a/docs/STATE_ROOTS.md
+++ b/docs/STATE_ROOTS.md
@@ -107,13 +107,10 @@ CAR does not install third-party runtimes as part of the state-root contract.
 - macOS safe refresh stores update rollback snapshots under
   `~/.codex-autorunner/update_snapshots/` when `UPDATE_STATUS_PATH` uses the
   global state root.
-- Snapshot pruning runs after every `snapshot-db` update phase. Defaults keep
-  at most 5 snapshot directories, remove snapshots older than 14 days, and
-  enforce a 5 GiB total byte budget.
-- Override with `UPDATE_SNAPSHOT_MAX_COUNT`, `UPDATE_SNAPSHOT_MAX_AGE_DAYS`,
-  and `UPDATE_SNAPSHOT_MAX_TOTAL_BYTES` when running
-  `scripts/safe-refresh-local-mac-hub.sh`. Set a value to `0` to disable that
-  specific bound.
+- Snapshot pruning runs after every `snapshot-db` update phase. The default
+  keeps only the newest snapshot directory needed for rollback.
+- Override with `UPDATE_SNAPSHOT_MAX_COUNT` when running
+  `scripts/safe-refresh-local-mac-hub.sh`. Set it to `0` to disable pruning.
 - Manual inspection and pruning:
 
 ```bash

--- a/docs/ops/state-cleanup.md
+++ b/docs/ops/state-cleanup.md
@@ -18,6 +18,7 @@ CAR manages state across several retention families:
 | filebox | repo | ephemeral | Inbox/outbox staging |
 | reports | repo | reviewable | Report history files |
 | update_cache | global | cache-only | Update artifacts cache |
+| update_snapshots | global | reviewable | Update rollback snapshots |
 | workspaces | repo/global | ephemeral | App-server workspace directories |
 
 Retention classes determine cleanup behavior:
@@ -84,6 +85,15 @@ Total: deleted=22 bytes=36700160
 | `repo` | worktree_archives, run_archives, logs, uploads, github_context, review_runs, filebox, reports, repo workspaces |
 | `global` | update_cache, logs, global workspaces |
 | `all` | All families |
+
+`update_snapshots` are pruned separately by the update transaction helper after
+macOS safe refresh snapshots the orchestration DB. To inspect or prune them
+directly:
+
+```bash
+python -m codex_autorunner.core.update_transaction prune-snapshots \
+  --snapshot-root ~/.codex-autorunner/update_snapshots
+```
 
 ## Safety Guards
 

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -47,9 +47,7 @@ set -euo pipefail
 #   KEEP_OLD_VENVS         how many old next-* venvs to keep (default: 3)
 #   UPDATE_SNAPSHOT_ROOT   directory for update DB rollback snapshots
 #                          (default: dirname(UPDATE_STATUS_PATH)/update_snapshots)
-#   UPDATE_SNAPSHOT_MAX_COUNT maximum update snapshot directories to keep (default: 5)
-#   UPDATE_SNAPSHOT_MAX_AGE_DAYS maximum update snapshot age in days (default: 14; 0 disables)
-#   UPDATE_SNAPSHOT_MAX_TOTAL_BYTES maximum total update snapshot bytes (default: 5368709120; 0 disables)
+#   UPDATE_SNAPSHOT_MAX_COUNT maximum update snapshot directories to keep (default: 1; 0 disables)
 #   NVM_BIN                Node bin path to prepend (default: ~/.nvm/versions/node/v22.12.0/bin)
 #   LOCAL_BIN              Local bin path for the `car` wrapper and PATH bootstrap (default: ~/.local/bin)
 #   PY39_BIN               Python bin path to prepend (default: auto-detected from active Python)
@@ -91,9 +89,7 @@ WAIT_HUB_HEALTH_BEFORE_CHAT_RELOAD="${WAIT_HUB_HEALTH_BEFORE_CHAT_RELOAD:-true}"
 LAUNCHD_STOP_WAIT_SECONDS="${LAUNCHD_STOP_WAIT_SECONDS:-10}"
 KEEP_OLD_VENVS="${KEEP_OLD_VENVS:-3}"
 UPDATE_SNAPSHOT_ROOT="${UPDATE_SNAPSHOT_ROOT:-}"
-UPDATE_SNAPSHOT_MAX_COUNT="${UPDATE_SNAPSHOT_MAX_COUNT:-5}"
-UPDATE_SNAPSHOT_MAX_AGE_DAYS="${UPDATE_SNAPSHOT_MAX_AGE_DAYS:-14}"
-UPDATE_SNAPSHOT_MAX_TOTAL_BYTES="${UPDATE_SNAPSHOT_MAX_TOTAL_BYTES:-5368709120}"
+UPDATE_SNAPSHOT_MAX_COUNT="${UPDATE_SNAPSHOT_MAX_COUNT:-1}"
 NVM_BIN="${NVM_BIN:-$HOME/.nvm/versions/node/v22.12.0/bin}"
 LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
 PY39_BIN="${PY39_BIN:-$HOME/Library/Python/$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')/bin}"
@@ -278,9 +274,7 @@ _snapshot_db_phase() {
       --hub-root "${HUB_ROOT}" \
       --snapshot-root "${UPDATE_SNAPSHOT_ROOT}" \
       --run-id "${update_run_id}" \
-      --max-snapshots "${UPDATE_SNAPSHOT_MAX_COUNT}" \
-      --max-age-days "${UPDATE_SNAPSHOT_MAX_AGE_DAYS}" \
-      --max-total-bytes "${UPDATE_SNAPSHOT_MAX_TOTAL_BYTES}"
+      --max-snapshots "${UPDATE_SNAPSHOT_MAX_COUNT}"
   )" || return
   db_snapshot_dir="$(
     SNAPSHOT_PAYLOAD="${snapshot_payload}" "${HELPER_PYTHON}" - <<'PY'

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -45,6 +45,11 @@ set -euo pipefail
 #   LAUNCHD_STOP_WAIT_SECONDS seconds to wait after launchctl unload for the old PID to exit before
 #                          SIGKILL (default: 10). Hub/chat can hold DB handles briefly; 5s was tight.
 #   KEEP_OLD_VENVS         how many old next-* venvs to keep (default: 3)
+#   UPDATE_SNAPSHOT_ROOT   directory for update DB rollback snapshots
+#                          (default: dirname(UPDATE_STATUS_PATH)/update_snapshots)
+#   UPDATE_SNAPSHOT_MAX_COUNT maximum update snapshot directories to keep (default: 5)
+#   UPDATE_SNAPSHOT_MAX_AGE_DAYS maximum update snapshot age in days (default: 14; 0 disables)
+#   UPDATE_SNAPSHOT_MAX_TOTAL_BYTES maximum total update snapshot bytes (default: 5368709120; 0 disables)
 #   NVM_BIN                Node bin path to prepend (default: ~/.nvm/versions/node/v22.12.0/bin)
 #   LOCAL_BIN              Local bin path for the `car` wrapper and PATH bootstrap (default: ~/.local/bin)
 #   PY39_BIN               Python bin path to prepend (default: auto-detected from active Python)
@@ -86,6 +91,9 @@ WAIT_HUB_HEALTH_BEFORE_CHAT_RELOAD="${WAIT_HUB_HEALTH_BEFORE_CHAT_RELOAD:-true}"
 LAUNCHD_STOP_WAIT_SECONDS="${LAUNCHD_STOP_WAIT_SECONDS:-10}"
 KEEP_OLD_VENVS="${KEEP_OLD_VENVS:-3}"
 UPDATE_SNAPSHOT_ROOT="${UPDATE_SNAPSHOT_ROOT:-}"
+UPDATE_SNAPSHOT_MAX_COUNT="${UPDATE_SNAPSHOT_MAX_COUNT:-5}"
+UPDATE_SNAPSHOT_MAX_AGE_DAYS="${UPDATE_SNAPSHOT_MAX_AGE_DAYS:-14}"
+UPDATE_SNAPSHOT_MAX_TOTAL_BYTES="${UPDATE_SNAPSHOT_MAX_TOTAL_BYTES:-5368709120}"
 NVM_BIN="${NVM_BIN:-$HOME/.nvm/versions/node/v22.12.0/bin}"
 LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
 PY39_BIN="${PY39_BIN:-$HOME/Library/Python/$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')/bin}"
@@ -269,7 +277,10 @@ _snapshot_db_phase() {
       snapshot-db \
       --hub-root "${HUB_ROOT}" \
       --snapshot-root "${UPDATE_SNAPSHOT_ROOT}" \
-      --run-id "${update_run_id}"
+      --run-id "${update_run_id}" \
+      --max-snapshots "${UPDATE_SNAPSHOT_MAX_COUNT}" \
+      --max-age-days "${UPDATE_SNAPSHOT_MAX_AGE_DAYS}" \
+      --max-total-bytes "${UPDATE_SNAPSHOT_MAX_TOTAL_BYTES}"
   )" || return
   db_snapshot_dir="$(
     SNAPSHOT_PAYLOAD="${snapshot_payload}" "${HELPER_PYTHON}" - <<'PY'

--- a/src/codex_autorunner/core/update_transaction.py
+++ b/src/codex_autorunner/core/update_transaction.py
@@ -4,13 +4,15 @@ import argparse
 import json
 import shutil
 import sqlite3
+import subprocess
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 from .orchestration.migrations import ORCHESTRATION_SCHEMA_VERSION
 from .orchestration.sqlite import resolve_orchestration_sqlite_path
+from .utils import resolve_executable
 
 _PRESERVED_STATUS_KEYS = (
     "notify_chat_id",
@@ -26,6 +28,11 @@ _MAX_PHASE_TIMINGS = 24
 
 _ORCHESTRATION_DB_SUFFIXES = ("", "-wal", "-shm")
 _SNAPSHOT_METADATA = "snapshot.json"
+_DEFAULT_MAX_SNAPSHOTS = 5
+_DEFAULT_MAX_AGE_DAYS = 14
+_DEFAULT_MAX_TOTAL_BYTES = 5 * 1024 * 1024 * 1024
+
+OpenFileChecker = Callable[[Path], bool]
 
 
 @dataclass(frozen=True)
@@ -55,12 +62,198 @@ class OrchestrationDbSnapshot:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class UpdateSnapshotPruneResult:
+    snapshot_root: str
+    kept: tuple[str, ...]
+    pruned: tuple[str, ...]
+    skipped_open: tuple[str, ...]
+    skipped_invalid: tuple[str, ...]
+    max_snapshots: int | None
+    max_age_seconds: int | None
+    max_total_bytes: int | None
+    total_bytes_before: int
+    total_bytes_after: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class UpdateSnapshotDirectory:
+    path: Path
+    created_at: float
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class UpdateSnapshotTransaction:
+    snapshot: OrchestrationDbSnapshot
+    prune: UpdateSnapshotPruneResult
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.snapshot.to_dict()
+        payload["prune"] = self.prune.to_dict()
+        return payload
+
+
 def _read_json(path: Path) -> dict[str, Any] | None:
     try:
         parsed = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     return parsed if isinstance(parsed, dict) else None
+
+
+def _directory_size(path: Path) -> int:
+    total = 0
+    for item in path.rglob("*"):
+        try:
+            if item.is_file() or item.is_symlink():
+                total += item.lstat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _snapshot_created_at(path: Path) -> float:
+    metadata = _read_json(path / "orchestration" / _SNAPSHOT_METADATA)
+    if metadata is not None:
+        try:
+            created_at = float(metadata.get("created_at") or 0.0)
+        except (TypeError, ValueError):
+            created_at = 0.0
+        if created_at > 0:
+            return created_at
+    return path.stat().st_mtime
+
+
+def _has_open_files(path: Path) -> bool:
+    lsof = resolve_executable("lsof")
+    if lsof is None:
+        return False
+    try:
+        completed = subprocess.run(
+            [lsof, "+D", str(path)],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return True
+    return completed.returncode == 0
+
+
+def _positive_int_or_none(value: int | None) -> int | None:
+    return value if value is not None and value > 0 else None
+
+
+def collect_update_snapshots(
+    snapshot_root: Path,
+) -> tuple[list[UpdateSnapshotDirectory], tuple[str, ...]]:
+    if not snapshot_root.exists():
+        return [], ()
+
+    snapshots: list[UpdateSnapshotDirectory] = []
+    skipped_invalid: list[str] = []
+    for child in snapshot_root.iterdir():
+        if not child.is_dir():
+            skipped_invalid.append(str(child))
+            continue
+        try:
+            snapshots.append(
+                UpdateSnapshotDirectory(
+                    path=child,
+                    created_at=_snapshot_created_at(child),
+                    size_bytes=_directory_size(child),
+                )
+            )
+        except OSError:
+            skipped_invalid.append(str(child))
+    return snapshots, tuple(skipped_invalid)
+
+
+def prune_update_snapshots(
+    snapshot_root: Path,
+    *,
+    current_run_id: str | None = None,
+    max_snapshots: int | None = _DEFAULT_MAX_SNAPSHOTS,
+    max_age_seconds: int | None = _DEFAULT_MAX_AGE_DAYS * 24 * 60 * 60,
+    max_total_bytes: int | None = _DEFAULT_MAX_TOTAL_BYTES,
+    now: float | None = None,
+    open_file_checker: OpenFileChecker | None = None,
+) -> UpdateSnapshotPruneResult:
+    max_snapshots = _positive_int_or_none(max_snapshots)
+    max_age_seconds = _positive_int_or_none(max_age_seconds)
+    max_total_bytes = _positive_int_or_none(max_total_bytes)
+    now = time.time() if now is None else now
+    open_file_checker = (
+        _has_open_files if open_file_checker is None else open_file_checker
+    )
+
+    snapshots, skipped_invalid = collect_update_snapshots(snapshot_root)
+    total_before = sum(snapshot.size_bytes for snapshot in snapshots)
+
+    snapshots_by_age = sorted(
+        snapshots,
+        key=lambda snapshot: (snapshot.created_at, snapshot.path.name),
+        reverse=True,
+    )
+    kept_paths = {snapshot.path for snapshot in snapshots}
+    protected = {snapshot_root / current_run_id} if current_run_id else set()
+
+    prune_paths: set[Path] = set()
+    if max_snapshots is not None:
+        for snapshot in snapshots_by_age[max_snapshots:]:
+            if snapshot.path not in protected:
+                prune_paths.add(snapshot.path)
+
+    if max_age_seconds is not None:
+        oldest_allowed = now - max_age_seconds
+        for snapshot in snapshots:
+            if snapshot.created_at < oldest_allowed and snapshot.path not in protected:
+                prune_paths.add(snapshot.path)
+
+    if max_total_bytes is not None:
+        retained_bytes = total_before - sum(
+            snapshot.size_bytes
+            for snapshot in snapshots
+            if snapshot.path in prune_paths
+        )
+        for snapshot in reversed(snapshots_by_age):
+            if retained_bytes <= max_total_bytes:
+                break
+            if snapshot.path in protected or snapshot.path in prune_paths:
+                continue
+            prune_paths.add(snapshot.path)
+            retained_bytes -= snapshot.size_bytes
+
+    pruned: list[str] = []
+    skipped_open: list[str] = []
+    size_by_path = {snapshot.path: snapshot.size_bytes for snapshot in snapshots}
+    for path in sorted(prune_paths):
+        if open_file_checker(path):
+            skipped_open.append(str(path))
+            continue
+        shutil.rmtree(path)
+        pruned.append(str(path))
+        kept_paths.discard(path)
+
+    kept = tuple(str(path) for path in sorted(kept_paths))
+    total_after = total_before - sum(size_by_path.get(Path(path), 0) for path in pruned)
+    return UpdateSnapshotPruneResult(
+        snapshot_root=str(snapshot_root),
+        kept=kept,
+        pruned=tuple(pruned),
+        skipped_open=tuple(skipped_open),
+        skipped_invalid=skipped_invalid,
+        max_snapshots=max_snapshots,
+        max_age_seconds=max_age_seconds,
+        max_total_bytes=max_total_bytes,
+        total_bytes_before=total_before,
+        total_bytes_after=total_after,
+    )
 
 
 def write_update_status_projection(
@@ -179,6 +372,30 @@ def snapshot_orchestration_db(
     return snapshot
 
 
+def snapshot_orchestration_db_transaction(
+    hub_root: Path,
+    *,
+    snapshot_root: Path,
+    run_id: str,
+    max_snapshots: int | None = _DEFAULT_MAX_SNAPSHOTS,
+    max_age_seconds: int | None = _DEFAULT_MAX_AGE_DAYS * 24 * 60 * 60,
+    max_total_bytes: int | None = _DEFAULT_MAX_TOTAL_BYTES,
+) -> UpdateSnapshotTransaction:
+    snapshot = snapshot_orchestration_db(
+        hub_root,
+        snapshot_root=snapshot_root,
+        run_id=run_id,
+    )
+    prune = prune_update_snapshots(
+        snapshot_root,
+        current_run_id=run_id,
+        max_snapshots=max_snapshots,
+        max_age_seconds=max_age_seconds,
+        max_total_bytes=max_total_bytes,
+    )
+    return UpdateSnapshotTransaction(snapshot=snapshot, prune=prune)
+
+
 def restore_orchestration_db_snapshot(snapshot_dir: Path) -> OrchestrationDbSnapshot:
     metadata_path = snapshot_dir / _SNAPSHOT_METADATA
     metadata = _read_json(metadata_path)
@@ -255,6 +472,39 @@ def _build_parser() -> argparse.ArgumentParser:
     snapshot.add_argument("--hub-root", required=True)
     snapshot.add_argument("--snapshot-root", required=True)
     snapshot.add_argument("--run-id", required=True)
+    snapshot.add_argument(
+        "--max-snapshots",
+        type=int,
+        default=_DEFAULT_MAX_SNAPSHOTS,
+        help=(
+            "Maximum update snapshot directories to retain. "
+            "Use 0 to disable count pruning."
+        ),
+    )
+    snapshot.add_argument(
+        "--max-age-days",
+        type=float,
+        default=float(_DEFAULT_MAX_AGE_DAYS),
+        help="Maximum snapshot age in days. Use 0 to disable age pruning.",
+    )
+    snapshot.add_argument(
+        "--max-total-bytes",
+        type=int,
+        default=_DEFAULT_MAX_TOTAL_BYTES,
+        help=(
+            "Maximum total bytes under the update snapshot root. "
+            "Use 0 to disable byte-budget pruning."
+        ),
+    )
+
+    prune = sub.add_parser("prune-snapshots", help="Prune update snapshot history.")
+    prune.add_argument("--snapshot-root", required=True)
+    prune.add_argument("--current-run-id")
+    prune.add_argument("--max-snapshots", type=int, default=_DEFAULT_MAX_SNAPSHOTS)
+    prune.add_argument(
+        "--max-age-days", type=float, default=float(_DEFAULT_MAX_AGE_DAYS)
+    )
+    prune.add_argument("--max-total-bytes", type=int, default=_DEFAULT_MAX_TOTAL_BYTES)
 
     restore = sub.add_parser("restore-db", help="Restore an orchestration DB snapshot.")
     restore.add_argument("--snapshot-dir", required=True)
@@ -286,12 +536,36 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "snapshot-db":
-        snapshot = snapshot_orchestration_db(
+        max_age_seconds = (
+            int(args.max_age_days * 24 * 60 * 60)
+            if args.max_age_days is not None
+            else None
+        )
+        transaction = snapshot_orchestration_db_transaction(
             Path(args.hub_root),
             snapshot_root=Path(args.snapshot_root),
             run_id=args.run_id,
+            max_snapshots=args.max_snapshots,
+            max_age_seconds=max_age_seconds,
+            max_total_bytes=args.max_total_bytes,
         )
-        print(json.dumps(snapshot.to_dict(), sort_keys=True))
+        print(json.dumps(transaction.to_dict(), sort_keys=True))
+        return 0
+
+    if args.command == "prune-snapshots":
+        max_age_seconds = (
+            int(args.max_age_days * 24 * 60 * 60)
+            if args.max_age_days is not None
+            else None
+        )
+        prune = prune_update_snapshots(
+            Path(args.snapshot_root),
+            current_run_id=args.current_run_id,
+            max_snapshots=args.max_snapshots,
+            max_age_seconds=max_age_seconds,
+            max_total_bytes=args.max_total_bytes,
+        )
+        print(json.dumps(prune.to_dict(), sort_keys=True))
         return 0
 
     if args.command == "restore-db":

--- a/src/codex_autorunner/core/update_transaction.py
+++ b/src/codex_autorunner/core/update_transaction.py
@@ -28,9 +28,7 @@ _MAX_PHASE_TIMINGS = 24
 
 _ORCHESTRATION_DB_SUFFIXES = ("", "-wal", "-shm")
 _SNAPSHOT_METADATA = "snapshot.json"
-_DEFAULT_MAX_SNAPSHOTS = 5
-_DEFAULT_MAX_AGE_DAYS = 14
-_DEFAULT_MAX_TOTAL_BYTES = 5 * 1024 * 1024 * 1024
+_DEFAULT_MAX_SNAPSHOTS = 1
 
 OpenFileChecker = Callable[[Path], bool]
 
@@ -70,10 +68,6 @@ class UpdateSnapshotPruneResult:
     skipped_open: tuple[str, ...]
     skipped_invalid: tuple[str, ...]
     max_snapshots: int | None
-    max_age_seconds: int | None
-    max_total_bytes: int | None
-    total_bytes_before: int
-    total_bytes_after: int
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -83,7 +77,6 @@ class UpdateSnapshotPruneResult:
 class UpdateSnapshotDirectory:
     path: Path
     created_at: float
-    size_bytes: int
 
 
 @dataclass(frozen=True)
@@ -103,17 +96,6 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     except (OSError, json.JSONDecodeError):
         return None
     return parsed if isinstance(parsed, dict) else None
-
-
-def _directory_size(path: Path) -> int:
-    total = 0
-    for item in path.rglob("*"):
-        try:
-            if item.is_file() or item.is_symlink():
-                total += item.lstat().st_size
-        except OSError:
-            continue
-    return total
 
 
 def _snapshot_created_at(path: Path) -> float:
@@ -168,7 +150,6 @@ def collect_update_snapshots(
                 UpdateSnapshotDirectory(
                     path=child,
                     created_at=_snapshot_created_at(child),
-                    size_bytes=_directory_size(child),
                 )
             )
         except OSError:
@@ -181,21 +162,14 @@ def prune_update_snapshots(
     *,
     current_run_id: str | None = None,
     max_snapshots: int | None = _DEFAULT_MAX_SNAPSHOTS,
-    max_age_seconds: int | None = _DEFAULT_MAX_AGE_DAYS * 24 * 60 * 60,
-    max_total_bytes: int | None = _DEFAULT_MAX_TOTAL_BYTES,
-    now: float | None = None,
     open_file_checker: OpenFileChecker | None = None,
 ) -> UpdateSnapshotPruneResult:
     max_snapshots = _positive_int_or_none(max_snapshots)
-    max_age_seconds = _positive_int_or_none(max_age_seconds)
-    max_total_bytes = _positive_int_or_none(max_total_bytes)
-    now = time.time() if now is None else now
     open_file_checker = (
         _has_open_files if open_file_checker is None else open_file_checker
     )
 
     snapshots, skipped_invalid = collect_update_snapshots(snapshot_root)
-    total_before = sum(snapshot.size_bytes for snapshot in snapshots)
 
     snapshots_by_age = sorted(
         snapshots,
@@ -211,29 +185,8 @@ def prune_update_snapshots(
             if snapshot.path not in protected:
                 prune_paths.add(snapshot.path)
 
-    if max_age_seconds is not None:
-        oldest_allowed = now - max_age_seconds
-        for snapshot in snapshots:
-            if snapshot.created_at < oldest_allowed and snapshot.path not in protected:
-                prune_paths.add(snapshot.path)
-
-    if max_total_bytes is not None:
-        retained_bytes = total_before - sum(
-            snapshot.size_bytes
-            for snapshot in snapshots
-            if snapshot.path in prune_paths
-        )
-        for snapshot in reversed(snapshots_by_age):
-            if retained_bytes <= max_total_bytes:
-                break
-            if snapshot.path in protected or snapshot.path in prune_paths:
-                continue
-            prune_paths.add(snapshot.path)
-            retained_bytes -= snapshot.size_bytes
-
     pruned: list[str] = []
     skipped_open: list[str] = []
-    size_by_path = {snapshot.path: snapshot.size_bytes for snapshot in snapshots}
     for path in sorted(prune_paths):
         if open_file_checker(path):
             skipped_open.append(str(path))
@@ -243,7 +196,6 @@ def prune_update_snapshots(
         kept_paths.discard(path)
 
     kept = tuple(str(path) for path in sorted(kept_paths))
-    total_after = total_before - sum(size_by_path.get(Path(path), 0) for path in pruned)
     return UpdateSnapshotPruneResult(
         snapshot_root=str(snapshot_root),
         kept=kept,
@@ -251,10 +203,6 @@ def prune_update_snapshots(
         skipped_open=tuple(skipped_open),
         skipped_invalid=skipped_invalid,
         max_snapshots=max_snapshots,
-        max_age_seconds=max_age_seconds,
-        max_total_bytes=max_total_bytes,
-        total_bytes_before=total_before,
-        total_bytes_after=total_after,
     )
 
 
@@ -380,8 +328,6 @@ def snapshot_orchestration_db_transaction(
     snapshot_root: Path,
     run_id: str,
     max_snapshots: int | None = _DEFAULT_MAX_SNAPSHOTS,
-    max_age_seconds: int | None = _DEFAULT_MAX_AGE_DAYS * 24 * 60 * 60,
-    max_total_bytes: int | None = _DEFAULT_MAX_TOTAL_BYTES,
 ) -> UpdateSnapshotTransaction:
     snapshot = snapshot_orchestration_db(
         hub_root,
@@ -392,8 +338,6 @@ def snapshot_orchestration_db_transaction(
         snapshot_root,
         current_run_id=run_id,
         max_snapshots=max_snapshots,
-        max_age_seconds=max_age_seconds,
-        max_total_bytes=max_total_bytes,
     )
     return UpdateSnapshotTransaction(snapshot=snapshot, prune=prune)
 
@@ -483,30 +427,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "Use 0 to disable count pruning."
         ),
     )
-    snapshot.add_argument(
-        "--max-age-days",
-        type=float,
-        default=float(_DEFAULT_MAX_AGE_DAYS),
-        help="Maximum snapshot age in days. Use 0 to disable age pruning.",
-    )
-    snapshot.add_argument(
-        "--max-total-bytes",
-        type=int,
-        default=_DEFAULT_MAX_TOTAL_BYTES,
-        help=(
-            "Maximum total bytes under the update snapshot root. "
-            "Use 0 to disable byte-budget pruning."
-        ),
-    )
-
     prune = sub.add_parser("prune-snapshots", help="Prune update snapshot history.")
     prune.add_argument("--snapshot-root", required=True)
     prune.add_argument("--current-run-id")
     prune.add_argument("--max-snapshots", type=int, default=_DEFAULT_MAX_SNAPSHOTS)
-    prune.add_argument(
-        "--max-age-days", type=float, default=float(_DEFAULT_MAX_AGE_DAYS)
-    )
-    prune.add_argument("--max-total-bytes", type=int, default=_DEFAULT_MAX_TOTAL_BYTES)
 
     restore = sub.add_parser("restore-db", help="Restore an orchestration DB snapshot.")
     restore.add_argument("--snapshot-dir", required=True)
@@ -538,34 +462,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "snapshot-db":
-        max_age_seconds = (
-            int(args.max_age_days * 24 * 60 * 60)
-            if args.max_age_days is not None
-            else None
-        )
         transaction = snapshot_orchestration_db_transaction(
             Path(args.hub_root),
             snapshot_root=Path(args.snapshot_root),
             run_id=args.run_id,
             max_snapshots=args.max_snapshots,
-            max_age_seconds=max_age_seconds,
-            max_total_bytes=args.max_total_bytes,
         )
         print(json.dumps(transaction.to_dict(), sort_keys=True))
         return 0
 
     if args.command == "prune-snapshots":
-        max_age_seconds = (
-            int(args.max_age_days * 24 * 60 * 60)
-            if args.max_age_days is not None
-            else None
-        )
         prune = prune_update_snapshots(
             Path(args.snapshot_root),
             current_run_id=args.current_run_id,
             max_snapshots=args.max_snapshots,
-            max_age_seconds=max_age_seconds,
-            max_total_bytes=args.max_total_bytes,
         )
         print(json.dumps(prune.to_dict(), sort_keys=True))
         return 0

--- a/src/codex_autorunner/core/update_transaction.py
+++ b/src/codex_autorunner/core/update_transaction.py
@@ -131,7 +131,7 @@ def _snapshot_created_at(path: Path) -> float:
 def _has_open_files(path: Path) -> bool:
     lsof = resolve_executable("lsof")
     if lsof is None:
-        return False
+        return True
     try:
         completed = subprocess.run(
             [lsof, "+D", str(path)],
@@ -141,6 +141,8 @@ def _has_open_files(path: Path) -> bool:
             timeout=10,
         )
     except (OSError, subprocess.TimeoutExpired):
+        return True
+    if completed.returncode not in (0, 1):
         return True
     return completed.returncode == 0
 

--- a/src/codex_autorunner/core/update_transaction.py
+++ b/src/codex_autorunner/core/update_transaction.py
@@ -98,16 +98,15 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-def _snapshot_created_at(path: Path) -> float:
+def _snapshot_created_at(path: Path) -> float | None:
     metadata = _read_json(path / "orchestration" / _SNAPSHOT_METADATA)
-    if metadata is not None:
-        try:
-            created_at = float(metadata.get("created_at") or 0.0)
-        except (TypeError, ValueError):
-            created_at = 0.0
-        if created_at > 0:
-            return created_at
-    return path.stat().st_mtime
+    if metadata is None:
+        return None
+    try:
+        created_at = float(metadata.get("created_at") or 0.0)
+    except (TypeError, ValueError):
+        return None
+    return created_at if created_at > 0 else None
 
 
 def _has_open_files(path: Path) -> bool:
@@ -146,10 +145,14 @@ def collect_update_snapshots(
             skipped_invalid.append(str(child))
             continue
         try:
+            created_at = _snapshot_created_at(child)
+            if created_at is None:
+                skipped_invalid.append(str(child))
+                continue
             snapshots.append(
                 UpdateSnapshotDirectory(
                     path=child,
-                    created_at=_snapshot_created_at(child),
+                    created_at=created_at,
                 )
             )
         except OSError:

--- a/tests/test_safe_refresh_local_mac_hub_script.py
+++ b/tests/test_safe_refresh_local_mac_hub_script.py
@@ -23,7 +23,7 @@ def test_safe_refresh_local_mac_hub_voice_provider_prefers_config_over_env(
         encoding="utf-8",
     )
     (car_dir / "config.yml").write_text(
-        "repo_defaults:\n" "  voice:\n" "    provider: mlx_whisper\n",
+        "repo_defaults:\n  voice:\n    provider: mlx_whisper\n",
         encoding="utf-8",
     )
 
@@ -106,3 +106,14 @@ def test_safe_refresh_local_mac_hub_script_uses_pip_cache_for_dependencies() -> 
         "\n}\n", 1
     )[0]
     assert "--no-cache-dir" not in install_function
+
+
+def test_safe_refresh_local_mac_hub_script_bounds_update_snapshots() -> None:
+    script = Path("scripts/safe-refresh-local-mac-hub.sh").read_text(encoding="utf-8")
+
+    assert "UPDATE_SNAPSHOT_MAX_COUNT" in script
+    assert "UPDATE_SNAPSHOT_MAX_AGE_DAYS" in script
+    assert "UPDATE_SNAPSHOT_MAX_TOTAL_BYTES" in script
+    assert "--max-snapshots" in script
+    assert "--max-age-days" in script
+    assert "--max-total-bytes" in script

--- a/tests/test_safe_refresh_local_mac_hub_script.py
+++ b/tests/test_safe_refresh_local_mac_hub_script.py
@@ -112,8 +112,8 @@ def test_safe_refresh_local_mac_hub_script_bounds_update_snapshots() -> None:
     script = Path("scripts/safe-refresh-local-mac-hub.sh").read_text(encoding="utf-8")
 
     assert "UPDATE_SNAPSHOT_MAX_COUNT" in script
-    assert "UPDATE_SNAPSHOT_MAX_AGE_DAYS" in script
-    assert "UPDATE_SNAPSHOT_MAX_TOTAL_BYTES" in script
     assert "--max-snapshots" in script
-    assert "--max-age-days" in script
-    assert "--max-total-bytes" in script
+    assert "UPDATE_SNAPSHOT_MAX_AGE_DAYS" not in script
+    assert "UPDATE_SNAPSHOT_MAX_TOTAL_BYTES" not in script
+    assert "--max-age-days" not in script
+    assert "--max-total-bytes" not in script

--- a/tests/test_update_transaction.py
+++ b/tests/test_update_transaction.py
@@ -11,9 +11,11 @@ from codex_autorunner.core.orchestration.sqlite import (
     resolve_orchestration_sqlite_path,
 )
 from codex_autorunner.core.update_transaction import (
+    prune_update_snapshots,
     read_orchestration_schema_info,
     restore_orchestration_db_snapshot,
     snapshot_orchestration_db,
+    snapshot_orchestration_db_transaction,
     write_update_status_projection,
 )
 
@@ -166,3 +168,141 @@ def test_orchestration_db_snapshot_restore_removes_new_db_when_absent(
     restore_orchestration_db_snapshot(Path(snapshot.snapshot_dir))
 
     assert not db_path.exists()
+
+
+def _write_update_snapshot(
+    snapshot_root: Path,
+    run_id: str,
+    *,
+    created_at: float,
+    bytes_count: int,
+) -> Path:
+    snapshot_dir = snapshot_root / run_id / "orchestration"
+    snapshot_dir.mkdir(parents=True)
+    (snapshot_dir / "orchestration.sqlite3").write_bytes(b"x" * bytes_count)
+    (snapshot_dir / "snapshot.json").write_text(
+        json.dumps(
+            {
+                "snapshot_dir": str(snapshot_dir),
+                "hub_root": "/hub",
+                "db_path": "/hub/.codex-autorunner/orchestration.sqlite3",
+                "db_existed": True,
+                "copied_files": ["orchestration.sqlite3"],
+                "current_schema": 1,
+                "supported_schema": 1,
+                "created_at": created_at,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return snapshot_root / run_id
+
+
+def test_prune_update_snapshots_bounds_count_and_age(
+    tmp_path: Path,
+) -> None:
+    snapshot_root = tmp_path / "update_snapshots"
+    _write_update_snapshot(
+        snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=9
+    )
+    current = _write_update_snapshot(
+        snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=9
+    )
+    _write_update_snapshot(
+        snapshot_root, "20260603-000000-3", created_at=300.0, bytes_count=9
+    )
+    _write_update_snapshot(
+        snapshot_root, "20260604-000000-4", created_at=400.0, bytes_count=9
+    )
+
+    result = prune_update_snapshots(
+        snapshot_root,
+        current_run_id=current.name,
+        max_snapshots=1,
+        max_age_seconds=250,
+        max_total_bytes=0,
+        now=500.0,
+        open_file_checker=lambda _path: False,
+    )
+
+    assert current.exists()
+    assert sorted(path.name for path in snapshot_root.iterdir()) == [
+        "20260602-000000-2",
+        "20260604-000000-4",
+    ]
+    assert len(result.pruned) == 2
+
+
+def test_prune_update_snapshots_enforces_total_byte_budget(
+    tmp_path: Path,
+) -> None:
+    snapshot_root = tmp_path / "update_snapshots"
+    oldest = _write_update_snapshot(
+        snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=10_000
+    )
+    newest = _write_update_snapshot(
+        snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=10_000
+    )
+
+    result = prune_update_snapshots(
+        snapshot_root,
+        max_snapshots=0,
+        max_age_seconds=0,
+        max_total_bytes=15_000,
+        now=500.0,
+        open_file_checker=lambda _path: False,
+    )
+
+    assert not oldest.exists()
+    assert newest.exists()
+    assert result.pruned == (str(oldest),)
+
+
+def test_prune_update_snapshots_skips_directories_with_open_files(
+    tmp_path: Path,
+) -> None:
+    snapshot_root = tmp_path / "update_snapshots"
+    open_snapshot = _write_update_snapshot(
+        snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=1
+    )
+    _write_update_snapshot(
+        snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=1
+    )
+
+    result = prune_update_snapshots(
+        snapshot_root,
+        max_snapshots=1,
+        max_age_seconds=0,
+        max_total_bytes=0,
+        now=500.0,
+        open_file_checker=lambda path: path == open_snapshot,
+    )
+
+    assert open_snapshot.exists()
+    assert result.pruned == ()
+    assert result.skipped_open == (str(open_snapshot),)
+
+
+def test_snapshot_orchestration_db_transaction_reports_prune_result(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    db_path.parent.mkdir(parents=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE marker (value TEXT)")
+
+    snapshot_root = tmp_path / "update_snapshots"
+    _write_update_snapshot(snapshot_root, "old-run", created_at=100.0, bytes_count=1)
+
+    transaction = snapshot_orchestration_db_transaction(
+        hub_root,
+        snapshot_root=snapshot_root,
+        run_id="new-run",
+        max_snapshots=1,
+        max_age_seconds=0,
+        max_total_bytes=0,
+    )
+
+    assert Path(transaction.snapshot.snapshot_dir).exists()
+    assert transaction.prune.pruned == (str(snapshot_root / "old-run"),)

--- a/tests/test_update_transaction.py
+++ b/tests/test_update_transaction.py
@@ -198,64 +198,59 @@ def _write_update_snapshot(
     return snapshot_root / run_id
 
 
-def test_prune_update_snapshots_bounds_count_and_age(
+def test_prune_update_snapshots_keeps_one_newest_snapshot(
     tmp_path: Path,
 ) -> None:
     snapshot_root = tmp_path / "update_snapshots"
     _write_update_snapshot(
         snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=9
     )
-    current = _write_update_snapshot(
+    _write_update_snapshot(
         snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=9
     )
     _write_update_snapshot(
         snapshot_root, "20260603-000000-3", created_at=300.0, bytes_count=9
     )
+
+    result = prune_update_snapshots(
+        snapshot_root,
+        max_snapshots=1,
+        open_file_checker=lambda _path: False,
+    )
+
+    assert sorted(path.name for path in snapshot_root.iterdir()) == [
+        "20260603-000000-3",
+    ]
+    assert len(result.pruned) == 2
+
+
+def test_prune_update_snapshots_protects_current_run(
+    tmp_path: Path,
+) -> None:
+    snapshot_root = tmp_path / "update_snapshots"
+    current = _write_update_snapshot(
+        snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=9
+    )
     _write_update_snapshot(
-        snapshot_root, "20260604-000000-4", created_at=400.0, bytes_count=9
+        snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=9
+    )
+    _write_update_snapshot(
+        snapshot_root, "20260603-000000-3", created_at=300.0, bytes_count=9
     )
 
     result = prune_update_snapshots(
         snapshot_root,
         current_run_id=current.name,
         max_snapshots=1,
-        max_age_seconds=250,
-        max_total_bytes=0,
-        now=500.0,
         open_file_checker=lambda _path: False,
     )
 
     assert current.exists()
     assert sorted(path.name for path in snapshot_root.iterdir()) == [
-        "20260602-000000-2",
-        "20260604-000000-4",
+        "20260601-000000-1",
+        "20260603-000000-3",
     ]
-    assert len(result.pruned) == 2
-
-
-def test_prune_update_snapshots_enforces_total_byte_budget(
-    tmp_path: Path,
-) -> None:
-    snapshot_root = tmp_path / "update_snapshots"
-    oldest = _write_update_snapshot(
-        snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=10_000
-    )
-    newest = _write_update_snapshot(
-        snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=10_000
-    )
-
-    result = prune_update_snapshots(
-        snapshot_root,
-        max_snapshots=0,
-        max_age_seconds=0,
-        max_total_bytes=15_000,
-        now=500.0,
-        open_file_checker=lambda _path: False,
-    )
-
-    assert not oldest.exists()
-    assert newest.exists()
-    assert result.pruned == (str(oldest),)
+    assert result.pruned == (str(snapshot_root / "20260602-000000-2"),)
 
 
 def test_prune_update_snapshots_skips_directories_with_open_files(
@@ -272,9 +267,6 @@ def test_prune_update_snapshots_skips_directories_with_open_files(
     result = prune_update_snapshots(
         snapshot_root,
         max_snapshots=1,
-        max_age_seconds=0,
-        max_total_bytes=0,
-        now=500.0,
         open_file_checker=lambda path: path == open_snapshot,
     )
 
@@ -300,8 +292,6 @@ def test_snapshot_orchestration_db_transaction_reports_prune_result(
         snapshot_root=snapshot_root,
         run_id="new-run",
         max_snapshots=1,
-        max_age_seconds=0,
-        max_total_bytes=0,
     )
 
     assert Path(transaction.snapshot.snapshot_dir).exists()

--- a/tests/test_update_transaction.py
+++ b/tests/test_update_transaction.py
@@ -275,6 +275,41 @@ def test_prune_update_snapshots_skips_directories_with_open_files(
     assert result.skipped_open == (str(open_snapshot),)
 
 
+def test_prune_update_snapshots_requires_snapshot_metadata(
+    tmp_path: Path,
+) -> None:
+    snapshot_root = tmp_path / "update_snapshots"
+    unrelated_state = snapshot_root / "workspaces"
+    unrelated_state.mkdir(parents=True)
+    (unrelated_state / "state.sqlite3").write_text("keep", encoding="utf-8")
+    malformed_snapshot = snapshot_root / "malformed"
+    (malformed_snapshot / "orchestration").mkdir(parents=True)
+    (malformed_snapshot / "orchestration" / "snapshot.json").write_text(
+        '{"created_at": "not-a-number"}',
+        encoding="utf-8",
+    )
+    _write_update_snapshot(
+        snapshot_root, "20260601-000000-1", created_at=100.0, bytes_count=1
+    )
+    _write_update_snapshot(
+        snapshot_root, "20260602-000000-2", created_at=200.0, bytes_count=1
+    )
+
+    result = prune_update_snapshots(
+        snapshot_root,
+        max_snapshots=1,
+        open_file_checker=lambda _path: False,
+    )
+
+    assert unrelated_state.exists()
+    assert malformed_snapshot.exists()
+    assert sorted(Path(path).name for path in result.skipped_invalid) == [
+        "malformed",
+        "workspaces",
+    ]
+    assert result.pruned == (str(snapshot_root / "20260601-000000-1"),)
+
+
 def test_snapshot_orchestration_db_transaction_reports_prune_result(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- prune update snapshot history after macOS safe-refresh creates the rollback DB snapshot
- default to keeping only one update snapshot directory, which is the rollback snapshot needed for the current update path
- keep a single `UPDATE_SNAPSHOT_MAX_COUNT` / `--max-snapshots` override for operators who explicitly want more or want to disable pruning with `0`
- add a manual `prune-snapshots` helper plus docs for inspecting and pruning `~/.codex-autorunner/update_snapshots`

## Root Cause
The macOS update path created timestamped rollback snapshots under `update_snapshots` but never removed old successful-run snapshots, so repeated updates could accumulate full orchestration DB copies without bound.

## Safety
Pruning only considers direct children of the configured update snapshot root. It protects the current update run and skips deletion when `lsof` reports open files or cannot prove the directory is closed.

## Validation
- `.venv/bin/python -m pytest -q tests/test_update_transaction.py tests/test_safe_refresh_local_mac_hub_script.py tests/test_system_update_worker.py`
- pre-commit aggregate lane: guardrails, mypy, full pytest suite (`9677 passed`), Web Hub lint/build/tests, SPA shell check

Closes #2017
