### PR TITLE
[codex] Fix services overflow menu layout

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/components/OverflowMenu.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/OverflowMenu.svelte
@@ -8,6 +8,8 @@
    * Pattern follows DropdownSelect for outside-click + escape behavior.
    */
 
+  import { tick } from 'svelte';
+  import { overflowMenuPosition } from './OverflowMenu';
   import type { OverflowMenuItem } from './OverflowMenu';
 
   let {
@@ -24,15 +26,37 @@
   let activeIndex = $state(0);
   let triggerEl = $state<HTMLButtonElement | null>(null);
   let panelEl = $state<HTMLDivElement | null>(null);
+  let panelPortalParent: HTMLElement | null = null;
+  let panelTop = $state(0);
+  let panelLeft = $state(0);
 
   const selectableItems = $derived(items.filter((item) => !item.disabled));
 
-  function openPanel(): void {
+  const panelStyle = $derived(`top: ${panelTop}px; left: ${panelLeft}px;`);
+
+  function updatePanelPosition(): void {
+    if (typeof window === 'undefined' || !triggerEl) return;
+    const rect = triggerEl.getBoundingClientRect();
+    const panelRect = panelEl?.getBoundingClientRect();
+    const position = overflowMenuPosition({
+      triggerRect: rect,
+      panelWidth: panelRect?.width ?? 180,
+      panelHeight: panelRect?.height ?? 0,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight
+    });
+    panelTop = position.top;
+    panelLeft = position.left;
+  }
+
+  async function openPanel(): Promise<void> {
     if (selectableItems.length === 0) return;
     open = true;
     const firstEnabled = items.findIndex((item) => !item.disabled);
     activeIndex = firstEnabled >= 0 ? firstEnabled : 0;
-    queueMicrotask(() => panelEl?.focus());
+    await tick();
+    updatePanelPosition();
+    panelEl?.focus();
   }
 
   function closePanel(): void {
@@ -43,7 +67,7 @@
     event.preventDefault();
     event.stopPropagation();
     if (open) closePanel();
-    else openPanel();
+    else void openPanel();
   }
 
   function selectItem(item: OverflowMenuItem): void {
@@ -66,7 +90,7 @@
   function handleTriggerKeydown(event: KeyboardEvent): void {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      openPanel();
+      void openPanel();
     }
   }
 
@@ -95,6 +119,29 @@
     if (triggerEl?.contains(target) || panelEl?.contains(target)) return;
     closePanel();
   }
+
+  $effect(() => {
+    if (!open || typeof window === 'undefined') return;
+    updatePanelPosition();
+    window.addEventListener('resize', updatePanelPosition);
+    window.addEventListener('scroll', updatePanelPosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePanelPosition);
+      window.removeEventListener('scroll', updatePanelPosition, true);
+    };
+  });
+
+  $effect(() => {
+    if (!panelEl || typeof document === 'undefined') return;
+    panelPortalParent = document.body;
+    document.body.appendChild(panelEl);
+    return () => {
+      const parent = panelPortalParent;
+      if (parent && panelEl && panelEl.parentNode === parent) {
+        parent.removeChild(panelEl);
+      }
+    };
+  });
 </script>
 
 <svelte:window onpointerdown={onWindowPointerDown} />
@@ -127,6 +174,7 @@
       role="menu"
       aria-label={ariaLabel}
       tabindex="-1"
