### PR TITLE
[codex] Make chat titles explicit and editable

### DIFF
--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -77,8 +77,8 @@ from .orchestration.runtime_bindings import (
     set_runtime_thread_binding,
 )
 from .orchestration.thread_titles import (
-    EXPLICIT_TITLE_SOURCE,
     FIRST_MESSAGE_TITLE_SOURCE,
+    PROVIDER_TITLE_SOURCE,
     choose_owned_thread_title,
     is_deprioritized_thread_title,
     is_generic_thread_title,
@@ -1332,8 +1332,20 @@ class ManagedThreadStore:
                     and metadata_patch.get("car_title_source") == "message_preview"
                 ):
                     source = FIRST_MESSAGE_TITLE_SOURCE
+                if source is None and may_replace_preview_title:
+                    source = FIRST_MESSAGE_TITLE_SOURCE
+                if source is None and (
+                    metadata_patch.get("provider_conversation_title")
+                    or metadata_patch.get("provider_conversation_summary")
+                ):
+                    source = PROVIDER_TITLE_SOURCE
+                if source is None and thread_title_source_allows_replacement(
+                    current_title_source
+                ):
+                    source = normalize_thread_title_source(current_title_source)
                 metadata_patch = dict(metadata_patch)
-                metadata_patch["title_source"] = source or EXPLICIT_TITLE_SOURCE
+                if source is not None:
+                    metadata_patch["title_source"] = source
                 metadata_patch.pop("car_title_source", None)
             updated_metadata = dict(current_metadata)
             updated_metadata.update(metadata_patch)

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -77,10 +77,14 @@ from .orchestration.runtime_bindings import (
     set_runtime_thread_binding,
 )
 from .orchestration.thread_titles import (
+    EXPLICIT_TITLE_SOURCE,
+    FIRST_MESSAGE_TITLE_SOURCE,
     choose_owned_thread_title,
     is_deprioritized_thread_title,
     is_generic_thread_title,
     normalize_thread_title,
+    normalize_thread_title_source,
+    thread_title_source_allows_replacement,
 )
 from .orchestration.turn_assistant_output import TurnAssistantOutput
 from .orchestration.turn_execution_contract import (
@@ -1278,12 +1282,14 @@ class ManagedThreadStore:
             current_metadata = _sanitize_thread_metadata(
                 dict(thread.get("metadata") or {})
             )
-            current_title_source = _coerce_text(
-                current_metadata.get("car_title_source")
-            )
+            current_title_source = _coerce_text(current_metadata.get("title_source"))
+            if current_title_source is None:
+                current_title_source = _coerce_text(
+                    current_metadata.get("car_title_source")
+                )
             incoming_title = normalize_thread_title(title)
             may_replace_preview_title = (
-                current_title_source == "message_preview"
+                current_title_source in {"message_preview", FIRST_MESSAGE_TITLE_SOURCE}
                 and incoming_title is not None
                 and not is_generic_thread_title(incoming_title)
             )
@@ -1300,13 +1306,34 @@ class ManagedThreadStore:
                 and next_title != current_title
                 and (
                     not only_if_generic
-                    or is_generic_thread_title(current_title)
-                    or is_deprioritized_thread_title(current_title)
+                    or thread_title_source_allows_replacement(current_title_source)
                     or may_replace_preview_title
+                    or (
+                        current_title_source is None
+                        and (
+                            is_generic_thread_title(current_title)
+                            or is_deprioritized_thread_title(current_title)
+                        )
+                    )
                 )
             )
-            if not should_update_title and "car_title_source" in metadata_patch:
+            if not should_update_title and (
+                "car_title_source" in metadata_patch or "title_source" in metadata_patch
+            ):
                 metadata_patch = dict(metadata_patch)
