### PR TITLE
[codex] Fix preview capability HTML asset rewriting

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import re
 from pathlib import Path, PurePosixPath
 from typing import Annotated, Any, Iterable, Optional
 from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
@@ -58,6 +59,11 @@ PROXY_STREAM_ACQUIRE_TIMEOUT_SECONDS = 0.1
 _GLOBAL_PROXY_SEMAPHORE: asyncio.Semaphore | None = None
 _GLOBAL_PROXY_SEMAPHORE_LIMIT: int | None = None
 _SERVICE_PROXY_SEMAPHORES: dict[str, tuple[int, asyncio.Semaphore]] = {}
+_ROOT_RELATIVE_HTML_URL_RE = re.compile(
+    r"(?P<quote>[\"'])/(?!(?:/|[a-zA-Z][a-zA-Z0-9+.-]*:))"
+    r"(?P<path>[^\"'<> \t\r\n]*)"
+    r"(?P=quote)"
+)
 
 
 class ServiceScopeLinkPayload(BaseModel):
@@ -1226,6 +1232,25 @@ async def _proxy_http_request(
                 record=record,
                 preview_prefix=preview_prefix,
             )
+            if _should_rewrite_proxy_html(upstream):
+                content = await upstream.aread()
+                rewritten = _rewrite_proxy_html_body(
+                    content,
+                    content_type=upstream.headers.get("content-type", ""),
+                    preview_prefix=preview_prefix,
+                )
+                await _close_proxy_response(
+                    upstream,
+                    client,
+                    global_semaphore,
+                    service_semaphore,
+                )
+                response_headers["Content-Length"] = str(len(rewritten))
+                return Response(
+                    content=rewritten,
+                    status_code=upstream.status_code,
+                    headers=response_headers,
+                )
             return StreamingResponse(
                 upstream.aiter_bytes(),
                 status_code=upstream.status_code,
@@ -1594,6 +1619,43 @@ def _proxy_response_headers(
         forwarded[key] = value
     _apply_capability_preview_header_values(forwarded, preview_prefix=preview_prefix)
     return forwarded
+
+
+def _should_rewrite_proxy_html(response: httpx.Response) -> bool:
+    content_type = response.headers.get("content-type", "")
+    return "text/html" in content_type.lower()
+
+
+def _rewrite_proxy_html_body(
+    content: bytes,
+    *,
+    content_type: str,
+    preview_prefix: str,
+) -> bytes:
+    charset = _content_type_charset(content_type)
+    try:
+        text = content.decode(charset, errors="replace")
+    except LookupError:
+        charset = "utf-8"
+        text = content.decode(charset, errors="replace")
+    prefix = "/" + preview_prefix.strip("/")
+
+    def replace(match: re.Match[str]) -> str:
+        quote = match.group("quote")
+        path = match.group("path")
+        if not path or path.startswith("#") or path.startswith("?"):
+            return match.group(0)
+        return f"{quote}{_join_url_path(prefix, path)}{quote}"
+
+    return _ROOT_RELATIVE_HTML_URL_RE.sub(replace, text).encode(charset)
+
+
+def _content_type_charset(content_type: str) -> str:
+    for part in content_type.split(";")[1:]:
+        key, separator, value = part.strip().partition("=")
+        if separator and key.lower() == "charset" and value.strip():
+            return value.strip().strip("\"'")
+    return "utf-8"
 
 
 def _is_capability_preview_prefix(preview_prefix: str) -> bool:

--- a/src/codex_autorunner/surfaces/web/routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/services.py
@@ -1643,8 +1643,6 @@ def _rewrite_proxy_html_body(
     def replace(match: re.Match[str]) -> str:
         quote = match.group("quote")
         path = match.group("path")
-        if not path or path.startswith("#") or path.startswith("?"):
-            return match.group(0)
         return f"{quote}{_join_url_path(prefix, path)}{quote}"
 
     return _ROOT_RELATIVE_HTML_URL_RE.sub(replace, text).encode(charset)

--- a/src/codex_autorunner/surfaces/web/routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/services.py
@@ -1245,7 +1245,7 @@ async def _proxy_http_request(
                     global_semaphore,
                     service_semaphore,
                 )
-                response_headers["Content-Length"] = str(len(rewritten))
+                _set_header(response_headers, "Content-Length", str(len(rewritten)))
                 return Response(
                     content=rewritten,
                     status_code=upstream.status_code,
@@ -1621,6 +1621,13 @@ def _proxy_response_headers(
     return forwarded
 
 
+def _set_header(headers: dict[str, str], key: str, value: str) -> None:
+    for existing in list(headers):
+        if existing.lower() == key.lower():
+            del headers[existing]
+    headers[key] = value
+
+
 def _should_rewrite_proxy_html(response: httpx.Response) -> bool:
     content_type = response.headers.get("content-type", "")
     return "text/html" in content_type.lower()
@@ -1643,9 +1650,14 @@ def _rewrite_proxy_html_body(
     def replace(match: re.Match[str]) -> str:
         quote = match.group("quote")
         path = match.group("path")
-        return f"{quote}{_join_url_path(prefix, path)}{quote}"
+        return f"{quote}{_prepend_url_path(prefix, path)}{quote}"
 
     return _ROOT_RELATIVE_HTML_URL_RE.sub(replace, text).encode(charset)
+
+
+def _prepend_url_path(prefix: str, suffix: str) -> str:
+    clean_prefix = "/" + prefix.strip("/")
+    return f"{clean_prefix}/{suffix}"
 
 
 def _content_type_charset(content_type: str) -> str:

--- a/tests/surfaces/web/test_preview_services_routes.py
+++ b/tests/surfaces/web/test_preview_services_routes.py
@@ -635,9 +635,12 @@ def test_preview_loopback_http_rewrites_html_root_relative_urls(
         opened = client.get(f"/preview/services/{service_id}/")
 
         assert opened.status_code == 200
-        assert opened.headers["content-length"] == str(len(opened.content))
+        assert f'href="/preview/services/{service_id}/"' in opened.text
+        assert f'href="/preview/services/{service_id}/#section"' in opened.text
+        assert f'href="/preview/services/{service_id}/?q=1"' in opened.text
         assert f'src="/preview/services/{service_id}/assets/app.js"' in opened.text
         assert f'href="/preview/services/{service_id}/assets/app.css"' in opened.text
+        assert f'href="/preview/services/{service_id}/docs/"' in opened.text
         assert f"fetch('/preview/services/{service_id}/api/status')" in opened.text
         assert 'href="https://example.test/assets/app.css"' in opened.text
         assert 'src="//cdn.example.test/app.js"' in opened.text
@@ -667,9 +670,12 @@ def test_preview_capability_loopback_http_rewrites_html_to_capability_prefix(
         assert opened.status_code == 200
         assert opened.headers["referrer-policy"] == "no-referrer"
         assert opened.headers["cache-control"] == "no-store, private"
-        assert opened.headers["content-length"] == str(len(opened.content))
+        assert f'href="/car{preview_url}"' in opened.text
+        assert f'href="/car{preview_url}#section"' in opened.text
+        assert f'href="/car{preview_url}?q=1"' in opened.text
         assert f'src="/car{preview_url}assets/app.js"' in opened.text
         assert f'href="/car{preview_url}assets/app.css"' in opened.text
+        assert f'href="/car{preview_url}docs/"' in opened.text
         assert f"fetch('/car{preview_url}api/status')" in opened.text
     finally:
         server.shutdown()
@@ -1457,9 +1463,13 @@ def _start_loopback_spa_server() -> tuple[http.server.ThreadingHTTPServer, int]:
         def do_GET(self) -> None:
             body = (
                 "<!doctype html>"
-                '<html><head><link rel="stylesheet" href="/assets/app.css">'
+                '<html><head><base href="/">'
+                '<link rel="canonical" href="/#section">'
+                '<link rel="search" href="/?q=1">'
+                '<link rel="stylesheet" href="/assets/app.css">'
                 '<link rel="preload" href="https://example.test/assets/app.css">'
                 "</head><body>"
+                '<a href="/docs/">Docs</a>'
                 '<script type="module" src="/assets/app.js"></script>'
                 '<script src="//cdn.example.test/app.js"></script>'
                 "<script>fetch('/api/status')</script>"

--- a/tests/surfaces/web/test_preview_services_routes.py
+++ b/tests/surfaces/web/test_preview_services_routes.py
@@ -618,6 +618,64 @@ def test_preview_loopback_http_service_proxies_method_path_query_and_body(
         server.server_close()
 
 
+def test_preview_loopback_http_rewrites_html_root_relative_urls(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    server, port = _start_loopback_spa_server()
+    client = TestClient(create_hub_app(hub_root))
+    try:
+        created = client.post(
+            "/hub/services/loopback-url",
+            json={"url": f"http://127.0.0.1:{port}/", "name": "SPA"},
+        )
+        service_id = created.json()["service"]["service_id"]
+
+        opened = client.get(f"/preview/services/{service_id}/")
+
+        assert opened.status_code == 200
+        assert opened.headers["content-length"] == str(len(opened.content))
+        assert f'src="/preview/services/{service_id}/assets/app.js"' in opened.text
+        assert f'href="/preview/services/{service_id}/assets/app.css"' in opened.text
+        assert f"fetch('/preview/services/{service_id}/api/status')" in opened.text
+        assert 'href="https://example.test/assets/app.css"' in opened.text
+        assert 'src="//cdn.example.test/app.js"' in opened.text
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_preview_capability_loopback_http_rewrites_html_to_capability_prefix(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    server, port = _start_loopback_spa_server()
+    client = TestClient(create_hub_app(hub_root, base_path="/car"))
+    try:
+        created = client.post(
+            "/car/hub/services/loopback-url",
+            json={"url": f"http://127.0.0.1:{port}/", "name": "SPA"},
+        )
+        service_id = created.json()["service"]["service_id"]
+        issued = client.post(f"/car/hub/services/{service_id}/preview-token")
+        preview_url = issued.json()["preview_url"]
+
+        opened = client.get(f"/car{preview_url}")
+
+        assert opened.status_code == 200
+        assert opened.headers["referrer-policy"] == "no-referrer"
+        assert opened.headers["cache-control"] == "no-store, private"
+        assert opened.headers["content-length"] == str(len(opened.content))
+        assert f'src="/car{preview_url}assets/app.js"' in opened.text
+        assert f'href="/car{preview_url}assets/app.css"' in opened.text
+        assert f"fetch('/car{preview_url}api/status')" in opened.text
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
 def test_preview_capability_proxy_strips_token_leak_headers(
     tmp_path: Path,
 ) -> None:
@@ -1384,6 +1442,34 @@ def _start_loopback_capture_server() -> tuple[http.server.ThreadingHTTPServer, i
             self.send_header("Service-Worker-Allowed", "/")
             self.end_headers()
             self.wfile.write(content)
+
+        def log_message(self, *args: object) -> None:
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def _start_loopback_spa_server() -> tuple[http.server.ThreadingHTTPServer, int]:
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            body = (
+                "<!doctype html>"
+                '<html><head><link rel="stylesheet" href="/assets/app.css">'
+                '<link rel="preload" href="https://example.test/assets/app.css">'
+                "</head><body>"
+                '<script type="module" src="/assets/app.js"></script>'
+                '<script src="//cdn.example.test/app.js"></script>'
+                "<script>fetch('/api/status')</script>"
+                "</body></html>"
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
         def log_message(self, *args: object) -> None:
             return


### PR DESCRIPTION
## Summary

- rewrite proxied `text/html` preview responses so root-relative SPA URLs resolve under the active preview prefix
- apply the same rewrite for capability links, including hubs mounted under a base path
- keep non-HTML responses on the existing streaming path

## Validation

- `.venv/bin/python -m pytest tests/surfaces/web/test_preview_services_routes.py`
- commit hook selected `web-ui` lane: repo-wide pytest `9815 passed`, mypy, Ruff, web UI lab/lint/build/tests, and SPA shell check passed

Closes #2025