+      style={panelStyle}
       onkeydown={handlePanelKeydown}
     >
       {#each items as item, idx (item.label)}
@@ -198,13 +246,14 @@
   }
 
   .overflow-menu-panel {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
+    position: fixed;
     z-index: 40;
     display: flex;
     flex-direction: column;
-    min-width: 180px;
+    min-width: min(180px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: 4px;
     background: var(--color-surface);
     border: 1px solid var(--color-border-subtle);

--- a/src/codex_autorunner/web_frontend/src/lib/components/OverflowMenu.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/OverflowMenu.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { overflowMenuPosition } from './OverflowMenu';
+
+describe('overflowMenuPosition', () => {
+  it('opens below the trigger when the panel fits', () => {
+    expect(
+      overflowMenuPosition({
+        triggerRect: { top: 100, bottom: 130, right: 420 },
+        panelWidth: 180,
+        panelHeight: 96,
+        viewportWidth: 800,
+        viewportHeight: 600
+      })
+    ).toEqual({ top: 134, left: 240 });
+  });
+
+  it('flips above the trigger near the viewport bottom', () => {
+    expect(
+      overflowMenuPosition({
+        triggerRect: { top: 540, bottom: 570, right: 760 },
+        panelWidth: 180,
+        panelHeight: 120,
+        viewportWidth: 800,
+        viewportHeight: 600
+      })
+    ).toEqual({ top: 416, left: 580 });
+  });
+
+  it('clamps horizontally for triggers near the viewport left edge', () => {
+    expect(
+      overflowMenuPosition({
+        triggerRect: { top: 100, bottom: 130, right: 40 },
+        panelWidth: 180,
+        panelHeight: 96,
+        viewportWidth: 800,
+        viewportHeight: 600
+      }).left
+    ).toBe(8);
+  });
+});

--- a/src/codex_autorunner/web_frontend/src/lib/components/OverflowMenu.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/OverflowMenu.ts
@@ -6,3 +6,47 @@ export type OverflowMenuItem = {
   ariaLabel?: string;
   title?: string;
 };
+
+type OverflowMenuRect = Pick<DOMRect, 'top' | 'bottom' | 'right'>;
+
+export type OverflowMenuPositionInput = {
+  triggerRect: OverflowMenuRect;
+  panelWidth: number;
+  panelHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  margin?: number;
+  gap?: number;
+};
+
+export type OverflowMenuPosition = {
+  top: number;
+  left: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+export function overflowMenuPosition({
+  triggerRect,
+  panelWidth,
+  panelHeight,
+  viewportWidth,
+  viewportHeight,
+  margin = 8,
+  gap = 4
+}: OverflowMenuPositionInput): OverflowMenuPosition {
+  const maxLeft = viewportWidth - panelWidth - margin;
+  const left = clamp(triggerRect.right - panelWidth, margin, maxLeft);
+  const belowTop = triggerRect.bottom + gap;
+  const aboveTop = triggerRect.top - panelHeight - gap;
+  const top =
+    belowTop + panelHeight <= viewportHeight - margin
+      ? belowTop
+      : aboveTop >= margin
+        ? aboveTop
+        : clamp(belowTop, margin, viewportHeight - panelHeight - margin);
+  return { top, left };
+}

--- a/src/codex_autorunner/web_frontend/src/routes/services/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/services/+page.svelte
@@ -688,7 +688,7 @@
               <th>Class</th>
               <th>Target</th>
               <th>Uptime</th>
-              <th>Owner</th>
+              <th class="col-pid">PID</th>
               <th class="col-links">Links</th>
               <th class="col-actions">Actions</th>
             </tr>
@@ -724,7 +724,7 @@
                 </td>
                 <td><span class="truncate cell-muted">{serviceTargetLabel(service)}</span></td>
                 <td class="cell-num">{serviceUptimeLabel(service)}</td>
-                <td class="cell-muted">{service.ownerPid ? `pid ${service.ownerPid}` : service.createdBy ?? '—'}</td>
+                <td class="cell-num col-pid">{service.ownerPid ?? '—'}</td>
                 <td class="col-links">
                   {#if eligibility.canOpen}
                     <div class="link-actions">
@@ -1067,10 +1067,12 @@
     vertical-align: middle;
   }
 
+  .services-table .col-pid,
   .services-table .col-links,
   .services-table .col-actions {
     text-align: right;
     white-space: nowrap;
+    width: 1%;
   }
 
   .services-table tbody tr {
@@ -1217,6 +1219,10 @@
     flex-wrap: nowrap;
     align-items: center;
     gap: var(--space-1);
+  }
+
+  .link-actions {
+    justify-content: flex-end;
   }
 
   .row-actions {


### PR DESCRIPTION
## Summary

- Portal `OverflowMenu` panels to `document.body` and position them against the trigger so menus are not clipped by scroll containers.
- Add a tested `overflowMenuPosition` helper for below/above placement and viewport clamping.
- Change the Services table `Owner` column to `PID`, display `—` when no process is attached, and tighten PID/Links/Actions columns so row buttons no longer spread apart.

## Review

Subagent review: no findings. Residual risk noted: real-browser edge cases around portaled menu positioning were not manually verified.

## Validation

- `pnpm run lint`
- `pnpm run test`
- pre-commit web-ui lane: guardrails, static checks, repo pytest (`9796 passed`), Web UI lab fast scenarios, `pnpm web:lint`, SvelteKit build, `pnpm web:test`, SPA shell check