+                metadata_patch.pop("car_title_source", None)
+                metadata_patch.pop("title_source", None)
+            if should_update_title and "title_source" not in metadata_patch:
+                source = normalize_thread_title_source(
+                    metadata_patch.get("car_title_source")
+                )
+                if (
+                    source is None
+                    and metadata_patch.get("car_title_source") == "message_preview"
+                ):
+                    source = FIRST_MESSAGE_TITLE_SOURCE
+                metadata_patch = dict(metadata_patch)
+                metadata_patch["title_source"] = source or EXPLICIT_TITLE_SOURCE
                 metadata_patch.pop("car_title_source", None)
             updated_metadata = dict(current_metadata)
             updated_metadata.update(metadata_patch)

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -79,6 +79,7 @@ from .orchestration.runtime_bindings import (
 from .orchestration.thread_titles import (
     EXPLICIT_TITLE_SOURCE,
     FIRST_MESSAGE_TITLE_SOURCE,
+    PROVIDER_TITLE_SOURCE,
     choose_owned_thread_title,
     is_deprioritized_thread_title,
     is_generic_thread_title,
@@ -1293,9 +1294,14 @@ class ManagedThreadStore:
                 and incoming_title is not None
                 and not is_generic_thread_title(incoming_title)
             )
+            may_replace_sourced_title = (
+                thread_title_source_allows_replacement(current_title_source)
+                and incoming_title is not None
+                and not is_generic_thread_title(incoming_title)
+            )
             next_title = (
                 incoming_title
-                if may_replace_preview_title
+                if may_replace_preview_title or may_replace_sourced_title
                 else choose_owned_thread_title(
                     current_title,
                     provider_title=title,
@@ -1308,6 +1314,7 @@ class ManagedThreadStore:
                     not only_if_generic
                     or thread_title_source_allows_replacement(current_title_source)
                     or may_replace_preview_title
+                    or may_replace_sourced_title
                     or (
                         current_title_source is None
                         and (
@@ -1333,7 +1340,9 @@ class ManagedThreadStore:
                 ):
                     source = FIRST_MESSAGE_TITLE_SOURCE
                 metadata_patch = dict(metadata_patch)
-                metadata_patch["title_source"] = source or EXPLICIT_TITLE_SOURCE
+                metadata_patch["title_source"] = source or (
+                    PROVIDER_TITLE_SOURCE if only_if_generic else EXPLICIT_TITLE_SOURCE
+                )
                 metadata_patch.pop("car_title_source", None)
             updated_metadata = dict(current_metadata)
             updated_metadata.update(metadata_patch)

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1529,6 +1529,7 @@ class ChatSurfaceReadService:
                     "provider_conversation_title": _normalize_text(
                         metadata.get("provider_conversation_title")
                     ),
+                    "title_source": _normalize_text(metadata.get("title_source")),
                     "turn_kinds": execution_facets.get("turn_kinds") or ["message"],
                     "origin_kinds": execution_facets.get("origin_kinds") or ["surface"],
                     "last_visible_message_at": last_visible_message_at,
@@ -2195,6 +2196,8 @@ def _chat_index_rows_from_surfaces(
         )
         if surface_kind == "pma" or row.get("surface") is None:
             row["surface"] = base_surface
+            if metadata_map.get("title_source") is not None:
+                row["title_source"] = metadata_map.get("title_source")
             row["title"] = _display_title(display_map, managed_thread_id)
             for key in (
                 "repo_id",
@@ -2285,10 +2288,6 @@ def _chat_index_rows_from_surfaces(
         row["display_title"] = _normalize_text(row.get("chat_display_name")) or str(
             row.get("title") or row.get("chat_id") or row.get("row_id") or ""
         )
-        if row.get("managed_thread_id") is not None:
-            binding_title = _direct_external_binding_display_name(row)
-            if binding_title is not None:
-                row["display_title"] = binding_title
         _apply_ticket_flow_child_state(row)
         row["technical_title"] = _normalize_text(row.get("technical_title")) or str(
             row.get("managed_thread_id") or row.get("row_id") or ""
@@ -2365,6 +2364,7 @@ def _managed_thread_identity_title(row: Mapping[str, Any]) -> str:
         resolve_managed_thread_display_title(
             ManagedThreadTitleInputs(
                 stored_title=_visible_chrome_text(row.get("title")),
+                stored_title_source=row.get("title_source"),
                 provider_title=_visible_chrome_text(
                     row.get("provider_conversation_title")
                 ),
@@ -2466,23 +2466,6 @@ def _binding_display_names(surfaces: Iterable[Mapping[str, Any]]) -> list[str]:
         if name not in names:
             names.append(name)
     return names
-
-
-def _direct_external_binding_display_name(row: Mapping[str, Any]) -> Optional[str]:
-    for surface in row.get("surface_bindings") or []:
-        if not isinstance(surface, Mapping):
-            continue
-        surface_kind = _normalize_kind(surface.get("surface_kind"))
-        if surface_kind in {None, "pma", "managed_thread", "notification"}:
-            continue
-        name = _visible_chrome_text(
-            surface.get("binding_display_name")
-            or surface.get("display_name")
-            or surface.get("title")
-        )
-        if name is not None and not _is_surface_id_title(name, surface):
-            return name
-    return None
 
 
 def _primary_surface(row: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
@@ -3487,6 +3470,7 @@ def _chat_detail_thread_metadata(
     title = resolve_managed_thread_display_title(
         ManagedThreadTitleInputs(
             stored_title=stored_title,
+            stored_title_source=metadata_map.get("title_source"),
             provider_title=metadata_map.get("provider_conversation_title"),
             user_visible_title_seed=thread.get("last_message_preview"),
             chat_display_name=chat_display_name,
@@ -4239,6 +4223,7 @@ def _pma_thread_from_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
     display_title = resolve_managed_thread_display_title(
         ManagedThreadTitleInputs(
             stored_title=_visible_chrome_text(display.get("display_name")),
+            stored_title_source=metadata.get("title_source"),
             provider_title=metadata.get("provider_conversation_title"),
             user_visible_title_seed=metadata.get("last_message_preview"),
             chat_display_name=chat_display_name,

--- a/src/codex_autorunner/core/orchestration/execution_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/execution_lifecycle.py
@@ -28,6 +28,8 @@ from .runtime_bindings import (
     runtime_thread_binding_allows_resume,
 )
 from .thread_titles import (
+    FIRST_MESSAGE_TITLE_SOURCE,
+    PROVIDER_TITLE_SOURCE,
     choose_owned_thread_title,
     provider_title_metadata,
 )
@@ -564,7 +566,7 @@ class _ThreadExecutionLifecycle:
                         provider_summary=getattr(conversation, "summary", None),
                     )
                     if provider_metadata.get("provider_conversation_title"):
-                        provider_metadata["car_title_source"] = "provider"
+                        provider_metadata["title_source"] = PROVIDER_TITLE_SOURCE
                     thread, provider_title_changed = (
                         _update_owned_thread_title_best_effort(
                             self.thread_store,
@@ -586,6 +588,7 @@ class _ThreadExecutionLifecycle:
                             self.thread_store,
                             thread,
                             title=message_title,
+                            metadata={"title_source": FIRST_MESSAGE_TITLE_SOURCE},
                         )
                     )
                     await _set_runtime_conversation_title_best_effort(

--- a/src/codex_autorunner/core/orchestration/thread_store_adapter.py
+++ b/src/codex_autorunner/core/orchestration/thread_store_adapter.py
@@ -19,7 +19,7 @@ from .managed_turn_lifecycle_contract import (
 )
 from .models import ExecutionRecord, MessageRequestKind, ThreadTarget
 from .runtime_bindings import RuntimeThreadBinding
-from .thread_titles import choose_owned_thread_title
+from .thread_titles import FIRST_MESSAGE_TITLE_SOURCE, choose_owned_thread_title
 from .turn_execution_contract import TurnExecutionRecord, TurnExecutionRequest
 
 logger = logging.getLogger(__name__)
@@ -638,7 +638,7 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
         self.update_thread_title(
             thread_target_id,
             choose_owned_thread_title(None, message_preview=message_preview),
-            metadata={"car_title_source": "message_preview"},
+            metadata={"title_source": FIRST_MESSAGE_TITLE_SOURCE},
         )
 
     def update_thread_title(

--- a/src/codex_autorunner/core/orchestration/thread_titles.py
+++ b/src/codex_autorunner/core/orchestration/thread_titles.py
@@ -3,17 +3,35 @@ from __future__ import annotations
 import re
 import uuid
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 _TITLE_LIMIT = 80
 _GENERIC_TITLES = {
     "chat",
     "new chat",
+    "new coding agent chat",
     "new managed thread",
     "pma",
     "untitled",
     "untitled chat",
 }
+ThreadTitleSource = Literal[
+    "unset",
+    "user_explicit",
+    "provider",
+    "first_user_message",
+    "system_generated",
+]
+REPLACEABLE_TITLE_SOURCES: set[str] = {
+    "unset",
+    "provider",
+    "first_user_message",
+    "system_generated",
+}
+EXPLICIT_TITLE_SOURCE: ThreadTitleSource = "user_explicit"
+FIRST_MESSAGE_TITLE_SOURCE: ThreadTitleSource = "first_user_message"
+PROVIDER_TITLE_SOURCE: ThreadTitleSource = "provider"
+UNSET_TITLE_SOURCE: ThreadTitleSource = "unset"
 _CAR_TICKET_ID_RE = re.compile(r"\bTICKET-\d+[A-Za-z0-9_-]*\b")
 _THREAD_ID_RE = re.compile(r"^(?:thread|chat|run|exec|turn)[-_:][A-Za-z0-9_.:-]+$")
 _PROTOCOL_ID_RE = re.compile(r"^(?:discord|telegram):\S+$", re.IGNORECASE)
@@ -26,6 +44,7 @@ _TRANSPORT_MARKER_RE = re.compile(
 @dataclass(frozen=True)
 class ManagedThreadTitleInputs:
     stored_title: Any = None
+    stored_title_source: Any = None
     provider_title: Any = None
     user_visible_title_seed: Any = None
     chat_display_name: Any = None
@@ -94,6 +113,14 @@ def resolve_managed_thread_display_title(
     last-resort fallbacks.
     """
 
+    if (
+        normalize_thread_title_source(inputs.stored_title_source)
+        == EXPLICIT_TITLE_SOURCE
+    ):
+        explicit_title = normalize_thread_title(inputs.stored_title)
+        if explicit_title is not None:
+            return explicit_title
+
     fallback_id = normalize_thread_title(inputs.fallback_id)
     for candidate in (
         inputs.stored_title,
@@ -139,6 +166,26 @@ def choose_owned_thread_title(
             fallback_id=fallback,
         )
     )
+
+
+def normalize_thread_title_source(value: Any) -> Optional[ThreadTitleSource]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if normalized in {
+        "unset",
+        "user_explicit",
+        "provider",
+        "first_user_message",
+        "system_generated",
+    }:
+        return normalized  # type: ignore[return-value]
+    return None
+
+
+def thread_title_source_allows_replacement(value: Any) -> bool:
+    source = normalize_thread_title_source(value)
+    return source is not None and source in REPLACEABLE_TITLE_SOURCES
 
 
 def provider_title_metadata(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -22,6 +22,10 @@ from .....core.orchestration.managed_thread_timeline import (
     MAX_MANAGED_THREAD_TIMELINE_LIMIT,
     build_managed_thread_timeline,
 )
+from .....core.orchestration.thread_titles import (
+    EXPLICIT_TITLE_SOURCE,
+    UNSET_TITLE_SOURCE,
+)
 from .....core.orchestration.turn_timeline import list_turn_timeline
 from .....core.pma_automation_services import PmaAutomationThreadNotFoundError
 from .....core.text_utils import _truncate_text
@@ -30,6 +34,7 @@ from ...schemas import (
     ManagedThreadCompactRequest,
     ManagedThreadCreateRequest,
     ManagedThreadForkRequest,
+    ManagedThreadRenameRequest,
     ManagedThreadResumeRequest,
     PmaAutomationSubscriptionCreateRequest,
     PmaAutomationTimerCancelRequest,
@@ -365,6 +370,10 @@ def build_managed_thread_crud_routes(
                 resolved,
                 provisioned_workspace,
             )
+            display_name = normalize_optional_text(payload.name)
+            metadata["title_source"] = (
+                EXPLICIT_TITLE_SOURCE if display_name else UNSET_TITLE_SOURCE
+            )
             try:
                 if resolved.scope is not None:
                     thread = service.create_thread_target(
@@ -374,7 +383,7 @@ def build_managed_thread_crud_routes(
                             payload.managed_thread_id
                         ),
                         scope=resolved.scope,
-                        display_name=normalize_optional_text(payload.name),
+                        display_name=display_name,
                         metadata=metadata,
                     )
                 else:
@@ -387,7 +396,7 @@ def build_managed_thread_crud_routes(
                         repo_id=resolved.repo_id,
                         resource_kind=resolved.resource_kind,
                         resource_id=resolved.resource_id,
-                        display_name=normalize_optional_text(payload.name),
+                        display_name=display_name,
                         metadata=metadata,
                     )
             except Exception:
@@ -523,6 +532,39 @@ def build_managed_thread_crud_routes(
         )
         return {
             "thread": serialized_thread,
+        }
+
+    @router.patch("/threads/{managed_thread_id}/title")
+    def rename_managed_thread(
+        managed_thread_id: str,
+        request: Request,
+        payload: ManagedThreadRenameRequest,
+    ) -> dict[str, Any]:
+        context = get_pma_request_context(request)
+        store = context.thread_store()
+        title = normalize_optional_text(payload.title)
+        if title is None:
+            raise HTTPException(status_code=400, detail="title is required")
+        updated = store.update_thread_title(
+            managed_thread_id,
+            title,
+            metadata={"title_source": EXPLICIT_TITLE_SOURCE},
+            only_if_generic=False,
+        )
+        if updated is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+        store.append_action(
+            "managed_thread_rename",
+            managed_thread_id=managed_thread_id,
+            payload_json=json.dumps({"title": title}, ensure_ascii=True),
+        )
+        binding_metadata = _load_chat_binding_metadata_by_thread(context.hub_root)
+        return {
+            "thread": _apply_chat_binding_fields(
+                _serialize_managed_thread(updated),
+                managed_thread_id=managed_thread_id,
+                binding_metadata_by_thread=binding_metadata,
+            )
         }
 
     @router.post("/threads/{managed_thread_id}/compact")

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -25,6 +25,7 @@ from .....core.orchestration.managed_thread_timeline import (
 from .....core.orchestration.thread_titles import (
     EXPLICIT_TITLE_SOURCE,
     UNSET_TITLE_SOURCE,
+    is_generic_thread_title,
 )
 from .....core.orchestration.turn_timeline import list_turn_timeline
 from .....core.pma_automation_services import PmaAutomationThreadNotFoundError
@@ -372,7 +373,9 @@ def build_managed_thread_crud_routes(
             )
             display_name = normalize_optional_text(payload.name)
             metadata["title_source"] = (
-                EXPLICIT_TITLE_SOURCE if display_name else UNSET_TITLE_SOURCE
+                EXPLICIT_TITLE_SOURCE
+                if display_name and not is_generic_thread_title(display_name)
+                else UNSET_TITLE_SOURCE
             )
             try:
                 if resolved.scope is not None:

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -1065,6 +1065,20 @@ class ManagedThreadCompactRequest(Payload):
     reset_backend: bool = True
 
 
+class ManagedThreadRenameRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    title: str = Field(validation_alias=AliasChoices("title", "name"))
+
+    @field_validator("title")
+    @classmethod
+    def _normalize_title(cls, value: str) -> str:
+        normalized = _normalize_text(value)
+        if not normalized:
+            raise ValueError("title is required")
+        return normalized
+
+
 class ManagedThreadResumeRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime.py
@@ -45,6 +45,10 @@ from .....core.orchestration.runtime_threads import (
     RuntimeThreadExecution,
     begin_runtime_thread_execution,
 )
+from .....core.orchestration.thread_titles import (
+    EXPLICIT_TITLE_SOURCE,
+    UNSET_TITLE_SOURCE,
+)
 from .....core.text_utils import _truncate_text
 from ...schemas import ManagedThreadMessageRequest, ManagedThreadStartMessageRequest
 from ...services.pma.automation import notify_managed_thread_terminal_transition
@@ -160,6 +164,10 @@ async def _create_managed_thread_for_first_message(
             resolved,
             provisioned_workspace,
         )
+        display_name = normalize_optional_text(payload.name)
+        metadata["title_source"] = (
+            EXPLICIT_TITLE_SOURCE if display_name else UNSET_TITLE_SOURCE
+        )
         try:
             if resolved.scope is not None:
                 thread = service.create_thread_target(
@@ -167,7 +175,7 @@ async def _create_managed_thread_for_first_message(
                     provisioned_workspace.workspace_root,
                     thread_target_id=normalize_optional_text(payload.managed_thread_id),
                     scope=resolved.scope,
-                    display_name=normalize_optional_text(payload.name),
+                    display_name=display_name,
                     metadata=metadata,
                 )
             else:
@@ -178,7 +186,7 @@ async def _create_managed_thread_for_first_message(
                     repo_id=resolved.repo_id,
                     resource_kind=resolved.resource_kind,
                     resource_id=resolved.resource_id,
-                    display_name=normalize_optional_text(payload.name),
+                    display_name=display_name,
                     metadata=metadata,
                 )
         except Exception:

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime.py
@@ -48,6 +48,7 @@ from .....core.orchestration.runtime_threads import (
 from .....core.orchestration.thread_titles import (
     EXPLICIT_TITLE_SOURCE,
     UNSET_TITLE_SOURCE,
+    is_generic_thread_title,
 )
 from .....core.text_utils import _truncate_text
 from ...schemas import ManagedThreadMessageRequest, ManagedThreadStartMessageRequest
@@ -166,7 +167,9 @@ async def _create_managed_thread_for_first_message(
         )
         display_name = normalize_optional_text(payload.name)
         metadata["title_source"] = (
-            EXPLICIT_TITLE_SOURCE if display_name else UNSET_TITLE_SOURCE
+            EXPLICIT_TITLE_SOURCE
+            if display_name and not is_generic_thread_title(display_name)
+            else UNSET_TITLE_SOURCE
         )
         try:
             if resolved.scope is not None:

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -1787,7 +1787,9 @@ a.scope-chip-label:hover {
     align-self: start;
   }
 
-  .chat-header-copy > h1 {
+  .chat-header-copy > h1,
+  .chat-header-copy > .chat-title-button,
+  .chat-header-copy > .chat-title-editor {
     grid-column: 1;
     grid-row: 1;
     min-width: 0;
@@ -1807,10 +1809,49 @@ a.scope-chip-label:hover {
 }
 
 .chat-header h1,
-.chat-header h2 {
+.chat-header h2,
+.chat-title-button,
+.chat-title-editor {
   font-size: var(--font-size-3);
   font-weight: 600;
-  letter-spacing: -0.012em;
+  letter-spacing: 0;
+}
+
+.chat-title-button {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  min-height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  overflow-wrap: anywhere;
+  cursor: text;
+}
+
+.chat-title-button:hover,
+.chat-title-button:focus-visible {
+  color: var(--color-accent);
+  outline: none;
+}
+
+.chat-title-editor {
+  width: min(100%, 760px);
+  min-height: 32px;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  outline: none;
+}
+
+.chat-title-editor:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-soft);
 }
 
 .chat-header-copy {

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -634,6 +634,14 @@ export class WebApiClient {
       mapResult(await this.getJson<JsonRecord>(`/hub/pma/threads/${encodeURIComponent(chatId)}`), (payload) =>
         mapChatSummary(asRecord(payload.thread))
       ),
+    renameChat: async (chatId: string, title: string): Promise<ApiResult<ChatSummary>> =>
+      mapResult(
+        await this.requestJson<JsonRecord>(`/hub/pma/threads/${encodeURIComponent(chatId)}/title`, {
+          method: 'PATCH',
+          body: { title }
+        }),
+        (payload) => mapChatSummary(asRecord(payload.thread ?? payload))
+      ),
     sendMessage: async (chatId: string, body: unknown): Promise<ApiResult<ChatMessage>> =>
       mapResult(
         await this.requestJson<JsonRecord>(`/hub/pma/threads/${encodeURIComponent(chatId)}/messages`, {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatCommands.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatCommands.test.ts
@@ -18,17 +18,20 @@ describe('chat command plans', () => {
       body: {
         agent: 'hermes',
         chat_kind: 'pma',
-        name: 'New chat',
         profile: 'planning',
         model: 'gpt-5.2',
         scope_urn: 'hub'
+      }
+    });
+    expect(planStartChat(localChatScopeOption(), 'hermes', '', '', 'Release planning')).toMatchObject({
+      body: {
+        name: 'Release planning'
       }
     });
     expect(planStartChat(localChatScopeOption(), 'codex', '', '', 'New coding agent chat', 'coding_agent')).toMatchObject({
       body: {
         agent: 'codex',
         chat_kind: 'coding_agent',
-        name: 'New coding agent chat',
         scope_urn: 'hub'
       }
     });

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -210,6 +210,10 @@
   let linkDialogOpen = $state(false);
   let fileDrawerOpen = $state(false);
   let linkDraft = $state('');
+  let titleEditingChatId = $state<string | null>(null);
+  let titleDraft = $state('');
+  let titleSaving = $state(false);
+  let titleInput = $state<HTMLInputElement | null>(null);
   let artifactDeliveries = $state<ArtifactDelivery[]>([]);
   let loadingArtifactDeliveries = $state(false);
   let artifactDeliveryError = $state<ApiError | null>(null);
@@ -583,6 +587,7 @@
   let followBottom = true;
 
   const activeChat = $derived(activeChatId ? chatSummaryForId(activeChatId) : null);
+  const titleEditorOpen = $derived(Boolean(activeChat && titleEditingChatId === activeChat.id));
   const activeSurfaceDeliveries = $derived<ArtifactDelivery[]>(artifactDeliveriesForActiveSurface(activeChat, artifactDeliveries));
   const assistantSharedFiles = $derived<ArtifactDelivery[]>(activeSurfaceDeliveries.slice(0, 4));
   let expandedRunGroups = $state<Record<string, boolean>>({});
@@ -2013,6 +2018,59 @@
     scroller.scrollTop = scroller.scrollHeight;
   }
 
+  async function beginTitleEdit(): Promise<void> {
+    if (!activeChat || isLocalDraft(activeChat.id) || isChatArchived(activeChat)) return;
+    titleEditingChatId = activeChat.id;
+    titleDraft = activeChat.title;
+    await tick();
+    titleInput?.focus();
+    titleInput?.select();
+  }
+
+  function cancelTitleEdit(): void {
+    titleEditingChatId = null;
+    titleDraft = '';
+  }
+
+  async function commitTitleEdit(): Promise<void> {
+    if (!activeChat || titleEditingChatId !== activeChat.id || titleSaving) return;
+    const nextTitle = titleDraft.trim();
+    if (!nextTitle) {
+      cancelTitleEdit();
+      return;
+    }
+    if (nextTitle === activeChat.title) {
+      cancelTitleEdit();
+      return;
+    }
+    titleSaving = true;
+    composeError = null;
+    const chatId = activeChat.id;
+    const result = await webApi.pma.renameChat(chatId, nextTitle);
+    titleSaving = false;
+    if (!result.ok) {
+      composeError = result.error;
+      await tick();
+      titleInput?.focus();
+      return;
+    }
+    titleEditingChatId = null;
+    titleDraft = '';
+    await invalidateChatMutation(chatId);
+    await refreshActive(chatId, { quiet: true });
+  }
+
+  function handleTitleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      void commitTitleEdit();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelTitleEdit();
+    }
+  }
+
   function updateTranscriptScrollState(atBottom: boolean): void {
     transcriptAtBottom = atBottom;
     followBottom = atBottom;
@@ -2920,7 +2978,28 @@
   <div class="active-chat">
     <div class="chat-header">
       <div class="chat-header-copy">
-        <h1>{activeChat?.title ?? 'Chats'}</h1>
+        {#if activeChat && titleEditorOpen}
+          <input
+            bind:this={titleInput}
+            class="chat-title-editor"
+            bind:value={titleDraft}
+            disabled={titleSaving}
+            aria-label="Chat title"
+            onkeydown={handleTitleKeydown}
+            onblur={() => void commitTitleEdit()}
+          />
+        {:else if activeChat && !isLocalDraft(activeChat.id) && !isChatArchived(activeChat)}
+          <button
+            class="chat-title-button"
+            type="button"
+            title="Rename chat"
+            onclick={() => void beginTitleEdit()}
+          >
+            {activeChat.title}
+          </button>
+        {:else}
+          <h1>{activeChat?.title ?? 'Chats'}</h1>
+        {/if}
         {#if activeChat}
           <div class="chat-header-scope-line">
             <span class="chat-header-scope-primary">

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -2033,31 +2033,40 @@
   }
 
   async function commitTitleEdit(): Promise<void> {
-    if (!activeChat || titleEditingChatId !== activeChat.id || titleSaving) return;
+    const chatId = titleEditingChatId;
+    if (!chatId || titleSaving) return;
+    const editingChat = chatSummaryForId(chatId);
+    if (!editingChat || isLocalDraft(chatId) || isChatArchived(editingChat)) {
+      cancelTitleEdit();
+      return;
+    }
     const nextTitle = titleDraft.trim();
     if (!nextTitle) {
       cancelTitleEdit();
       return;
     }
-    if (nextTitle === activeChat.title) {
+    if (nextTitle === editingChat.title) {
       cancelTitleEdit();
       return;
     }
     titleSaving = true;
     composeError = null;
-    const chatId = activeChat.id;
     const result = await webApi.pma.renameChat(chatId, nextTitle);
     titleSaving = false;
     if (!result.ok) {
       composeError = result.error;
-      await tick();
-      titleInput?.focus();
+      if (activeChat?.id === chatId) {
+        await tick();
+        titleInput?.focus();
+      }
       return;
     }
     titleEditingChatId = null;
     titleDraft = '';
     await invalidateChatMutation(chatId);
-    await refreshActive(chatId, { quiet: true });
+    if (activeChat?.id === chatId) {
+      await refreshActive(chatId, { quiet: true });
+    }
   }
 
   function handleTitleKeydown(event: KeyboardEvent): void {

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -2033,19 +2033,20 @@
   }
 
   async function commitTitleEdit(): Promise<void> {
-    if (!activeChat || titleEditingChatId !== activeChat.id || titleSaving) return;
+    const chatId = titleEditingChatId;
+    if (!chatId || titleSaving) return;
+    const editingChat = chatSummaryForId(chatId);
     const nextTitle = titleDraft.trim();
     if (!nextTitle) {
       cancelTitleEdit();
       return;
     }
-    if (nextTitle === activeChat.title) {
+    if (editingChat && nextTitle === editingChat.title) {
       cancelTitleEdit();
       return;
     }
     titleSaving = true;
     composeError = null;
-    const chatId = activeChat.id;
     const result = await webApi.pma.renameChat(chatId, nextTitle);
     titleSaving = false;
     if (!result.ok) {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/chat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/chat.test.ts
@@ -50,6 +50,7 @@ import {
   chatScopeTagView,
   chatSurfaceFilterOptions,
   chatSurfaceFilterToken,
+  localChatScopeOption,
   mergeLocalChatPlaceholders,
   progressPercent,
   reconcileChatSurfaceEvent,
@@ -2414,39 +2415,33 @@ describe('chat view helpers', () => {
     expect(buildManagedThreadCreatePayload('codex', local)).toEqual({
       agent: 'codex',
       chat_kind: 'pma',
-      name: 'New chat',
       scope_urn: 'hub'
     });
     expect(buildManagedThreadCreatePayload('codex', repo)).toEqual({
       agent: 'codex',
       chat_kind: 'pma',
-      name: 'New chat',
       scope_urn: 'repo:repo-1'
     });
     expect(buildManagedThreadCreatePayload('codex', worktree)).toEqual({
       agent: 'codex',
       chat_kind: 'pma',
-      name: 'New chat',
       scope_urn: 'worktree:repo-1/worktree-1'
     });
     expect(buildManagedThreadCreatePayload('opencode', local, 'New chat', 'zai/glm')).toEqual({
       agent: 'opencode',
       chat_kind: 'pma',
       model: 'zai/glm',
-      name: 'New chat',
       scope_urn: 'hub'
     });
     expect(buildManagedThreadCreatePayload('hermes', local, 'New chat', '', 'planning')).toEqual({
       agent: 'hermes',
       chat_kind: 'pma',
-      name: 'New chat',
       profile: 'planning',
       scope_urn: 'hub'
     });
     expect(buildManagedThreadCreatePayload('codex', repo, 'New coding agent chat', '', '', 'coding_agent')).toEqual({
       agent: 'codex',
       chat_kind: 'coding_agent',
-      name: 'New coding agent chat',
       scope_urn: 'repo:repo-1'
     });
   });
@@ -2612,7 +2607,12 @@ describe('chat view helpers', () => {
     expect(buildManagedThreadCreatePayload('codex')).toEqual({
       agent: 'codex',
       chat_kind: 'pma',
-      name: 'New chat',
+      scope_urn: 'hub'
+    });
+    expect(buildManagedThreadCreatePayload('codex', localChatScopeOption(), 'Release planning')).toEqual({
+      agent: 'codex',
+      chat_kind: 'pma',
+      name: 'Release planning',
       scope_urn: 'hub'
     });
     const attachments = [

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/chat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/chat.ts
@@ -339,7 +339,7 @@ export type ManagedThreadCreatePayload = {
   chat_kind?: ChatKind;
   model?: string;
   profile?: string;
-  name: string;
+  name?: string;
   scope_urn: string;
 };
 
@@ -2539,10 +2539,11 @@ export function buildManagedThreadCreatePayload(
   chatKind: ChatKind = 'pma',
   managedThreadId: string | null = null
 ): ManagedThreadCreatePayload {
+  const trimmedName = name.trim();
   const base: Pick<ManagedThreadCreatePayload, 'agent' | 'name' | 'model'> = {
-    agent: agent || undefined,
-    name
+    agent: agent || undefined
   };
+  if (trimmedName && !isGeneratedNewChatTitle(trimmedName)) base.name = trimmedName;
   if (model) base.model = model;
   const trimmedProfile = profile.trim();
   return {
@@ -2552,6 +2553,11 @@ export function buildManagedThreadCreatePayload(
     ...(trimmedProfile ? { profile: trimmedProfile } : {}),
     scope_urn: scope.scopeUrn
   };
+}
+
+export function isGeneratedNewChatTitle(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'new chat' || normalized === 'new coding agent chat';
 }
 
 export type ChatKind = 'pma' | 'coding_agent';

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -2361,8 +2361,52 @@ def test_chat_index_uses_message_preview_before_thread_id_fallback(
     ][0]
 
     assert row["title"] == "Investigate failed deploy"
-    assert row["display_title"] == "Agent Nexus / #deploys"
+    assert row["display_title"] == "Investigate failed deploy"
     assert row["binding_display_name"] == "Agent Nexus / #deploys"
+
+
+def test_chat_index_titles_coding_agent_placeholder_from_visible_message(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-coding-agent",
+        display_name="New coding agent chat",
+        last_message_preview="Can we test the new services feature?",
+        metadata={"title_source": "unset"},
+    )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(limit=20)[
+        "rows"
+    ][0]
+
+    assert row["title"] == "Can we test the new services feature?"
+    assert row["display_title"] == "Can we test the new services feature?"
+
+
+def test_chat_index_keeps_user_explicit_title_even_if_generic_or_technical(
+    tmp_path: Path,
+) -> None:
+    for explicit_title in ("New chat", "discord:123"):
+        hub_root = tmp_path / explicit_title.replace(":", "-")
+        _seed_thread(
+            hub_root,
+            thread_id="thread-explicit-title",
+            display_name=explicit_title,
+            last_message_preview="Visible message should not replace explicit title",
+            metadata={
+                "provider_conversation_title": "Provider title should not replace it",
+                "title_source": "user_explicit",
+            },
+        )
+
+        row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+            limit=20
+        )["rows"][0]
+
+        assert row["title"] == explicit_title
+        assert row["display_title"] == explicit_title
 
 
 def test_chat_index_uses_provider_title_before_visible_seed(tmp_path: Path) -> None:

--- a/tests/core/orchestration/test_thread_titles.py
+++ b/tests/core/orchestration/test_thread_titles.py
@@ -32,6 +32,13 @@ from codex_autorunner.core.orchestration.thread_titles import (
         ),
         (
             ManagedThreadTitleInputs(
+                stored_title="New coding agent chat",
+                user_visible_title_seed="Test preview services",
+            ),
+            "Test preview services",
+        ),
+        (
+            ManagedThreadTitleInputs(
                 stored_title="discord:1488827014600331415",
                 user_visible_title_seed="Investigate notification routing",
                 chat_display_name="CAR Workspace / #hermes",

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -1474,7 +1474,7 @@ def test_hub_read_models_chats_includes_binding_display_contract_fields(
     assert response.status_code == 200
     row = response.json()["rows"][0]
     assert row["chatId"] == "thread-0003"
-    assert row["displayTitle"] == "Release room"
+    assert row["displayTitle"] == "Thread 0003"
     assert row["technicalTitle"] == "thread-0003"
     assert row["primarySurface"]["surfaceKind"] == "pma"
     assert "Release room" in row["bindingDisplayNames"]

--- a/tests/test_managed_thread_store.py
+++ b/tests/test_managed_thread_store.py
@@ -98,6 +98,15 @@ def test_update_thread_title_only_replaces_generic_titles(tmp_path: Path) -> Non
     assert updated_generic["metadata"]["provider_conversation_summary"] == (
         "native summary"
     )
+    assert updated_generic["metadata"]["title_source"] == "provider"
+    updated_generic_again = store.update_thread_title(
+        generic["managed_thread_id"],
+        "First visible message",
+        metadata={"title_source": "first_user_message"},
+    )
+    assert updated_generic_again is not None
+    assert updated_generic_again["name"] == "First visible message"
+    assert updated_generic_again["metadata"]["title_source"] == "first_user_message"
     assert updated_explicit is not None
     assert updated_explicit["name"] == "Release notes"
     assert "car_title_source" not in updated_explicit["metadata"]

--- a/tests/test_managed_thread_store.py
+++ b/tests/test_managed_thread_store.py
@@ -103,6 +103,78 @@ def test_update_thread_title_only_replaces_generic_titles(tmp_path: Path) -> Non
     assert "car_title_source" not in updated_explicit["metadata"]
 
 
+def test_update_thread_title_replaces_unset_placeholder_from_message_preview(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    store = ManagedThreadStore(tmp_path / "hub")
+    thread = store.create_thread(
+        "codex",
+        workspace_root,
+        name="New coding agent chat",
+        metadata={"title_source": "unset"},
+    )
+
+    updated = store.update_thread_title(
+        thread["managed_thread_id"],
+        "Test CAR services preview",
+        metadata={"title_source": "first_user_message"},
+    )
+
+    assert updated is not None
+    assert updated["name"] == "Test CAR services preview"
+    assert updated["metadata"]["title_source"] == "first_user_message"
+
+
+def test_update_thread_title_user_explicit_blocks_automatic_replacement(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    store = ManagedThreadStore(tmp_path / "hub")
+    thread = store.create_thread(
+        "codex",
+        workspace_root,
+        name="My saved title",
+        metadata={"title_source": "user_explicit"},
+    )
+
+    updated = store.update_thread_title(
+        thread["managed_thread_id"],
+        "Automatic title",
+        metadata={"title_source": "first_user_message"},
+    )
+
+    assert updated is not None
+    assert updated["name"] == "My saved title"
+    assert updated["metadata"]["title_source"] == "user_explicit"
+
+
+def test_update_thread_title_user_explicit_generic_title_blocks_automatic_replacement(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    store = ManagedThreadStore(tmp_path / "hub")
+    thread = store.create_thread(
+        "codex",
+        workspace_root,
+        name="New chat",
+        metadata={"title_source": "user_explicit"},
+    )
+
+    updated = store.update_thread_title(
+        thread["managed_thread_id"],
+        "Automatic title",
+        metadata={"title_source": "first_user_message"},
+    )
+
+    assert updated is not None
+    assert updated["name"] == "New chat"
+    assert updated["metadata"]["title_source"] == "user_explicit"
+
+
 def test_prepare_runs_legacy_backfill_before_marking_prepared(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_managed_threads_messages.py
+++ b/tests/test_managed_threads_messages.py
@@ -273,6 +273,39 @@ def test_start_thread_message_commits_agent_selection_without_empty_thread(
     assert turns[0]["model"] == "zai-coding-plan/glm-5.1"
 
 
+def test_start_thread_message_with_generic_name_marks_title_unset(hub_env) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        model="zai-coding-plan/glm-5.1",
+        reactive_enabled=False,
+        managed_thread_terminal_followup_default=False,
+    )
+    app = create_hub_app(hub_env.hub_root)
+    fake_supervisor = FakeSupervisor(FakeClient(sequential=True))
+
+    with TestClient(app) as client:
+        app.state.app_server_supervisor = fake_supervisor
+        app.state.app_server_events = object()
+        start_resp = client.post(
+            "/hub/pma/thread-starts",
+            json={
+                "message": "run with a placeholder name",
+                "agent": "codex",
+                "name": "New coding agent chat",
+                "defer_execution": True,
+                "wait_for_confirmation": False,
+                **_repo_owner(hub_env),
+            },
+        )
+
+    assert start_resp.status_code == 200
+    managed_thread_id = start_resp.json()["managed_thread_id"]
+    thread = ManagedThreadStore(hub_env.hub_root).get_thread(managed_thread_id)
+    assert thread is not None
+    assert thread["name"] == "run with a placeholder name"
+    assert thread["metadata"]["title_source"] == "first_user_message"
+
+
 def test_start_thread_message_persists_genesis_metadata(hub_env) -> None:
     _enable_pma(
         hub_env.hub_root,

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -1204,6 +1204,29 @@ def test_create_managed_thread_without_name_marks_title_unset(hub_env) -> None:
     assert stored["metadata"]["title_source"] == "unset"
 
 
+def test_create_managed_thread_with_generic_name_marks_title_unset(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "name": "New coding agent chat",
+                **_repo_owner(hub_env),
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    stored = ManagedThreadStore(hub_env.hub_root).get_thread(
+        thread["managed_thread_id"]
+    )
+    assert stored is not None
+    assert stored["name"] == "New coding agent chat"
+    assert stored["metadata"]["title_source"] == "unset"
+
+
 def test_get_managed_thread_returns_created_thread(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
 

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -146,6 +146,7 @@ def test_create_managed_thread_with_repo_owner(hub_env) -> None:
     stored = store.get_thread(thread["managed_thread_id"])
     assert stored is not None
     assert stored.get("backend_thread_id") is None
+    assert stored["metadata"]["title_source"] == "user_explicit"
     assert "notification" not in resp.json()
     subscriptions = _subscription_rows(
         hub_env.hub_root, thread_id=thread["managed_thread_id"]
@@ -1182,6 +1183,27 @@ def test_list_managed_threads_includes_ticket_flow_threads_for_repo(hub_env) -> 
     assert thread["resource_id"] == hub_env.repo_id
 
 
+def test_create_managed_thread_without_name_marks_title_unset(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    stored = ManagedThreadStore(hub_env.hub_root).get_thread(
+        thread["managed_thread_id"]
+    )
+    assert stored is not None
+    assert stored["metadata"]["title_source"] == "unset"
+
+
 def test_get_managed_thread_returns_created_thread(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
 
@@ -1201,6 +1223,56 @@ def test_get_managed_thread_returns_created_thread(hub_env) -> None:
     assert get_resp.status_code == 200
     fetched = get_resp.json()["thread"]
     assert fetched["managed_thread_id"] == created["managed_thread_id"]
+
+
+def test_rename_managed_thread_sets_user_explicit_title(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+            },
+        )
+        assert create_resp.status_code == 200
+        thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        rename_resp = client.patch(
+            f"/hub/pma/threads/{thread_id}/title",
+            json={"title": "CAR services test"},
+        )
+
+    assert rename_resp.status_code == 200
+    renamed = rename_resp.json()["thread"]
+    assert renamed["name"] == "CAR services test"
+    stored = ManagedThreadStore(hub_env.hub_root).get_thread(thread_id)
+    assert stored is not None
+    assert stored["metadata"]["title_source"] == "user_explicit"
+    assert stored["metadata"].get("car_title_source") is None
+
+
+def test_rename_managed_thread_rejects_blank_title(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+            },
+        )
+        assert create_resp.status_code == 200
+        thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        rename_resp = client.patch(
+            f"/hub/pma/threads/{thread_id}/title",
+            json={"title": "   "},
+        )
+
+    assert rename_resp.status_code == 422
 
 
 def test_managed_thread_routes_expose_chat_binding_metadata(hub_env) -> None:
@@ -2085,7 +2157,9 @@ def test_retire_active_managed_threads_route_retires_notification_chat_rows(
     assert payload["retired_count"] == 3
     assert payload["error_count"] == 0
     assert payload["threads"] == []
-    assert [surface["surface_key"] for surface in payload["retired_surfaces"]] == [
+    assert sorted(
+        surface["surface_key"] for surface in payload["retired_surfaces"]
+    ) == [
         "notification:notif-0",
         "notification:notif-1",
         "notification:notif-2",
@@ -2278,6 +2352,7 @@ def test_managed_thread_crud_routes_use_orchestration_service(
             agent_id,
             workspace_root,
             *,
+            thread_target_id=None,
             repo_id=None,
             resource_kind=None,
             resource_id=None,
@@ -2290,6 +2365,7 @@ def test_managed_thread_crud_routes_use_orchestration_service(
                     {
                         "agent_id": agent_id,
                         "workspace_root": str(workspace_root),
+                        "thread_target_id": thread_target_id,
                         "repo_id": repo_id,
                         "resource_kind": resource_kind,
                         "resource_id": resource_id,
@@ -2299,13 +2375,14 @@ def test_managed_thread_crud_routes_use_orchestration_service(
                 )
             )
             self.thread = ThreadTarget(
-                thread_target_id=self.thread.thread_target_id,
+                thread_target_id=thread_target_id or self.thread.thread_target_id,
                 agent_id=agent_id,
                 repo_id=repo_id,
                 resource_kind=resource_kind,
                 resource_id=resource_id,
                 workspace_root=str(workspace_root),
                 display_name=display_name,
+                metadata=metadata,
                 status="idle",
                 lifecycle_status="active",
                 status_reason="thread_created",
@@ -2457,6 +2534,7 @@ def test_managed_thread_crud_routes_use_orchestration_service(
             {
                 "agent_id": "codex",
                 "workspace_root": str(hub_env.repo_root.resolve()),
+                "thread_target_id": None,
                 "repo_id": hub_env.repo_id,
                 "resource_kind": "repo",
                 "resource_id": hub_env.repo_id,
@@ -2465,6 +2543,7 @@ def test_managed_thread_crud_routes_use_orchestration_service(
                     "context_profile": "car_ambient",
                     "approval_mode": "yolo",
                     "chat_kind": "pma",
+                    "title_source": "user_explicit",
                     "genesis": {
                         "origin": "legacy",
                         "scope_source": "legacy_scope_fields",


### PR DESCRIPTION
## Summary

- Add explicit managed-thread title source semantics (`user_explicit`, `unset`, `provider`, `first_user_message`) so only replaceable sources are automatically retitled.
- Stop persisting generated frontend placeholders as chat names, and keep PMA-owned titles ahead of external binding display names.
- Add a `PATCH /hub/pma/threads/{id}/title` endpoint and inline title editing in the chat panel.

## Root Cause

The frontend was sending placeholder names like `New coding agent chat` as durable managed-thread names. The backend did not classify that placeholder as generic, and the read-model layer could then prefer binding display names over the managed-thread title. Chats with user messages could therefore stay titled as the placeholder indefinitely.

## Validation

- Subagent review completed; it found explicit generic/technical title gaps, which this PR fixes with regression tests.
- Normal commit hook passed: `web-core-contract` lane, including guardrails, repo-wide mypy, fast pytest, web build, full web tests, and SPA shell check.
- Targeted checks also run: `ruff` on changed Python files, focused managed-thread/read-model pytest slices, title route tests, frontend unit tests, `svelte-check`, and Vite build.
