### PR TITLE
[codex] Remove redundant repo detail actions

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeDetail.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeDetail.svelte
@@ -292,18 +292,15 @@
       <section class="page-panel execution-panel wide workspace-ticket-queue-panel">
         <div class="panel-heading-row">
           <h2>{detail.kind === 'worktree' ? 'Worktree tickets' : 'Repo tickets'}</h2>
-          <div class="panel-heading-actions">
-            <a
-              class="ghost-button is-primary"
-              href={href(detail.newTicketHref)}
-              data-sveltekit-preload-data="tap"
-            >+ New ticket</a>
-            <a
-              class="ghost-button"
-              href={href(detail.ticketIndexHref)}
-              data-sveltekit-preload-data="tap"
-            >All tickets</a>
-          </div>
+          {#if detail.ticketOverview.total === 0}
+            <div class="panel-heading-actions">
+              <a
+                class="ghost-button"
+                href={href(detail.ticketIndexHref)}
+                data-sveltekit-preload-data="tap"
+              >All tickets</a>
+            </div>
+          {/if}
         </div>
         {@render degradedIssues(ticketIssues)}
         {#if detail.ticketOverview.total > 0}
@@ -334,16 +331,13 @@
               </a>
             {/each}
             {#if detail.ticketOverview.remaining > 0}
-              <a class="ticket-overview-more" href={href(detail.ticketIndexHref)}>
+              <span class="ticket-overview-more" aria-label={`${detail.ticketOverview.remaining} more open tickets`}>
                 +{detail.ticketOverview.remaining} more open ticket{detail.ticketOverview.remaining === 1 ? '' : 's'}
-              </a>
+              </span>
             {/if}
           {:else if ticketIssues.length === 0 && detail.ticketOverview.total === 0}
             <div class="panel-empty-card" role="status">
               <p class="panel-empty-card-title">No tickets yet for this {detail.kind}.</p>
-              <div class="panel-empty-card-actions">
-                <a class="ghost-button is-primary" href={href(detail.newTicketHref)} data-sveltekit-preload-data="tap">+ New ticket</a>
-              </div>
             </div>
           {/if}
         </div>
@@ -358,18 +352,10 @@
               Chats<span class="panel-heading-link-chevron" aria-hidden="true">→</span>
             </a>
           </h2>
-          <div class="panel-heading-actions">
-            <a class="ghost-button" href={href(detail.chatHref)} data-sveltekit-preload-data="tap">New chat</a>
-            <a class="ghost-button" href={href(detail.codingAgentChatHref)} data-sveltekit-preload-data="tap">New coding agent chat</a>
-          </div>
         </div>
         {#if detail.chatList.totalChatCount === 0}
           <div class="panel-empty-card" role="status">
             <p class="panel-empty-card-title">No chats scoped to this {detail.kind} yet.</p>
-            <div class="panel-empty-card-actions">
-              <a class="ghost-button is-primary" href={href(detail.chatHref)} data-sveltekit-preload-data="tap">+ New chat</a>
-              <a class="ghost-button" href={href(detail.codingAgentChatHref)} data-sveltekit-preload-data="tap">+ New coding agent chat</a>
-            </div>
           </div>
         {/if}
         {#if detail.chatList.totalChatCount > 0}

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.test.ts
@@ -149,6 +149,9 @@ describe('RepoWorktreeViews', () => {
     expect(body).toContain('Surfaced artifacts');
     expect(body).toContain('Chats');
     expect(body).toContain('configured model');
+    expect(body.match(/\+ New chat/g)).toHaveLength(1);
+    expect(body.match(/\+ New ticket/g)).toHaveLength(1);
+    expect(body).not.toContain('New coding agent chat');
     expect(body).not.toContain('Child worktrees');
     expect(body).not.toContain('Activity');
     expect(body).not.toContain('Open chat');
@@ -209,6 +212,9 @@ describe('RepoWorktreeViews', () => {
     expect(body).toContain('href="/repos/repo-1/contextspace"');
     expect(body).toContain('Chats');
     expect(body).toContain('href="/chats?new=repo:repo-1&amp;kind=pma"');
+    expect(body.match(/\+ New chat/g)).toHaveLength(1);
+    expect(body.match(/\+ New ticket/g)).toHaveLength(1);
+    expect(body).not.toContain('New coding agent chat');
     expect(body).not.toContain('Terminal');
     expect(body).not.toContain('Analytics');
     const tickets = body.indexOf('Repo tickets');

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
@@ -35,7 +35,6 @@ function makeChildRow(overrides: Partial<RepoWorktreeChildRow> = {}): RepoWorktr
     href: '/repos/r/worktrees/wt',
     ticketHref: null,
     chatHref: '/chats',
-    codingAgentChatHref: '/chats',
     signalWaiting: 0,
     signalFailed: 0,
     signalActive: 0,
@@ -134,7 +133,6 @@ describe('repo/worktree view models', () => {
       totalTickets: 1,
       doneTickets: 0,
       chatHref: '/chats?new=repo:repo-1&kind=pma',
-      codingAgentChatHref: '/chats?new=repo:repo-1&kind=agent',
       signalWaiting: 0,
       signalFailed: 0,
       signalActive: 0,
@@ -143,7 +141,6 @@ describe('repo/worktree view models', () => {
           id: 'worktree-1',
           href: '/repos/repo-1/worktrees/worktree-1',
           chatHref: '/chats?new=worktree:worktree-1&kind=pma',
-          codingAgentChatHref: '/chats?new=worktree:worktree-1&kind=agent',
           status: 'running',
           activeRuns: 1,
           lastActivityAt: '2026-05-04T00:02:00Z',
@@ -333,15 +330,13 @@ describe('repo/worktree view models', () => {
     expect(vm.rows[0]).toMatchObject({
       id: 'repo-1',
       chatHref: '/chats?new=repo:repo-1&kind=pma',
-      codingAgentChatHref: '/chats?new=repo:repo-1&kind=agent',
       signalWaiting: 0,
       signalFailed: 0,
       signalActive: 0,
       childWorktrees: [
         {
           id: 'worktree-1',
-          chatHref: '/chats?new=worktree:worktree-1&kind=pma',
-          codingAgentChatHref: '/chats?new=worktree:worktree-1&kind=agent'
+          chatHref: '/chats?new=worktree:worktree-1&kind=pma'
         }
       ]
     });
@@ -351,7 +346,6 @@ describe('repo/worktree view models', () => {
       repoHref: '/repos/missing-repo',
       ticketHref: '/repos/missing-repo/worktrees/orphan-worktree/tickets',
       chatHref: '/chats?new=worktree:orphan-worktree&kind=pma',
-      codingAgentChatHref: '/chats?new=worktree:orphan-worktree&kind=agent',
       signalWaiting: 0,
       signalFailed: 0,
       signalActive: 0,
@@ -379,7 +373,6 @@ describe('repo/worktree view models', () => {
       ticketHref: '/repos/repo-1/worktrees/worktree-1/tickets',
       repoHref: '/repos/repo-1',
       chatHref: '/chats?new=worktree:worktree-1&kind=pma',
-      codingAgentChatHref: '/chats?new=worktree:worktree-1&kind=agent',
       signalWaiting: 0,
       signalFailed: 0,
       signalActive: 0

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
@@ -65,8 +65,6 @@ export type RepoWorktreeIndexRow = {
   signalActive: number;
   /** Deep-link into chats with the new-chat scope picker preset for PMA mediation. */
   chatHref: string;
-  /** Deep-link into chats with the new-chat scope picker preset for direct agent control. */
-  codingAgentChatHref: string;
   hasCarState: boolean;
   unboundManagedThreadCount: number;
   chatBound: boolean;
@@ -107,8 +105,6 @@ export type RepoWorktreeChildRow = {
   ticketHref: string | null;
   /** Deep-link into chats with PMA mediation scoped to this worktree. */
   chatHref: string;
-  /** Deep-link into chats with direct agent control scoped to this worktree. */
-  codingAgentChatHref: string;
   /** chats + ticket-flow runs scoped to this worktree. */
   signalWaiting: number;
   signalFailed: number;
@@ -348,7 +344,6 @@ export type RepoWorktreeDetailViewModel = {
   missingIndexHref: string;
   missingIndexLabel: string;
   chatHref: string;
-  codingAgentChatHref: string;
   /** Chats list URL filtered to this detail's scope kind. */
   scopedChatListHref: string;
   /** "+ New ticket" URL for the scoped tickets/new route. */
@@ -520,7 +515,6 @@ export function buildRepoWorktreeDetailViewModel(
     missingIndexHref: kind === 'repo' ? '/repos' : '/worktrees',
     missingIndexLabel: kind === 'repo' ? 'Back to repos' : 'Back to worktrees',
     chatHref: scopedNewChatRoute(kind, id, 'pma'),
-    codingAgentChatHref: scopedNewChatRoute(kind, id, 'agent'),
     scopedChatListHref: scopedChatListHrefForKind(kind),
     newTicketHref:
       scopedNewTicketRoute(kind, id, parentRepoId) ?? `${scopedTicketHref(kind, id, parentRepoId)}/new`,
@@ -591,7 +585,6 @@ function missingDetailViewModel(kind: RepoWorktreeKind, id: string): RepoWorktre
     missingIndexHref: kind === 'repo' ? '/repos' : '/worktrees',
     missingIndexLabel: kind === 'repo' ? 'Back to repos' : 'Back to worktrees',
     chatHref: '/chats',
-    codingAgentChatHref: '/chats',
     scopedChatListHref: scopedChatListHrefForKind(kind),
     newTicketHref: kind === 'repo' ? '/repos' : '/worktrees',
     gitStatus: null,
@@ -800,7 +793,6 @@ function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source:
     signalFailed: 0,
     signalActive: 0,
     chatHref: scopedNewChatRoute('repo', repo.id, 'pma'),
-    codingAgentChatHref: scopedNewChatRoute('repo', repo.id, 'agent'),
     hasCarState: boolFromRaw(repo.raw, 'has_car_state'),
     unboundManagedThreadCount: numberFromRaw(repo.raw, 'unbound_managed_thread_count'),
     chatBound: boolFromRaw(repo.raw, 'chat_bound'),
@@ -859,7 +851,6 @@ function worktreeToNavChildRow(
     href: worktreeRoute(worktree.id, worktree.repoId),
     ticketHref: worktreeTicketRoute(worktree.id, worktree.repoId),
     chatHref: scopedNewChatRoute('worktree', worktree.id, 'pma'),
-    codingAgentChatHref: scopedNewChatRoute('worktree', worktree.id, 'agent'),
     signalWaiting: signals.waiting,
     signalFailed: signals.failed,
     signalActive: signals.active,
@@ -907,7 +898,6 @@ function worktreeToIndexRow(worktree: WorktreeSummary, source: RepoWorktreeSourc
     signalFailed: 0,
     signalActive: 0,
     chatHref: scopedNewChatRoute('worktree', worktree.id, 'pma'),
-    codingAgentChatHref: scopedNewChatRoute('worktree', worktree.id, 'agent'),
     hasCarState: boolFromRaw(worktree.raw, 'has_car_state'),
     unboundManagedThreadCount: numberFromRaw(worktree.raw, 'unbound_managed_thread_count'),
     chatBound: boolFromRaw(worktree.raw, 'chat_bound'),


### PR DESCRIPTION
## Summary

- remove redundant repo/worktree detail-page creation buttons from lower Chats and Tickets panels
- keep a single hero-level `+ New chat` and `+ New ticket` ingress for scoped creation
- remove the unused direct coding-agent chat href from repo/worktree view models
- keep ticket-index navigation to one populated-state drilldown, with a fallback `All tickets` link only when no rollup exists

## Review

A subagent review found one remaining duplicate ticket-index ingress. This PR includes the follow-up fix: the populated ticket panel now uses the kanban strip as the single ticket-index link, and the overflow count is informational.

## Validation

- `pnpm web:test -- --run src/lib/components/RepoWorktreeViews.test.ts src/lib/viewModels/repoWorktree.test.ts`
- `pnpm web:test`
- `pnpm web:lint`
- pre-commit web-ui lane: passed, including guardrails, full pytest, Web UI lab fast check, Web Hub build, frontend tests, and SPA shell check

Note: the first pre-commit attempt hit a timing-sensitive unrelated core pytest failure in `test_runtime_thread_progress_stall_timeout_keeps_hard_wall_clock_by_default`; rerunning that single test passed, and the second full pre-commit run passed.
