### PR TITLE
[codex] derive public preview service URLs

### DIFF
--- a/src/codex_autorunner/core/preview_services/public_urls.py
+++ b/src/codex_autorunner/core/preview_services/public_urls.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from ..config_parsers import normalize_base_path
+from ..config_validation import is_loopback_host
+
+
+def resolve_public_hub_base_url(config: Any) -> str | None:
+    explicit = _explicit_public_base_url(config)
+    if explicit:
+        return explicit
+    derived = _public_base_url_from_allowed_origins(config)
+    if derived:
+        return derived
+    return None
+
+
+def resolve_user_facing_preview_url(config: Any, preview_url: str) -> str:
+    if preview_url.startswith(("http://", "https://")):
+        return preview_url
+    public_base = resolve_public_hub_base_url(config)
+    if public_base:
+        return urljoin(f"{public_base.rstrip('/')}/", preview_url.lstrip("/"))
+    return _base_path_relative_url(config, preview_url)
+
+
+def _explicit_public_base_url(config: Any) -> str | None:
+    env_value = os.environ.get("CAR_PREVIEW_PUBLIC_BASE_URL")
+    if env_value and env_value.strip():
+        return env_value.strip().rstrip("/")
+    preview_cfg = _preview_services_config(config)
+    for key in ("public_base_url", "publicBaseUrl", "base_url", "baseUrl"):
+        value = preview_cfg.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().rstrip("/")
+    for attr in ("public_base_url", "server_public_url", "external_url"):
+        value = getattr(config, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip().rstrip("/")
+    return None
+
+
+def _public_base_url_from_allowed_origins(config: Any) -> str | None:
+    origins = _server_allowed_origins(config)
+    candidates = [
+        candidate
+        for origin in origins
+        if (candidate := _origin_base(origin)) is not None
+    ]
+    https_candidates = [
+        candidate for candidate in candidates if candidate.startswith("https://")
+    ]
+    selected: str | None = None
+    if len(https_candidates) == 1:
+        selected = https_candidates[0]
+    elif len(candidates) == 1:
+        selected = candidates[0]
+    if selected is None:
+        return None
+    base_path = _server_base_path(config)
+    return f"{selected}{base_path}".rstrip("/")
+
+
+def _origin_base(origin: str) -> str | None:
+    value = origin.strip()
+    if not value:
+        return None
+    split = urlsplit(value)
+    if split.scheme not in {"http", "https"} or not split.netloc:
+        return None
+    hostname = split.hostname
+    if not hostname or is_loopback_host(hostname):
+        return None
+    return urlunsplit((split.scheme, split.netloc, "", "", "")).rstrip("/")
+
+
+def _base_path_relative_url(config: Any, preview_url: str) -> str:
+    if not preview_url.startswith("/"):
+        return preview_url
+    base_path = _server_base_path(config)
+    if (
+        not base_path
+        or preview_url == base_path
+        or preview_url.startswith(f"{base_path}/")
+    ):
+        return preview_url
+    return f"{base_path}{preview_url}"
+
+
+def _server_base_path(config: Any) -> str:
+    value = getattr(config, "server_base_path", None)
+    if not isinstance(value, str):
+        server_cfg = _server_config(config)
+        value = server_cfg.get("base_path") if isinstance(server_cfg, dict) else ""
+    return normalize_base_path(value or "")
+
+
+def _server_allowed_origins(config: Any) -> list[str]:
+    values = getattr(config, "server_allowed_origins", None)
+    if not isinstance(values, list):
+        server_cfg = _server_config(config)
+        values = (
+            server_cfg.get("allowed_origins") if isinstance(server_cfg, dict) else []
+        )
+    if not isinstance(values, list):
+        return []
+    return [value for value in values if isinstance(value, str)]
+
+
+def _preview_services_config(config: Any) -> dict[str, Any]:
+    preview_cfg = getattr(config, "preview_services", None)
+    if not isinstance(preview_cfg, dict):
+        raw_cfg = getattr(config, "raw", None)
+        preview_cfg = (
+            raw_cfg.get("preview_services") if isinstance(raw_cfg, dict) else None
+        )
+    return preview_cfg if isinstance(preview_cfg, dict) else {}
+
+
+def _server_config(config: Any) -> dict[str, Any]:
+    raw_cfg = getattr(config, "raw", None)
+    server_cfg = raw_cfg.get("server") if isinstance(raw_cfg, dict) else None
+    return server_cfg if isinstance(server_cfg, dict) else {}

--- a/src/codex_autorunner/core/preview_services/public_urls.py
+++ b/src/codex_autorunner/core/preview_services/public_urls.py
@@ -8,23 +8,33 @@ from ..config_parsers import normalize_base_path
 from ..config_validation import is_loopback_host
 
 
-def resolve_public_hub_base_url(config: Any) -> str | None:
+def resolve_public_hub_base_url(
+    config: Any, *, base_path_override: str | None = None
+) -> str | None:
     explicit = _explicit_public_base_url(config)
     if explicit:
         return explicit
-    derived = _public_base_url_from_allowed_origins(config)
+    derived = _public_base_url_from_allowed_origins(
+        config, base_path_override=base_path_override
+    )
     if derived:
         return derived
     return None
 
 
-def resolve_user_facing_preview_url(config: Any, preview_url: str) -> str:
+def resolve_user_facing_preview_url(
+    config: Any, preview_url: str, *, base_path_override: str | None = None
+) -> str:
     if preview_url.startswith(("http://", "https://")):
         return preview_url
-    public_base = resolve_public_hub_base_url(config)
+    public_base = resolve_public_hub_base_url(
+        config, base_path_override=base_path_override
+    )
     if public_base:
         return urljoin(f"{public_base.rstrip('/')}/", preview_url.lstrip("/"))
-    return _base_path_relative_url(config, preview_url)
+    return _base_path_relative_url(
+        config, preview_url, base_path_override=base_path_override
+    )
 
 
 def _explicit_public_base_url(config: Any) -> str | None:
@@ -43,13 +53,17 @@ def _explicit_public_base_url(config: Any) -> str | None:
     return None
 
 
-def _public_base_url_from_allowed_origins(config: Any) -> str | None:
+def _public_base_url_from_allowed_origins(
+    config: Any, *, base_path_override: str | None = None
+) -> str | None:
     origins = _server_allowed_origins(config)
-    candidates = [
-        candidate
-        for origin in origins
-        if (candidate := _origin_base(origin)) is not None
-    ]
+    candidates = list(
+        dict.fromkeys(
+            candidate
+            for origin in origins
+            if (candidate := _origin_base(origin)) is not None
+        )
+    )
     https_candidates = [
         candidate for candidate in candidates if candidate.startswith("https://")
     ]
@@ -60,7 +74,7 @@ def _public_base_url_from_allowed_origins(config: Any) -> str | None:
         selected = candidates[0]
     if selected is None:
         return None
-    base_path = _server_base_path(config)
+    base_path = _server_base_path(config, base_path_override=base_path_override)
     return f"{selected}{base_path}".rstrip("/")
 
 
@@ -77,10 +91,12 @@ def _origin_base(origin: str) -> str | None:
     return urlunsplit((split.scheme, split.netloc, "", "", "")).rstrip("/")
 
 
-def _base_path_relative_url(config: Any, preview_url: str) -> str:
+def _base_path_relative_url(
+    config: Any, preview_url: str, *, base_path_override: str | None = None
+) -> str:
     if not preview_url.startswith("/"):
         return preview_url
-    base_path = _server_base_path(config)
+    base_path = _server_base_path(config, base_path_override=base_path_override)
     if (
         not base_path
         or preview_url == base_path
@@ -90,7 +106,9 @@ def _base_path_relative_url(config: Any, preview_url: str) -> str:
     return f"{base_path}{preview_url}"
 
 
-def _server_base_path(config: Any) -> str:
+def _server_base_path(config: Any, *, base_path_override: str | None = None) -> str:
+    if base_path_override is not None:
+        return normalize_base_path(base_path_override)
     value = getattr(config, "server_base_path", None)
     if not isinstance(value, str):
         server_cfg = _server_config(config)

--- a/src/codex_autorunner/surfaces/cli/commands/services.py
+++ b/src/codex_autorunner/surfaces/cli/commands/services.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import json
-import os
 import time
 import webbrowser
 from pathlib import Path
 from typing import Any, Callable, Optional
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode
 
 import httpx
 import typer
+
+from ....core.preview_services.public_urls import resolve_user_facing_preview_url
 
 
 def register_services_commands(
@@ -70,36 +71,8 @@ def register_services_commands(
     def _json(data: dict[str, Any]) -> None:
         typer.echo(json.dumps(data, indent=2, sort_keys=True))
 
-    def _preview_public_base_url(config: Any) -> Optional[str]:
-        env_value = os.environ.get("CAR_PREVIEW_PUBLIC_BASE_URL")
-        if env_value and env_value.strip():
-            return env_value.strip().rstrip("/")
-        preview_cfg = getattr(config, "preview_services", None)
-        if not isinstance(preview_cfg, dict):
-            raw_cfg = getattr(config, "raw", None)
-            preview_cfg = (
-                raw_cfg.get("preview_services")
-                if isinstance(raw_cfg, dict)
-                else preview_cfg
-            )
-        if isinstance(preview_cfg, dict):
-            for key in ("public_base_url", "publicBaseUrl", "base_url", "baseUrl"):
-                value = preview_cfg.get(key)
-                if isinstance(value, str) and value.strip():
-                    return value.strip().rstrip("/")
-        for attr in ("public_base_url", "server_public_url", "external_url"):
-            value = getattr(config, attr, None)
-            if isinstance(value, str) and value.strip():
-                return value.strip().rstrip("/")
-        return None
-
     def _absolute_or_relative_preview_url(config: Any, preview_url: str) -> str:
-        if preview_url.startswith(("http://", "https://")):
-            return preview_url
-        base = _preview_public_base_url(config)
-        if not base:
-            return preview_url
-        return urljoin(f"{base}/", preview_url.lstrip("/"))
+        return resolve_user_facing_preview_url(config, preview_url)
 
     def _with_absolute_preview_urls(config: Any, data: Any) -> Any:
         if isinstance(data, list):

--- a/src/codex_autorunner/surfaces/cli/commands/services.py
+++ b/src/codex_autorunner/surfaces/cli/commands/services.py
@@ -71,22 +71,33 @@ def register_services_commands(
     def _json(data: dict[str, Any]) -> None:
         typer.echo(json.dumps(data, indent=2, sort_keys=True))
 
-    def _absolute_or_relative_preview_url(config: Any, preview_url: str) -> str:
-        return resolve_user_facing_preview_url(config, preview_url)
+    def _absolute_or_relative_preview_url(
+        config: Any, preview_url: str, *, base_path: Optional[str] = None
+    ) -> str:
+        return resolve_user_facing_preview_url(
+            config, preview_url, base_path_override=base_path
+        )
 
-    def _with_absolute_preview_urls(config: Any, data: Any) -> Any:
+    def _with_absolute_preview_urls(
+        config: Any, data: Any, *, base_path: Optional[str] = None
+    ) -> Any:
         if isinstance(data, list):
-            return [_with_absolute_preview_urls(config, item) for item in data]
+            return [
+                _with_absolute_preview_urls(config, item, base_path=base_path)
+                for item in data
+            ]
         if not isinstance(data, dict):
             return data
         normalized: dict[str, Any] = {
-            key: _with_absolute_preview_urls(config, value)
+            key: _with_absolute_preview_urls(config, value, base_path=base_path)
             for key, value in data.items()
         }
         for key in ("preview_url", "car_url"):
             value = normalized.get(key)
             if isinstance(value, str) and value.startswith("/"):
-                normalized[key] = _absolute_or_relative_preview_url(config, value)
+                normalized[key] = _absolute_or_relative_preview_url(
+                    config, value, base_path=base_path
+                )
         return normalized
 
     def _parse_ttl_seconds(value: str) -> int:
@@ -295,7 +306,7 @@ def register_services_commands(
         )
         data = _request("GET", url, config)
         if json_output:
-            _json(_with_absolute_preview_urls(config, data))
+            _json(_with_absolute_preview_urls(config, data, base_path=base_path))
             return
         services = _service_models(data)
         if not services:
@@ -323,7 +334,7 @@ def register_services_commands(
             config,
         )
         if json_output:
-            _json(_with_absolute_preview_urls(config, data))
+            _json(_with_absolute_preview_urls(config, data, base_path=base_path))
             return
         _print_service_detail(_service(data))
 
@@ -842,7 +853,9 @@ def register_services_commands(
                 config,
             )
             preview_url = str(data.get("preview_url") or "")
-        resolved = _absolute_or_relative_preview_url(config, preview_url)
+        resolved = _absolute_or_relative_preview_url(
+            config, preview_url, base_path=base_path
+        )
         if json_output:
             _json({"service_id": service_id, "preview_url": resolved})
             return
@@ -875,7 +888,9 @@ def register_services_commands(
         )
         data = _request("POST", url, config)
         preview_url = str(data.get("preview_url") or "")
-        data["preview_url"] = _absolute_or_relative_preview_url(config, preview_url)
+        data["preview_url"] = _absolute_or_relative_preview_url(
+            config, preview_url, base_path=base_path
+        )
         if json_output:
             _json(data)
             return

--- a/tests/core/test_preview_services_public_urls.py
+++ b/tests/core/test_preview_services_public_urls.py
@@ -51,6 +51,49 @@ def test_public_base_url_derives_from_single_non_loopback_https_origin() -> None
     )
 
 
+def test_public_base_url_deduplicates_identical_non_loopback_origins() -> None:
+    config = ConfigStub(
+        server_base_path="/car",
+        server_allowed_origins=[
+            "https://davids-mac-mini-m4.tail76ea03.ts.net",
+            "https://davids-mac-mini-m4.tail76ea03.ts.net",
+        ],
+    )
+
+    assert (
+        resolve_public_hub_base_url(config)
+        == "https://davids-mac-mini-m4.tail76ea03.ts.net/car"
+    )
+
+
+def test_base_path_override_applies_to_derived_public_base_url() -> None:
+    config = ConfigStub(
+        server_allowed_origins=["https://davids-mac-mini-m4.tail76ea03.ts.net"],
+    )
+
+    assert (
+        resolve_user_facing_preview_url(
+            config,
+            "/preview/p/token/",
+            base_path_override="/car",
+        )
+        == "https://davids-mac-mini-m4.tail76ea03.ts.net/car/preview/p/token/"
+    )
+
+
+def test_base_path_override_applies_to_relative_fallback_url() -> None:
+    config = ConfigStub()
+
+    assert (
+        resolve_user_facing_preview_url(
+            config,
+            "/preview/p/token/",
+            base_path_override="/car",
+        )
+        == "/car/preview/p/token/"
+    )
+
+
 def test_ambiguous_public_origins_fall_back_to_base_path_relative_url() -> None:
     config = ConfigStub(
         server_base_path="/car",

--- a/tests/core/test_preview_services_public_urls.py
+++ b/tests/core/test_preview_services_public_urls.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from codex_autorunner.core.preview_services.public_urls import (
+    resolve_public_hub_base_url,
+    resolve_user_facing_preview_url,
+)
+
+
+@dataclass
+class ConfigStub:
+    server_base_path: str = ""
+    server_allowed_origins: list[str] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+def test_explicit_preview_public_base_url_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CAR_PREVIEW_PUBLIC_BASE_URL", raising=False)
+    config = ConfigStub(
+        raw={"preview_services": {"public_base_url": "https://car.example.test/car/"}}
+    )
+
+    assert resolve_public_hub_base_url(config) == "https://car.example.test/car"
+    assert (
+        resolve_user_facing_preview_url(config, "/preview/p/token/")
+        == "https://car.example.test/car/preview/p/token/"
+    )
+
+
+def test_public_base_url_derives_from_single_non_loopback_https_origin() -> None:
+    config = ConfigStub(
+        server_base_path="/car",
+        server_allowed_origins=[
+            "http://127.0.0.1:4517",
+            "http://localhost:4517",
+            "https://davids-mac-mini-m4.tail76ea03.ts.net",
+        ],
+    )
+
+    assert (
+        resolve_public_hub_base_url(config)
+        == "https://davids-mac-mini-m4.tail76ea03.ts.net/car"
+    )
+    assert (
+        resolve_user_facing_preview_url(config, "/preview/p/token/")
+        == "https://davids-mac-mini-m4.tail76ea03.ts.net/car/preview/p/token/"
+    )
+
+
+def test_ambiguous_public_origins_fall_back_to_base_path_relative_url() -> None:
+    config = ConfigStub(
+        server_base_path="/car",
+        server_allowed_origins=[
+            "https://one.example.test",
+            "https://two.example.test",
+        ],
+    )
+
+    assert resolve_public_hub_base_url(config) is None
+    assert resolve_user_facing_preview_url(config, "/preview/p/token/") == (
+        "/car/preview/p/token/"
+    )
+
+
+def test_loopback_only_origins_fall_back_to_base_path_relative_url() -> None:
+    config = ConfigStub(
+        server_base_path="/car",
+        server_allowed_origins=[
+            "http://127.0.0.1:4517",
+            "http://localhost:4517",
+        ],
+    )
+
+    assert resolve_public_hub_base_url(config) is None
+    assert resolve_user_facing_preview_url(config, "/preview/p/token/") == (
+        "/car/preview/p/token/"
+    )

--- a/tests/test_cli_services.py
+++ b/tests/test_cli_services.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.cli import app
 from codex_autorunner.server import create_hub_app
+from tests.conftest import write_test_config
 
 runner = CliRunner()
 
@@ -472,6 +473,60 @@ def test_services_open_json_uses_absolute_public_base_url(
     assert calls[0]["method"] == "POST"
     assert (
         urlsplit(str(calls[0]["url"])).path == "/hub/services/svc_abc123/preview-token"
+    )
+
+
+def test_services_open_json_derives_public_base_url_from_allowed_origin(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = _hub_root(tmp_path)
+    write_test_config(
+        hub_root / ".codex-autorunner" / "config.yml",
+        {
+            "version": 2,
+            "mode": "hub",
+            "server": {
+                "host": "127.0.0.1",
+                "port": 4517,
+                "base_path": "/car",
+                "allowed_origins": [
+                    "http://127.0.0.1:4517",
+                    "http://localhost:4517",
+                    "https://davids-mac-mini-m4.tail76ea03.ts.net",
+                ],
+            },
+        },
+    )
+    calls: list[dict[str, object]] = []
+
+    def _fake_request(
+        method, url, json=None, timeout=None, headers=None, follow_redirects=True
+    ):  # type: ignore[no-untyped-def]
+        calls.append({"method": method, "url": url, "json": json})
+        return _mock_response(
+            {
+                "service_id": "svc_abc123",
+                "preview_url": "/preview/p/tok_123/",
+                "expires_at": 123.0,
+            }
+        )
+
+    monkeypatch.setattr("httpx.request", _fake_request)
+
+    result = runner.invoke(
+        app,
+        ["services", "open", "svc_abc123", "--path", str(hub_root), "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        json.loads(result.output)["preview_url"]
+        == "https://davids-mac-mini-m4.tail76ea03.ts.net/car/preview/p/tok_123/"
+    )
+    assert calls[0]["method"] == "POST"
+    assert (
+        urlsplit(str(calls[0]["url"])).path
+        == "/car/hub/services/svc_abc123/preview-token"
     )
 
 

--- a/tests/test_cli_services.py
+++ b/tests/test_cli_services.py
@@ -530,6 +530,107 @@ def test_services_open_json_derives_public_base_url_from_allowed_origin(
     )
 
 
+def test_services_open_json_honors_base_path_override_in_public_link(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = _hub_root(tmp_path)
+    write_test_config(
+        hub_root / ".codex-autorunner" / "config.yml",
+        {
+            "version": 2,
+            "mode": "hub",
+            "server": {
+                "host": "127.0.0.1",
+                "port": 4517,
+                "allowed_origins": [
+                    "https://davids-mac-mini-m4.tail76ea03.ts.net",
+                ],
+            },
+        },
+    )
+    calls: list[dict[str, object]] = []
+
+    def _fake_request(
+        method, url, json=None, timeout=None, headers=None, follow_redirects=True
+    ):  # type: ignore[no-untyped-def]
+        calls.append({"method": method, "url": url, "json": json})
+        return _mock_response(
+            {
+                "service_id": "svc_abc123",
+                "preview_url": "/preview/p/tok_123/",
+                "expires_at": 123.0,
+            }
+        )
+
+    monkeypatch.setattr("httpx.request", _fake_request)
+
+    result = runner.invoke(
+        app,
+        [
+            "services",
+            "open",
+            "svc_abc123",
+            "--path",
+            str(hub_root),
+            "--base-path",
+            "/car",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        json.loads(result.output)["preview_url"]
+        == "https://davids-mac-mini-m4.tail76ea03.ts.net/car/preview/p/tok_123/"
+    )
+    assert (
+        urlsplit(str(calls[0]["url"])).path
+        == "/car/hub/services/svc_abc123/preview-token"
+    )
+
+
+def test_services_issue_link_honors_base_path_override_for_relative_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = _hub_root(tmp_path)
+    calls: list[dict[str, object]] = []
+
+    def _fake_request(
+        method, url, json=None, timeout=None, headers=None, follow_redirects=True
+    ):  # type: ignore[no-untyped-def]
+        calls.append({"method": method, "url": url, "json": json})
+        return _mock_response(
+            {
+                "service_id": "svc_abc123",
+                "preview_url": "/preview/p/tok_123/",
+                "expires_at": 123.0,
+            }
+        )
+
+    monkeypatch.setattr("httpx.request", _fake_request)
+
+    result = runner.invoke(
+        app,
+        [
+            "services",
+            "issue-link",
+            "svc_abc123",
+            "--path",
+            str(hub_root),
+            "--base-path",
+            "/car",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["preview_url"] == "/car/preview/p/tok_123/"
+    assert (
+        urlsplit(str(calls[0]["url"])).path
+        == "/car/hub/services/svc_abc123/preview-token"
+    )
+
+
 def test_services_open_direct_uses_diagnostic_service_url(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## What changed

- Added a shared preview-service public URL resolver.
- Updated `car services` URL presentation to use the shared resolver instead of local-only CLI URL logic.
- Added coverage for explicit public bases, hosted `server.allowed_origins` derivation, ambiguous-origin fallback, and CLI output for hosted `/car` deployments.

## Why

Agents and CLI output could present preview links as `127.0.0.1` because CLI control-plane calls use the local hub endpoint. Hosted browser flows already resolved capability paths against the browser origin, so Services page copy/open behaved correctly while agent-visible output did not.

The resolver now derives a user-facing public base from existing hosted config when there is a single non-loopback HTTPS `server.allowed_origins` value, while preserving explicit `preview_services.public_base_url` for deployments that need it. If no public base is knowable, it falls back to a base-path-relative URL such as `/car/preview/p/...` rather than publishing a loopback URL.

## Validation

- `.venv/bin/python -m pytest tests/core/test_preview_services_public_urls.py tests/test_cli_services.py -q`
- `.venv/bin/python -m black --check src/codex_autorunner/core/preview_services/public_urls.py src/codex_autorunner/surfaces/cli/commands/services.py tests/core/test_preview_services_public_urls.py tests/test_cli_services.py`
- `.venv/bin/python -m ruff check src/codex_autorunner/core/preview_services/public_urls.py src/codex_autorunner/surfaces/cli/commands/services.py tests/core/test_preview_services_public_urls.py tests/test_cli_services.py`
- `.venv/bin/python -m mypy src/codex_autorunner`
- Pre-commit core lane: guardrails, strict mypy, and 9,801 fast tests passed.