### PR TITLE
[codex] Improve read-model route responsiveness

### DIFF
--- a/src/codex_autorunner/web_frontend/AGENTS.md
+++ b/src/codex_autorunner/web_frontend/AGENTS.md
@@ -30,6 +30,12 @@ tests, and docs only; release/package builds produce and verify the static bundl
   environment mock in every file.
 - Normal updates should arrive through cursor streams plus repair snapshots.
   Do not add recurring `setInterval`/quiet-refresh loops for migrated screens.
+- Read-model-backed pages should render stale cached data while refreshing.
+  Add a non-blocking `+page.ts` loader (`ensureXLoaded({ blocking: false })`),
+  store snapshots in `readModelEntityStore`, and select from the store in the
+  Svelte page. Do not fetch read-model snapshots directly from `+page.svelte`
+  and blank back to skeletons on every navigation; `readModelRouteConventions.test.ts`
+  enforces this for route pages.
 - High-cardinality UI must stay windowed and virtualized. Do not render
   unbounded chat, timeline, repo/worktree, ticket, artifact, or dispatch lists
   with raw `{#each}` loops.

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelClients.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelClients.ts
@@ -1,4 +1,4 @@
-import { mapResult, webApi, type ApiResult, type WebApiClient } from '$lib/api/client';
+import { mapResult, webApi, type ApiResult, type AutomationWorkspace, type WebApiClient } from '$lib/api/client';
 import type { TicketSummary } from '$lib/viewModels/domain';
 import {
   normalizeChatFacetRequest,
@@ -6,6 +6,7 @@ import {
   type ChatFacetRequest,
   type ChatDetailSnapshot,
   type ChatIndexSnapshot,
+  type PreviewServicesReadModel,
   type RepoWorktreeDetailSnapshot,
   type RepoWorktreeRuntimeSnapshot,
   type RepoWorktreeTopologySnapshot,
@@ -28,10 +29,12 @@ export type ChatIndexRequest = {
 export type ReadModelSnapshotClient = {
   chatIndex(request?: ChatIndexRequest): Promise<ApiResult<ChatIndexSnapshot>>;
   chatDetail(chatId: string, timelineLimit?: number): Promise<ApiResult<ChatDetailSnapshot>>;
+  automationWorkspaceIndex(): Promise<ApiResult<AutomationWorkspace>>;
   repoWorktreeTopology(kind?: 'all' | 'repo' | 'worktree', limit?: number, cursor?: string | null): Promise<ApiResult<RepoWorktreeTopologySnapshot>>;
   repoWorktreeRuntime(kind?: 'all' | 'repo' | 'worktree', limit?: number, cursor?: string | null): Promise<ApiResult<RepoWorktreeRuntimeSnapshot>>;
   repoDetail(repoId: string): Promise<ApiResult<RepoWorktreeDetailSnapshot>>;
   worktreeDetail(worktreeId: string): Promise<ApiResult<RepoWorktreeDetailSnapshot>>;
+  servicesReadModel(scope?: string | null): Promise<ApiResult<PreviewServicesReadModel>>;
   ticketDetail(ticketId: string, owner: { kind: 'repo' | 'worktree'; id: string }): Promise<ApiResult<TicketDetailSnapshot>>;
   ticketIndex(owner?: { repo?: string; worktree?: string }): Promise<ApiResult<TicketSummary[]>>;
 };
@@ -62,10 +65,12 @@ export function createReadModelSnapshotClient(api: WebApiClient = webApi): ReadM
         (payload) => mapReadModelContract<ChatDetailSnapshot>(payload)
       );
     },
+    automationWorkspaceIndex: () => api.hub.getAutomationWorkspaceIndex(),
     repoWorktreeTopology: (kind, limit, cursor) => api.readModels.repoWorktreeTopology(kind, limit, cursor),
     repoWorktreeRuntime: (kind, limit, cursor) => api.readModels.repoWorktreeRuntime(kind, limit, cursor),
     repoDetail: (repoId) => api.readModels.repoDetail(repoId),
     worktreeDetail: (worktreeId) => api.readModels.worktreeDetail(worktreeId),
+    servicesReadModel: (scope) => api.hub.getServicesReadModel(scope),
     ticketDetail: async (ticketId, owner) =>
       mapResult(await api.readModels.ticketDetail(ticketId, owner), (payload) => mapReadModelContract<TicketDetailSnapshot>(payload)),
     ticketIndex: async (owner) => api.ticketFlow.listTickets(owner)

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import { READ_MODEL_CONTRACT_VERSION, type ChatDetailSnapshot, type ChatIndexSnapshot, type ProjectionCursor, type RepoWorktreeRuntimeSnapshot, type RepoWorktreeTopologySnapshot, type TicketDetailSnapshot } from '$lib/api/readModelContracts';
-import type { ApiError, ApiResult } from '$lib/api/client';
-import { ReadModelEntityStore, selectChatDetailView } from './readModelStore';
+import { READ_MODEL_CONTRACT_VERSION, type ChatDetailSnapshot, type ChatIndexSnapshot, type PreviewServicesReadModel, type ProjectionCursor, type RepoWorktreeRuntimeSnapshot, type RepoWorktreeTopologySnapshot, type TicketDetailSnapshot } from '$lib/api/readModelContracts';
+import type { ApiError, ApiResult, AutomationWorkspace } from '$lib/api/client';
+import { ReadModelEntityStore, selectAutomationWorkspace, selectChatDetailView, selectPreviewServicesReadModel } from './readModelStore';
 import type { ReadModelSnapshotClient } from './readModelClients';
 import type { TicketSummary } from '$lib/viewModels/domain';
 
@@ -110,6 +110,105 @@ describe('read model loaders', () => {
     expect(result).toEqual({ status: 'cold', tags: ['entity:chat:index'] });
     expect(depends).toHaveBeenCalledWith('entity:chat:index');
     expect(client.chatIndex).not.toHaveBeenCalled();
+  });
+
+  it('hydrates automation workspace snapshots through the shared read model store', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      automationWorkspaceIndex: vi.fn().mockResolvedValue(ok(automationWorkspace({ active: 1 })))
+    });
+    const depends = vi.fn();
+    const { ensureAutomationWorkspaceLoaded } = await importLoaders(true);
+
+    const result = await ensureAutomationWorkspaceLoaded({ store, client, depends });
+
+    expect(result).toEqual({ status: 'fetched', tags: ['entity:automation:workspace'] });
+    expect(depends).toHaveBeenCalledWith('entity:automation:workspace');
+    expect(client.automationWorkspaceIndex).toHaveBeenCalledWith();
+    expect(selectAutomationWorkspace(store.snapshot())?.summary.active).toBe(1);
+  });
+
+  it('keeps cached automations visible while refreshing in the background', async () => {
+    const store = new ReadModelEntityStore();
+    store.applyAutomationWorkspaceSnapshot(automationWorkspace({ generatedAt: 'cached', active: 1 }));
+    const deferred = createDeferred<ApiResult<AutomationWorkspace>>();
+    const client = mockClient({
+      automationWorkspaceIndex: vi.fn().mockReturnValue(deferred.promise)
+    });
+    const { ensureAutomationWorkspaceLoaded } = await importLoaders(true);
+
+    const result = await ensureAutomationWorkspaceLoaded({ store, client, blocking: false, refresh: true });
+
+    expect(result).toEqual({ status: 'cache-hit', tags: ['entity:automation:workspace'] });
+    expect(selectAutomationWorkspace(store.snapshot())?.generatedAt).toBe('cached');
+    deferred.resolve(ok(automationWorkspace({ generatedAt: 'fresh', active: 2 })));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(selectAutomationWorkspace(store.snapshot())?.generatedAt).toBe('fresh');
+    expect(selectAutomationWorkspace(store.snapshot())?.summary.active).toBe(2);
+  });
+
+  it('can defer automation workspace snapshots for non-blocking page loads', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      automationWorkspaceIndex: vi.fn().mockResolvedValue(ok(automationWorkspace({ active: 1 })))
+    });
+    const { ensureAutomationWorkspaceLoaded } = await importLoaders(true);
+
+    const result = await ensureAutomationWorkspaceLoaded({ store, client, blocking: false });
+
+    expect(result).toEqual({ status: 'cold', tags: ['entity:automation:workspace'] });
+    expect(client.automationWorkspaceIndex).not.toHaveBeenCalled();
+    expect(selectAutomationWorkspace(store.snapshot())).toBeNull();
+  });
+
+  it('hydrates services snapshots through the shared read model store', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      servicesReadModel: vi.fn().mockResolvedValue(ok(servicesReadModel('svc_frontend1', 'Frontend')))
+    });
+    const depends = vi.fn();
+    const { ensureServicesLoaded } = await importLoaders(true);
+
+    const result = await ensureServicesLoaded({ store, client, depends });
+
+    expect(result).toEqual({ status: 'fetched', tags: ['entity:service:index'] });
+    expect(depends).toHaveBeenCalledWith('entity:service:index');
+    expect(client.servicesReadModel).toHaveBeenCalledWith(null);
+    expect(selectPreviewServicesReadModel(store.snapshot())?.services[0]?.name).toBe('Frontend');
+  });
+
+  it('keeps cached services visible while refreshing in the background', async () => {
+    const store = new ReadModelEntityStore();
+    store.applyServicesReadModelSnapshot(servicesReadModel('svc_cached1', 'Cached'));
+    const deferred = createDeferred<ApiResult<PreviewServicesReadModel>>();
+    const client = mockClient({
+      servicesReadModel: vi.fn().mockReturnValue(deferred.promise)
+    });
+    const { ensureServicesLoaded } = await importLoaders(true);
+
+    const result = await ensureServicesLoaded({ store, client, blocking: false, refresh: true });
+
+    expect(result).toEqual({ status: 'cache-hit', tags: ['entity:service:index'] });
+    expect(selectPreviewServicesReadModel(store.snapshot())?.services[0]?.name).toBe('Cached');
+    deferred.resolve(ok(servicesReadModel('svc_fresh1', 'Fresh')));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(selectPreviewServicesReadModel(store.snapshot())?.services[0]?.name).toBe('Fresh');
+  });
+
+  it('can defer services snapshots for non-blocking page loads', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      servicesReadModel: vi.fn().mockResolvedValue(ok(servicesReadModel('svc_frontend1', 'Frontend')))
+    });
+    const { ensureServicesLoaded } = await importLoaders(true);
+
+    const result = await ensureServicesLoaded({ store, client, blocking: false });
+
+    expect(result).toEqual({ status: 'cold', tags: ['entity:service:index'] });
+    expect(client.servicesReadModel).not.toHaveBeenCalled();
+    expect(selectPreviewServicesReadModel(store.snapshot())).toBeNull();
   });
 
   it('hydrates repo-worktree index snapshots from existing snapshot clients', async () => {
@@ -259,14 +358,88 @@ function mockClient(overrides: Partial<Record<keyof ReadModelSnapshotClient, Ret
   return {
     chatIndex: vi.fn().mockResolvedValue(ok(chatIndexSnapshot())),
     chatDetail: vi.fn().mockResolvedValue(ok(chatDetailSnapshot())),
+    automationWorkspaceIndex: vi.fn().mockResolvedValue(ok(automationWorkspace())),
     repoWorktreeTopology: vi.fn().mockResolvedValue(ok(repoWorktreeTopologySnapshot())),
     repoWorktreeRuntime: vi.fn().mockResolvedValue(ok(repoWorktreeRuntimeSnapshot())),
     repoDetail: vi.fn(),
     worktreeDetail: vi.fn(),
+    servicesReadModel: vi.fn().mockResolvedValue(ok(servicesReadModel())),
     ticketDetail: vi.fn().mockResolvedValue(ok(ticketDetailSnapshot())),
     ticketIndex: vi.fn().mockResolvedValue(ok([])),
     ...overrides
   } as ReadModelSnapshotClient;
+}
+
+function automationWorkspace(overrides: { generatedAt?: string; active?: number } = {}): AutomationWorkspace {
+  const active = overrides.active ?? 0;
+  return {
+    automations: [],
+    presets: [],
+    summary: {
+      total: active,
+      active,
+      paused: 0,
+      failedJobs: 0
+    },
+    targetOptions: [],
+    agentDefaults: {
+      defaultAgent: 'codex',
+      defaultProfile: null,
+      defaultModel: null,
+      defaultReasoning: null,
+      raw: {}
+    },
+    generatedAt: overrides.generatedAt ?? now
+  };
+}
+
+function servicesReadModel(serviceId = 'svc_test1', name = 'Test service'): PreviewServicesReadModel {
+  return {
+    services: [
+      {
+        serviceId,
+        name,
+        kind: 'managed_command',
+        serviceClass: 'preview',
+        trustLevel: 'generated',
+        ownership: 'car_managed',
+        networkPolicy: 'loopback_only',
+        status: 'running',
+        createdBy: 'ui',
+        createdAt: now,
+        updatedAt: now,
+        scopeLinks: [],
+        scope: null,
+        carUrl: `/preview/services/${serviceId}/`,
+        previewUrl: null,
+        previewUrlExpiresAt: null,
+        proxyEnabled: true,
+        directUrl: null,
+        host: '127.0.0.1',
+        port: 5173,
+        ownerPid: 123,
+        healthCheck: null,
+        restartPolicy: {},
+        logs: null,
+        metadata: {},
+        capabilities: {},
+        desiredState: {},
+        observedState: {},
+        raw: {}
+      }
+    ],
+    counts: {
+      total: 1,
+      running: 1,
+      attention: 0,
+      managed: 1,
+      static: 0,
+      loopback: 0,
+      preview: 1,
+      application: 0,
+      infrastructure: 0
+    }
+  };
 }
 
 function ok<T>(data: T): ApiResult<T> {
@@ -279,6 +452,14 @@ function fail<T>(error: ApiError): ApiResult<T> {
 
 function apiError(message: string): ApiError {
   return { kind: 'http', status: 503, code: 'unavailable', message };
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 function cursor(sequence: number, source = 'test'): ProjectionCursor {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import type { ApiError } from '$lib/api/client';
 import {
   canonicalChatIndexWindowKey,
+  previewServicesWindowKey,
   readModelEntityStore,
   repoWorktreeWindowKey,
   type ReadModelEntityState,
@@ -38,10 +39,12 @@ export type ReadModelLoaderResult =
 
 export const readModelEntityTags = {
   chatIndex: 'entity:chat:index',
+  automationWorkspace: 'entity:automation:workspace',
   repoWorktreeIndex: 'entity:repo-worktree:index',
   chat: (chatId: string) => `entity:chat:${chatId}` as const,
   repo: (repoId: string) => `entity:repo:${repoId}` as const,
   worktree: (worktreeId: string) => `entity:worktree:${worktreeId}` as const,
+  serviceIndex: 'entity:service:index',
   ticket: (ticketId: string) => `entity:ticket:${ticketId}` as const,
   ticketIndex: 'entity:ticket:index' as const
 } as const;
@@ -90,6 +93,23 @@ export async function ensureChatDetailLoaded(
   });
 }
 
+export async function ensureAutomationWorkspaceLoaded(
+  options: ReadModelLoaderOptions = {}
+): Promise<ReadModelLoaderResult> {
+  const tags = [readModelEntityTags.automationWorkspace];
+  return ensureSnapshotLoaded({
+    tags,
+    options,
+    isCached: (state) => Boolean(state.automationWorkspace),
+    fetchAndApply: async (client, store) => {
+      const result = await client.automationWorkspaceIndex();
+      if (!result.ok) return result;
+      store.applyAutomationWorkspaceSnapshot(result.data);
+      return result;
+    }
+  });
+}
+
 export async function ensureRepoWorktreeIndexLoaded(
   options: ReadModelLoaderOptions & { limit?: number } = {}
 ): Promise<ReadModelLoaderResult> {
@@ -109,6 +129,24 @@ export async function ensureRepoWorktreeIndexLoaded(
       store.applyRepoWorktreeTopologySnapshot(topology.data);
       store.applyRepoWorktreeRuntimeSnapshot(runtime.data);
       return runtime;
+    }
+  });
+}
+
+export async function ensureServicesLoaded(
+  options: ReadModelLoaderOptions & { scope?: string | null } = {}
+): Promise<ReadModelLoaderResult> {
+  const tags = [readModelEntityTags.serviceIndex];
+  const scope = options.scope ?? null;
+  return ensureSnapshotLoaded({
+    tags,
+    options,
+    isCached: (state) => Boolean(state.previewServices[previewServicesWindowKey(scope)]),
+    fetchAndApply: async (client, store) => {
+      const result = await client.servicesReadModel(scope);
+      if (!result.ok) return result;
+      store.applyServicesReadModelSnapshot(result.data, scope);
+      return result;
     }
   });
 }

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.profile.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.profile.test.ts
@@ -80,6 +80,9 @@ function legacyDeepCloneState(state: ReadModelEntityState): ReadModelEntityState
     repoOrder: [...state.repoOrder],
     worktrees: { ...state.worktrees },
     worktreeOrder: [...state.worktreeOrder],
+    repoWorktreeWindows: legacyCloneRecord(state.repoWorktreeWindows),
+    previewServices: legacyCloneRecord(state.previewServices),
+    automationWorkspace: state.automationWorkspace ? JSON.parse(JSON.stringify(state.automationWorkspace)) : null,
     runtime: { ...state.runtime },
     tickets: { ...state.tickets },
     ticketSummaries: { ...state.ticketSummaries },
@@ -102,6 +105,8 @@ function legacyDeepCloneState(state: ReadModelEntityState): ReadModelEntityState
       ticket: { ...state.versions.ticket },
       run: { ...state.versions.run },
       artifact: { ...state.versions.artifact },
+      service: { ...state.versions.service },
+      automation: { ...state.versions.automation },
       agent: { ...state.versions.agent },
       model: { ...state.versions.model }
     }

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -226,7 +226,7 @@ describe('read model entity store', () => {
         enabled: false,
         updatedAt: '2026-05-11T12:00:00Z',
         jobs: [automationJob('old-1'), automationJob('old-2')],
-        jobCount: 2,
+        jobCount: 3,
         lastJob: automationJob('old-2', 'succeeded'),
         raw: { executor: { prompt: 'full detail prompt' } }
       })
@@ -239,7 +239,7 @@ describe('read model entity store', () => {
         enabled: true,
         updatedAt: '2026-05-11T12:05:00Z',
         jobs: [],
-        jobCount: 0,
+        jobCount: 3,
         lastJob: automationJob('fresh-1', 'failed'),
         raw: { shallow: true }
       })
@@ -251,7 +251,7 @@ describe('read model entity store', () => {
       enabled: true,
       updatedAt: '2026-05-11T12:05:00Z',
       lastJob: { jobId: 'fresh-1', effectiveState: 'failed' },
-      jobCount: 2,
+      jobCount: 3,
       raw: { executor: { prompt: 'full detail prompt' } }
     });
     expect(row?.jobs.map((job) => job.jobId)).toEqual(['old-1', 'old-2']);

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { get } from 'svelte/store';
+import type { AutomationSummary, AutomationWorkspace } from '$lib/api/client';
 import {
   READ_MODEL_CONTRACT_VERSION,
   type ChatDetailPatchEvent,
@@ -14,6 +15,7 @@ import type { ChatTranscriptCard } from '$lib/viewModels/chat';
 import {
   LIVE_PROGRESS_EVENT_LIMIT,
   ReadModelEntityStore,
+  selectAutomationWorkspace,
   selectChatDetailView,
   selectChatIndexView,
   selectChatIndexWindowView,
@@ -213,6 +215,46 @@ describe('read model entity store', () => {
     expect(typedWindow.rows.map((row) => row.chatId)).toEqual(['ticket-chat']);
     expect(typedWindow.facetCounts.category.ticket_run).toBe(1);
     expect(selectChatIndexWindowView(store.snapshot(), { facets: { categories: ['automation'] }, limit: 25 }).rows).toEqual([]);
+  });
+
+  it('preserves hydrated automation detail jobs without hiding fresh index fields', () => {
+    const store = new ReadModelEntityStore();
+    store.applyAutomationWorkspaceSnapshot(automationWorkspace([
+      automationSummary({
+        id: 'rule-1',
+        name: 'Cached detail',
+        enabled: false,
+        updatedAt: '2026-05-11T12:00:00Z',
+        jobs: [automationJob('old-1'), automationJob('old-2')],
+        jobCount: 2,
+        lastJob: automationJob('old-2', 'succeeded'),
+        raw: { executor: { prompt: 'full detail prompt' } }
+      })
+    ]));
+
+    store.applyAutomationWorkspaceSnapshot(automationWorkspace([
+      automationSummary({
+        id: 'rule-1',
+        name: 'Fresh index',
+        enabled: true,
+        updatedAt: '2026-05-11T12:05:00Z',
+        jobs: [],
+        jobCount: 0,
+        lastJob: automationJob('fresh-1', 'failed'),
+        raw: { shallow: true }
+      })
+    ]));
+
+    const row = selectAutomationWorkspace(store.snapshot())?.automations[0];
+    expect(row).toMatchObject({
+      name: 'Fresh index',
+      enabled: true,
+      updatedAt: '2026-05-11T12:05:00Z',
+      lastJob: { jobId: 'fresh-1', effectiveState: 'failed' },
+      jobCount: 2,
+      raw: { executor: { prompt: 'full detail prompt' } }
+    });
+    expect(row?.jobs.map((job) => job.jobId)).toEqual(['old-1', 'old-2']);
   });
 
   it('applies chat detail timeline patches and reconciles optimistic sends', () => {
@@ -1162,6 +1204,131 @@ function progressArtifact(id: string, progressItem: Record<string, unknown>): Su
     url: null,
     createdAt: now,
     raw: { progress_item: { item_id: id, title: id, ...progressItem } }
+  };
+}
+
+function automationWorkspace(automations: AutomationSummary[]): AutomationWorkspace {
+  return {
+    automations,
+    presets: [],
+    summary: {
+      total: automations.length,
+      active: automations.filter((automation) => automation.enabled).length,
+      paused: automations.filter((automation) => !automation.enabled).length,
+      failedJobs: automations.filter((automation) => automation.lastJob?.effectiveState === 'failed').length
+    },
+    targetOptions: [],
+    agentDefaults: {
+      defaultAgent: 'codex',
+      defaultProfile: null,
+      defaultModel: null,
+      defaultReasoning: null,
+      raw: {}
+    },
+    generatedAt: now
+  };
+}
+
+function automationSummary(overrides: Partial<AutomationSummary> = {}): AutomationSummary {
+  return {
+    id: 'rule-1',
+    name: 'Automation',
+    enabled: true,
+    systemOwned: false,
+    kind: 'scheduled',
+    executorKind: 'agent_task_turn',
+    targetPolicy: 'repo_required',
+    target: {},
+    metadata: {},
+    schedule: null,
+    lastJob: null,
+    jobs: [],
+    jobCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    product: {
+      productApiVersion: 1,
+      editable: {
+        canEnable: true,
+        canRename: true,
+        canEditSchedule: true,
+        canEditMessage: true,
+        canEditTicketBody: true,
+        canRunNow: true,
+        canEditRaw: true,
+        rawEditBlockedReason: '',
+        managedReason: null,
+        raw: {}
+      },
+      managed: {
+        systemOwned: false,
+        managed: false,
+        reason: null,
+        raw: {}
+      },
+      scheduleEditor: {
+        kind: 'daily',
+        editable: true,
+        summary: 'Daily',
+        timezone: 'UTC',
+        nextFireAt: null,
+        lastFireAt: null,
+        state: 'active',
+        fields: {},
+        raw: {}
+      },
+      triggerSummary: {
+        kind: 'schedule',
+        label: 'Schedule',
+        eventTypes: ['schedule.fire'],
+        filters: {},
+        raw: {}
+      },
+      targetSummary: {},
+      message: {
+        source: 'executor',
+        field: 'prompt',
+        preview: '',
+        template: false,
+        editable: true,
+        raw: {}
+      },
+      messageSource: 'prompt',
+      messagePreview: '',
+      actionPreview: {},
+      executorSummary: {},
+      policySummary: {},
+      diagnostics: [],
+      rawLinks: {}
+    },
+    raw: {},
+    ...overrides
+  };
+}
+
+function automationJob(id: string, effectiveState = 'succeeded') {
+  return {
+    jobId: id,
+    state: effectiveState,
+    rawState: effectiveState,
+    effectiveState,
+    createdAt: now,
+    startedAt: now,
+    finishedAt: now,
+    updatedAt: now,
+    resultSummary: null,
+    errorText: null,
+    attemptCount: 1,
+    blockedByJobId: null,
+    blockedReason: null,
+    blockedAt: null,
+    pmaQueueResult: null,
+    childExecution: null,
+    children: [],
+    runtimeContract: null,
+    terminalReason: null,
+    policyViolations: [],
+    raw: {}
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -1201,10 +1201,9 @@ function shouldKeepHydratedAutomation(
   next: AutomationSummary
 ): previous is AutomationSummary {
   if (!previous) return false;
-  if (previous.jobs.length > next.jobs.length) return true;
-  const previousJobCount = previous.jobs.length || previous.jobCount;
-  const nextJobCount = next.jobs.length || next.jobCount;
-  return previousJobCount > nextJobCount;
+  const previousJobCount = Math.max(previous.jobs.length, previous.jobCount);
+  const nextJobCount = Math.max(next.jobs.length, next.jobCount);
+  return previous.jobs.length > next.jobs.length || previousJobCount > nextJobCount;
 }
 
 function cloneAutomationWorkspace(workspace: AutomationWorkspace): AutomationWorkspace {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -1201,6 +1201,7 @@ function shouldKeepHydratedAutomation(
   next: AutomationSummary
 ): previous is AutomationSummary {
   if (!previous) return false;
+  if (previous.jobs.length > next.jobs.length) return true;
   const previousJobCount = previous.jobs.length || previous.jobCount;
   const nextJobCount = next.jobs.length || next.jobCount;
   return previousJobCount > nextJobCount;

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -1,5 +1,5 @@
 import { writable, type Readable } from 'svelte/store';
-import type { ChatQueuedTurn } from '$lib/api/client';
+import type { AutomationSummary, AutomationWorkspace, ChatQueuedTurn } from '$lib/api/client';
 import { chatFacetRequestIsEmpty, normalizeChatFacetRequest } from '$lib/api/readModelContracts';
 import type {
   ChatArtifactSummary,
@@ -22,6 +22,8 @@ import type {
   RepoWorktreePatchEvent,
   RepoWorktreeRuntimeSnapshot,
   RepoWorktreeTopologySnapshot,
+  PreviewServiceReadModel,
+  PreviewServicesReadModel,
   RuntimeProjection,
   TicketDetailPatchEvent,
   TicketDetailSnapshot,
@@ -45,6 +47,8 @@ export type EntityKind =
   | 'ticket'
   | 'run'
   | 'artifact'
+  | 'service'
+  | 'automation'
   | 'agent'
   | 'model';
 
@@ -132,6 +136,13 @@ export type RepoWorktreeIndexWindow = {
   lastLoadedAt: string;
 };
 
+export type PreviewServicesCacheEntry = {
+  key: string;
+  scope: string | null;
+  model: PreviewServicesReadModel;
+  lastLoadedAt: string;
+};
+
 export type ReadModelEntityState = {
   activeChatId: string | null;
   cursors: Record<string, ProjectionCursor>;
@@ -156,6 +167,8 @@ export type ReadModelEntityState = {
   worktrees: Record<string, WorktreeTopology>;
   worktreeOrder: string[];
   repoWorktreeWindows: Record<string, RepoWorktreeIndexWindow>;
+  previewServices: Record<string, PreviewServicesCacheEntry>;
+  automationWorkspace: AutomationWorkspace | null;
   runtime: Record<string, RepoWorktreeRuntimeEntity>;
   tickets: Record<string, TicketProjection>;
   ticketSummaries: Record<string, TicketSummary>;
@@ -242,6 +255,8 @@ export function createInitialReadModelState(): ReadModelEntityState {
     worktrees: {},
     worktreeOrder: [],
     repoWorktreeWindows: {},
+    previewServices: {},
+    automationWorkspace: null,
     runtime: {},
     tickets: {},
     ticketSummaries: {},
@@ -264,6 +279,8 @@ export function createInitialReadModelState(): ReadModelEntityState {
       ticket: {},
       run: {},
       artifact: {},
+      service: {},
+      automation: {},
       agent: {},
       model: {}
     },
@@ -665,6 +682,52 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     this.commit(next);
   }
 
+  applyServicesReadModelSnapshot(snapshot: PreviewServicesReadModel, scope: string | null = null): void {
+    const next = cloneState(this.state);
+    const key = previewServicesWindowKey(scope);
+    next.previewServices[key] = {
+      key,
+      scope: normalizedPreviewServicesScope(scope),
+      model: clonePreviewServicesReadModel(snapshot),
+      lastLoadedAt: new Date().toISOString()
+    };
+    for (const service of snapshot.services) bump(next, 'service', service.serviceId);
+    this.commit(next);
+  }
+
+  applyAutomationWorkspaceSnapshot(snapshot: AutomationWorkspace): void {
+    const next = cloneState(this.state);
+    next.automationWorkspace = mergeAutomationWorkspaceSnapshot(snapshot, this.state.automationWorkspace);
+    for (const automation of next.automationWorkspace.automations) bump(next, 'automation', automation.id);
+    this.commit(next);
+  }
+
+  replaceAutomationSummary(updated: AutomationSummary): void {
+    if (!this.state.automationWorkspace) return;
+    const next = cloneState(this.state);
+    const workspace = cloneAutomationWorkspace(this.state.automationWorkspace);
+    const existingIndex = workspace.automations.findIndex((automation) => automation.id === updated.id);
+    workspace.automations =
+      existingIndex >= 0
+        ? workspace.automations.map((automation) => (automation.id === updated.id ? cloneAutomationSummary(updated) : automation))
+        : [...workspace.automations, cloneAutomationSummary(updated)];
+    workspace.summary = automationSummaryCounts(workspace.automations);
+    next.automationWorkspace = workspace;
+    bump(next, 'automation', updated.id);
+    this.commit(next);
+  }
+
+  removeAutomationSummary(automationId: string): void {
+    if (!this.state.automationWorkspace) return;
+    const next = cloneState(this.state);
+    const workspace = cloneAutomationWorkspace(this.state.automationWorkspace);
+    workspace.automations = workspace.automations.filter((automation) => automation.id !== automationId);
+    workspace.summary = automationSummaryCounts(workspace.automations);
+    next.automationWorkspace = workspace;
+    bump(next, 'automation', automationId);
+    this.commit(next);
+  }
+
   applyRepoDetailSnapshot(snapshot: RepoWorktreeDetailSnapshot): void {
     const next = cloneState(this.state);
     next.repoDetails[snapshot.ownerId] = snapshot;
@@ -994,6 +1057,8 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
     worktrees: { ...state.worktrees },
     worktreeOrder: [...state.worktreeOrder],
     repoWorktreeWindows: Object.fromEntries(Object.entries(state.repoWorktreeWindows).map(([key, window]) => [key, cloneRepoWorktreeIndexWindow(window)])),
+    previewServices: Object.fromEntries(Object.entries(state.previewServices).map(([key, entry]) => [key, clonePreviewServicesCacheEntry(entry)])),
+    automationWorkspace: state.automationWorkspace ? cloneAutomationWorkspace(state.automationWorkspace) : null,
     runtime: { ...state.runtime },
     tickets: { ...state.tickets },
     ticketSummaries: { ...state.ticketSummaries },
@@ -1016,6 +1081,8 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
       ticket: { ...state.versions.ticket },
       run: { ...state.versions.run },
       artifact: { ...state.versions.artifact },
+      service: { ...state.versions.service },
+      automation: { ...state.versions.automation },
       agent: { ...state.versions.agent },
       model: { ...state.versions.model }
     }
@@ -1057,6 +1124,114 @@ function cloneRepoWorktreeIndexWindow(window: RepoWorktreeIndexWindow): RepoWork
     topologyWindow: window.topologyWindow ? { ...window.topologyWindow } : null,
     runtimeWindow: window.runtimeWindow ? { ...window.runtimeWindow } : null
   };
+}
+
+export function previewServicesWindowKey(scope: string | null | undefined = null): string {
+  return normalizedPreviewServicesScope(scope) ?? 'all';
+}
+
+function normalizedPreviewServicesScope(scope: string | null | undefined): string | null {
+  const trimmed = scope?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function selectPreviewServicesReadModel(
+  state: ReadModelEntityState,
+  scope: string | null | undefined = null
+): PreviewServicesReadModel | null {
+  return state.previewServices[previewServicesWindowKey(scope)]?.model ?? null;
+}
+
+export function selectAutomationWorkspace(state: ReadModelEntityState): AutomationWorkspace | null {
+  return state.automationWorkspace;
+}
+
+function clonePreviewServicesCacheEntry(entry: PreviewServicesCacheEntry): PreviewServicesCacheEntry {
+  return {
+    ...entry,
+    model: clonePreviewServicesReadModel(entry.model)
+  };
+}
+
+function clonePreviewServicesReadModel(model: PreviewServicesReadModel): PreviewServicesReadModel {
+  return {
+    services: model.services.map((service) => clonePreviewService(service)),
+    counts: { ...model.counts }
+  };
+}
+
+function clonePreviewService(service: PreviewServiceReadModel): PreviewServiceReadModel {
+  return {
+    ...service,
+    scopeLinks: service.scopeLinks.map((link) => ({ ...link })),
+    restartPolicy: { ...service.restartPolicy },
+    healthCheck: service.healthCheck ? { ...service.healthCheck } : null,
+    logs: service.logs ? { ...service.logs } : null,
+    metadata: { ...service.metadata },
+    capabilities: { ...service.capabilities },
+    desiredState: { ...service.desiredState },
+    observedState: { ...service.observedState },
+    raw: { ...service.raw }
+  };
+}
+
+function mergeAutomationWorkspaceSnapshot(
+  snapshot: AutomationWorkspace,
+  previous: AutomationWorkspace | null
+): AutomationWorkspace {
+  if (!previous) return cloneAutomationWorkspace(snapshot);
+  const previousById = new Map(previous.automations.map((automation) => [automation.id, automation]));
+  const next = cloneAutomationWorkspace(snapshot);
+  next.automations = next.automations.map((automation) => {
+    const previousAutomation = previousById.get(automation.id);
+    return shouldKeepHydratedAutomation(previousAutomation, automation)
+      ? cloneAutomationSummary({
+          ...automation,
+          jobs: previousAutomation.jobs,
+          jobCount: Math.max(automation.jobCount, previousAutomation.jobCount, previousAutomation.jobs.length),
+          raw: previousAutomation.raw
+        })
+      : automation;
+  });
+  return next;
+}
+
+function shouldKeepHydratedAutomation(
+  previous: AutomationSummary | undefined,
+  next: AutomationSummary
+): previous is AutomationSummary {
+  if (!previous) return false;
+  const previousJobCount = previous.jobs.length || previous.jobCount;
+  const nextJobCount = next.jobs.length || next.jobCount;
+  return previousJobCount > nextJobCount;
+}
+
+function cloneAutomationWorkspace(workspace: AutomationWorkspace): AutomationWorkspace {
+  return {
+    ...workspace,
+    automations: workspace.automations.map(cloneAutomationSummary),
+    presets: workspace.presets.map((preset) => cloneJson(preset)),
+    summary: { ...workspace.summary },
+    targetOptions: workspace.targetOptions.map((option) => cloneJson(option)),
+    agentDefaults: cloneJson(workspace.agentDefaults)
+  };
+}
+
+function cloneAutomationSummary(automation: AutomationSummary): AutomationSummary {
+  return cloneJson(automation);
+}
+
+function automationSummaryCounts(automations: AutomationSummary[]): AutomationWorkspace['summary'] {
+  return {
+    total: automations.length,
+    active: automations.filter((automation) => automation.enabled).length,
+    paused: automations.filter((automation) => !automation.enabled).length,
+    failedJobs: automations.filter((automation) => automation.lastJob?.effectiveState === 'failed').length
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
 }
 
 function cloneTimelineProjection(timeline: TimelineProjection): TimelineProjection {

--- a/src/codex_autorunner/web_frontend/src/lib/routes/readModelRouteConventions.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/readModelRouteConventions.test.ts
@@ -1,0 +1,87 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROUTES_ROOT = fileURLToPath(new URL('../../routes', import.meta.url));
+
+const KNOWN_DIRECT_READ_MODEL_PAGES = new Set<string>();
+
+const DIRECT_READ_MODEL_PATTERNS = [
+  /\bgetServicesReadModel\s*\(/,
+  /\bgetAutomationWorkspace(?:Index)?\s*\(/,
+  /\breadModels\.\w+\s*\(/,
+  /['"`]\/hub\/read-models\//
+];
+
+function walkSveltePages(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walkSveltePages(path, files);
+      continue;
+    }
+    if (entry === '+page.svelte') files.push(path);
+  }
+  return files;
+}
+
+function walkRouteLoaders(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walkRouteLoaders(path, files);
+      continue;
+    }
+    if (entry === '+page.ts') files.push(path);
+  }
+  return files;
+}
+
+function hasDirectReadModelFetch(source: string): boolean {
+  return DIRECT_READ_MODEL_PATTERNS.some((pattern) => pattern.test(source));
+}
+
+function hasReadModelEnsureCall(source: string): boolean {
+  return /\bensure[A-Za-z0-9]+Loaded\s*\(/.test(source);
+}
+
+function hasNonBlockingLoader(source: string): boolean {
+  return /\bblocking\s*:\s*false\b/.test(source);
+}
+
+describe('read-model route loading conventions', () => {
+  it('keeps read-model snapshots behind route loaders and the shared entity store', () => {
+    const violations: string[] = [];
+
+    for (const file of walkSveltePages(ROUTES_ROOT)) {
+      const relativePath = relative(ROUTES_ROOT, file);
+      if (KNOWN_DIRECT_READ_MODEL_PAGES.has(relativePath)) continue;
+      const source = readFileSync(file, 'utf8');
+      if (!hasDirectReadModelFetch(source)) continue;
+      const routeLoad = join(dirname(file), '+page.ts');
+      violations.push(
+        existsSync(routeLoad)
+          ? relativePath
+          : `${relativePath} (missing sibling +page.ts route loader)`
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps route read-model loaders non-blocking so cached screens stay responsive', () => {
+    const violations: string[] = [];
+
+    for (const file of walkRouteLoaders(ROUTES_ROOT)) {
+      const source = readFileSync(file, 'utf8');
+      if (!hasReadModelEnsureCall(source)) continue;
+      if (hasNonBlockingLoader(source)) continue;
+      violations.push(relative(ROUTES_ROOT, file));
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import AgentModelReasoningPicker from '$lib/components/AgentModelReasoningPicker.svelte';
   import ContentSkeleton from '$lib/components/ContentSkeleton.svelte';
   import MasterDetail from '$lib/components/MasterDetail.svelte';
@@ -14,7 +14,6 @@
   import {
     webApi,
     type ApiError,
-    type AutomationOverview,
     type AutomationPresetDescriptor,
     type AutomationSummary,
     type AutomationTargetOption,
@@ -22,17 +21,28 @@
     type JsonRecord
   } from '$lib/api/client';
   import { resolveAgentModelSelection } from '$lib/viewModels/modelPickers';
+  import {
+    ensureAutomationWorkspaceLoaded,
+    readModelEntityStore,
+    selectAutomationWorkspace
+  } from '$lib/data';
 
   type PresetId = 'security_scan_pr' | 'weekly_ticket_flow';
   type SelectionKind = 'automation' | 'preset' | null;
   type JsonField = 'trigger' | 'filters' | 'target' | 'executor' | 'policy' | 'metadata';
   type TicketPackTicket = { path: string; content: string };
 
-  let overview = $state<AutomationOverview | null>(null);
+  let { data = { status: 'cold' as const, tags: [] } } = $props();
+  let readModelState = $state(readModelEntityStore.snapshot());
+  let unsubscribeReadModels: (() => void) | null = null;
+  const overview = $derived(selectAutomationWorkspace(readModelState));
+  const hasCachedWorkspace = $derived(Boolean(overview));
   let targetOptions = $state<AutomationTargetOption[]>([]);
   let agents = $state<JsonRecord[]>([]);
   let models = $state<JsonRecord[]>([]);
-  let loading = $state(true);
+  let refreshing = $state(false);
+  let coldHydrating = $state(true);
+  const loading = $derived((data.status === 'cold' && coldHydrating && !hasCachedWorkspace) || (refreshing && !hasCachedWorkspace));
   let loadingTargetOptions = $state(false);
   let loadingAgents = $state(false);
   let loadingModels = $state(false);
@@ -96,31 +106,36 @@
   );
 
   onMount(() => {
-    void load();
+    unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
+      readModelState = state;
+    });
+    void load({ showLoading: data.status === 'cold' && !hasCachedWorkspace });
     return () => {
       if (saveTimer) window.clearTimeout(saveTimer);
     };
   });
 
-  async function load(): Promise<void> {
-    loading = true;
+  onDestroy(() => {
+    unsubscribeReadModels?.();
+  });
+
+  async function load(options: { showLoading?: boolean } = {}): Promise<void> {
+    if (options.showLoading !== false) refreshing = true;
     error = null;
-    const automationResult = await webApi.hub.getAutomationWorkspaceIndex();
-    if (automationResult.ok) {
-      overview = mergeAutomationOverview(automationResult.data);
-      if (!selectedRepoId) {
-        selectedRepoId = presetTargetOptions.find((option) => !option.disabled)?.id ?? presetTargetOptions[0]?.id ?? '';
+    try {
+      const result = await ensureAutomationWorkspaceLoaded({ refresh: true });
+      if (result.status === 'error') {
+        error = result.error;
+        return;
       }
-      defaultAgentId = automationResult.data.agentDefaults.defaultAgent;
-      defaultProfile = automationResult.data.agentDefaults.defaultProfile ?? '';
-      selectedModel = selectedModel || automationResult.data.agentDefaults.defaultModel || '';
-      selectedReasoning = selectedReasoning || automationResult.data.agentDefaults.defaultReasoning || '';
+      syncWorkspaceDefaults();
+      syncDraftsForSelection(true);
+      if (selectedKind === 'automation' && selectedId) void hydrateAutomationDetail(selectedId, { force: true });
+      void hydrateTargetOptions();
+    } finally {
+      coldHydrating = false;
+      refreshing = false;
     }
-    else error = automationResult.error;
-    loading = false;
-    syncDraftsForSelection(true);
-    if (selectedKind === 'automation' && selectedId) void hydrateAutomationDetail(selectedId, { force: true });
-    void hydrateTargetOptions();
   }
 
   async function hydrateAgentCatalog(): Promise<void> {
@@ -155,16 +170,16 @@
     }
   }
 
-  function mergeAutomationOverview(next: AutomationOverview): AutomationOverview {
-    if (!overview || hydratedDetailIds.length === 0) return next;
-    const currentById = new Map(overview.automations.map((automation) => [automation.id, automation]));
-    return {
-      ...next,
-      automations: next.automations.map((automation) => {
-        const current = currentById.get(automation.id);
-        return current && hydratedDetailIds.includes(automation.id) ? current : automation;
-      })
-    };
+  function syncWorkspaceDefaults(): void {
+    const workspace = selectAutomationWorkspace(readModelEntityStore.snapshot());
+    if (!workspace) return;
+    if (!selectedRepoId) {
+      selectedRepoId = presetTargetOptions.find((option) => !option.disabled)?.id ?? presetTargetOptions[0]?.id ?? '';
+    }
+    defaultAgentId = workspace.agentDefaults.defaultAgent;
+    defaultProfile = workspace.agentDefaults.defaultProfile ?? '';
+    selectedModel = selectedModel || workspace.agentDefaults.defaultModel || '';
+    selectedReasoning = selectedReasoning || workspace.agentDefaults.defaultReasoning || '';
   }
 
   async function hydrateAutomationDetail(ruleId: string, options: { force?: boolean } = {}): Promise<void> {
@@ -332,17 +347,7 @@
 
   function replaceAutomation(updated: AutomationSummary): void {
     if (!overview) return;
-    const nextAutomations = overview.automations.map((automation) => (automation.id === updated.id ? updated : automation));
-    overview = {
-      ...overview,
-      automations: nextAutomations,
-      summary: {
-        total: nextAutomations.length,
-        active: nextAutomations.filter((automation) => automation.enabled).length,
-        paused: nextAutomations.filter((automation) => !automation.enabled).length,
-        failedJobs: nextAutomations.filter((automation) => automation.lastJob?.effectiveState === 'failed').length
-      }
-    };
+    readModelEntityStore.replaceAutomationSummary(updated);
   }
 
   async function savePatch(patch: AutomationUpdateRequest, label: string): Promise<void> {
@@ -441,9 +446,7 @@
       error = result.error;
       return;
     }
-    overview = overview
-      ? { ...overview, automations: [...overview.automations, result.data] }
-      : { automations: [result.data], presets, summary: { total: 1, active: result.data.enabled ? 1 : 0, paused: result.data.enabled ? 0 : 1, failedJobs: 0 } };
+    readModelEntityStore.replaceAutomationSummary(result.data);
     notice = `Created ${result.data.name}${result.data.enabled ? '' : ' — paused'}`;
     detailMode = 'detail';
     await goto(automationRoute(result.data.id));
@@ -481,19 +484,7 @@
       error = result.error;
       return;
     }
-    if (overview) {
-      const nextAutomations = overview.automations.filter((entry) => entry.id !== automation.id);
-      overview = {
-        ...overview,
-        automations: nextAutomations,
-        summary: {
-          total: nextAutomations.length,
-          active: nextAutomations.filter((entry) => entry.enabled).length,
-          paused: nextAutomations.filter((entry) => !entry.enabled).length,
-          failedJobs: nextAutomations.filter((entry) => entry.lastJob?.state === 'failed').length
-        }
-      };
-    }
+    readModelEntityStore.removeAutomationSummary(automation.id);
     selectedKind = null;
     selectedId = '';
     detailMode = 'list';

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.ts
@@ -1,0 +1,5 @@
+import { ensureAutomationWorkspaceLoaded } from '$lib/data';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ depends }) =>
+  ensureAutomationWorkspaceLoaded({ depends, blocking: false });

--- a/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
@@ -10,7 +10,7 @@ describe('/automations page', () => {
   }
 
   it('renders the automation workspace shell before client automation data resolves', () => {
-    const { body } = render(Page);
+    const { body } = render(Page, { props: { data: { status: 'cold', tags: [] } } });
 
     expect(body).toContain('Automations workspace');
     expect(body).toContain('skeleton-chat-list');
@@ -57,10 +57,14 @@ describe('/automations page', () => {
     expect(canToggleEnabled).toContain('return Boolean(automation.product.editable.canEnable);');
   });
 
-  it('loads the workspace index before hydrating detail, repo, and agent controls', () => {
+  it('loads cached workspace data before hydrating detail, repo, and agent controls', () => {
     const source = pageSource();
+    const loadSource = readFileSync(fileURLToPath(new URL('./[[ruleId]]/+page.ts', import.meta.url)), 'utf8');
 
-    expect(source).toContain('webApi.hub.getAutomationWorkspaceIndex()');
+    expect(loadSource).toContain('ensureAutomationWorkspaceLoaded({ depends, blocking: false })');
+    expect(source).toContain('selectAutomationWorkspace(readModelState)');
+    expect(source).toContain('ensureAutomationWorkspaceLoaded({ refresh: true })');
+    expect(source).not.toContain('webApi.hub.getAutomationWorkspaceIndex()');
     expect(source).toContain('webApi.hub.getAutomation(ruleId)');
     expect(source).toContain('webApi.hub.getAutomationTargetOptions()');
     expect(source).toContain("const presetTargetOptions = $derived(targetOptions.filter((option) => option.kind === 'repo'))");

--- a/src/codex_autorunner/web_frontend/src/routes/services/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/services/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import AutoDismissNotice from '$lib/components/AutoDismissNotice.svelte';
   import ContentSkeleton from '$lib/components/ContentSkeleton.svelte';
   import PageHero from '$lib/components/PageHero.svelte';
@@ -35,9 +35,20 @@
     serviceUptimeLabel,
     type ServiceFilters
   } from '$lib/viewModels/services';
+  import {
+    ensureServicesLoaded,
+    readModelEntityStore,
+    selectPreviewServicesReadModel
+  } from '$lib/data';
 
-  let model = $state<PreviewServicesReadModel | null>(null);
-  let loading = $state(true);
+  let { data = { status: 'cold' as const, tags: [] } } = $props();
+  let readModelState = $state(readModelEntityStore.snapshot());
+  let unsubscribeReadModels: (() => void) | null = null;
+  const model = $derived<PreviewServicesReadModel | null>(selectPreviewServicesReadModel(readModelState));
+  const hasCachedServices = $derived(Boolean(model));
+  let refreshing = $state(false);
+  let coldHydrating = $state(true);
+  const loading = $derived((data.status === 'cold' && coldHydrating && !hasCachedServices) || (refreshing && !hasCachedServices));
   let actionId = $state<string | null>(null);
   let error = $state<ApiError | null>(null);
   let notice = $state<string | null>(null);
@@ -113,31 +124,38 @@
   const createModeHint = $derived(createModeHints[createMode]);
 
   onMount(() => {
-    void loadServices();
+    unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
+      readModelState = state;
+    });
+    void loadServices({ showLoading: data.status === 'cold' && !hasCachedServices });
     return () => {
       if (copyTimer) clearTimeout(copyTimer);
     };
   });
 
-  async function loadServices(): Promise<void> {
-    loading = true;
+  onDestroy(() => {
+    unsubscribeReadModels?.();
+  });
+
+  async function loadServices(options: { showLoading?: boolean } = {}): Promise<void> {
+    if (options.showLoading !== false) refreshing = true;
     error = null;
-    const result = await webApi.hub.getServicesReadModel();
-    loading = false;
-    if (!result.ok) {
-      error = result.error;
-      return;
+    try {
+      const result = await ensureServicesLoaded({ refresh: true });
+      if (result.status === 'error') {
+        error = result.error;
+      }
+    } finally {
+      coldHydrating = false;
+      refreshing = false;
     }
-    model = result.data;
   }
 
   async function refreshServices(): Promise<void> {
-    const result = await webApi.hub.getServicesReadModel();
-    if (!result.ok) {
+    const result = await ensureServicesLoaded({ refresh: true });
+    if (result.status === 'error') {
       error = result.error;
-      return;
     }
-    model = result.data;
   }
 
   async function runLifecycle(service: PreviewServiceReadModel, action: PreviewServiceAction): Promise<void> {
@@ -564,7 +582,7 @@
           {showRegister ? 'Hide register' : '+ Register service'}
         </button>
       {/if}
-      <button class="ghost-button" type="button" onclick={loadServices} disabled={loading}>Refresh</button>
+      <button class="ghost-button" type="button" onclick={() => loadServices()} disabled={loading}>Refresh</button>
     {/snippet}
   </PageHero>
 
@@ -574,7 +592,7 @@
     <div class="state-panel error">
       <strong>Could not load services</strong>
       <p>{error.message}</p>
-      <button class="ghost-button" type="button" onclick={loadServices}>Retry</button>
+      <button class="ghost-button" type="button" onclick={() => loadServices()}>Retry</button>
     </div>
   {:else}
     {#if error}

--- a/src/codex_autorunner/web_frontend/src/routes/services/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/services/+page.ts
@@ -1,0 +1,4 @@
+import { ensureServicesLoaded } from '$lib/data';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ depends }) => ensureServicesLoaded({ depends, blocking: false });


### PR DESCRIPTION
## Summary

- Move Services and Automations list snapshots onto the shared read-model store with non-blocking route loaders.
- Keep cached/stale data visible while background refreshes run, instead of returning to skeletons after first load.
- Add a static read-model route convention test that blocks direct page-level read-model fetches and blocking route loaders.
- Document the read-model-backed page pattern in the Web UI agent guide.

## Root Cause

Services and Automations were fetching read-model snapshots directly from `+page.svelte` and toggling local loading state, so revisiting those pages could blank back to skeletons even when useful data had already loaded. Chats and Repos avoid that by using route loaders plus `readModelEntityStore` as a durable browser cache.

## Validation

- Subagent review completed; addressed findings around stale Automations detail merge and static-check coverage.
- `pnpm --dir src/codex_autorunner/web_frontend exec vitest run src/lib/data/readModelStore.test.ts src/lib/routes/readModelRouteConventions.test.ts src/routes/automations/page.test.ts src/lib/data/readModelLoaders.test.ts`
- `pnpm web:lint`
- `pnpm web:test`
- Pre-commit `scripts/check.sh` web-ui lane passed, including guardrails, mypy, fast pytest, Web UI lab, frontend lint, build, web tests, and SPA shell check.

Note: the first pre-commit attempt hit a transient Hypothesis `too_slow` health check in `tests/contracts/scope/test_scope_resolver_contract.py::TestUrnRoundTripInvariants::test_scope_ref_urn_round_trip`; rerunning the exact seed passed, and the second full pre-commit run passed.