### PR TITLE
[codex] Return full scoped ticket queues

### DIFF
--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -111,7 +111,7 @@ class CursorGapRepair(RepairPolicy):
 
 
 class PageWindow(ReadModelContract):
-    limit: int = Field(ge=1, le=500)
+    limit: int = Field(ge=1)
     next_cursor: Optional[str] = None
     previous_cursor: Optional[str] = None
     total_estimate: Optional[int] = Field(default=None, ge=0)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/read_models.py
@@ -43,15 +43,15 @@ def build_hub_repo_read_model_router(
     @router.get("/hub/read-models/repos/{repo_id}/detail")
     async def repo_detail(
         repo_id: str,
-        ticket_limit: int = 25,
+        ticket_limit: int = 100,
         run_limit: int = 10,
         chat_limit: int = 25,
         artifact_limit: int = 25,
     ):
+        del ticket_limit  # Detail snapshots return the full ticket queue until ticket pagination exists.
         return await service.detail(
             owner_kind="repo",
             owner_id=repo_id,
-            ticket_limit=ticket_limit,
             run_limit=run_limit,
             chat_limit=chat_limit,
             artifact_limit=artifact_limit,
@@ -60,15 +60,15 @@ def build_hub_repo_read_model_router(
     @router.get("/hub/read-models/worktrees/{worktree_id}/detail")
     async def worktree_detail(
         worktree_id: str,
-        ticket_limit: int = 25,
+        ticket_limit: int = 100,
         run_limit: int = 10,
         chat_limit: int = 25,
         artifact_limit: int = 25,
     ):
+        del ticket_limit  # Detail snapshots return the full ticket queue until ticket pagination exists.
         return await service.detail(
             owner_kind="worktree",
             owner_id=worktree_id,
-            ticket_limit=ticket_limit,
             run_limit=run_limit,
             chat_limit=chat_limit,
             artifact_limit=artifact_limit,

--- a/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
@@ -667,7 +667,7 @@ class RepoWorktreeReadModelService:
         )
         return dump_read_model_contract(snapshot)
 
-    def _scoped_tickets(self, snapshot: Any, *, limit: int) -> list[dict[str, Any]]:
+    def _scoped_tickets(self, snapshot: Any) -> list[dict[str, Any]]:
         from ....core.flows.store import FlowStore
         from ....core.pma_context import get_latest_ticket_flow_run_state_with_record
 
@@ -718,7 +718,7 @@ class RepoWorktreeReadModelService:
                     )
             mark_duplicate_ticket_numbers(payloads)
             payloads.sort(key=lambda item: _int_value(item.get("ticket_number")))
-            return payloads[:limit]
+            return payloads
         finally:
             if store is not None:
                 store.close()
@@ -936,7 +936,6 @@ class RepoWorktreeReadModelService:
         *,
         owner_kind: Literal["repo", "worktree"],
         owner_id: str,
-        ticket_limit: int,
         run_limit: int,
         chat_limit: int,
         artifact_limit: int,
@@ -949,13 +948,10 @@ class RepoWorktreeReadModelService:
                 status_code=404, detail=f"Worktree not found: {owner_id}"
             )
         enriched = await asyncio.to_thread(self._enricher.enrich_repo, snapshot_obj)
-        ticket_limit = _bounded_limit(ticket_limit, maximum=100)
         run_limit = _bounded_limit(run_limit, maximum=100)
         chat_limit = _bounded_limit(chat_limit, maximum=100)
         artifact_limit = _bounded_limit(artifact_limit, maximum=100)
-        tickets_task = asyncio.to_thread(
-            self._scoped_tickets, snapshot_obj, limit=ticket_limit
-        )
+        tickets_task = asyncio.to_thread(self._scoped_tickets, snapshot_obj)
         runs_task = asyncio.to_thread(
             self._scoped_runs, snapshot_obj.path, limit=run_limit
         )
@@ -995,7 +991,9 @@ class RepoWorktreeReadModelService:
             chat_queue=chats,
             contextspace_summary=contextspace,
             current_artifacts=artifacts,
-            ticket_window=_window(offset=0, limit=ticket_limit, total=len(tickets)),
+            ticket_window=_window(
+                offset=0, limit=max(1, len(tickets)), total=len(tickets)
+            ),
             run_window=_window(offset=0, limit=run_limit, total=len(runs)),
             chat_window=_window(offset=0, limit=chat_limit, total=len(chats)),
             artifact_window=_window(
@@ -1023,7 +1021,7 @@ class RepoWorktreeReadModelService:
         ticket_id: str,
     ) -> dict[str, Any]:
         snapshot_obj = self._snapshot_by_id(owner_id)
-        tickets = self._scoped_tickets(snapshot_obj, limit=500)
+        tickets = self._scoped_tickets(snapshot_obj)
         selected = next(
             (
                 ticket

--- a/tests/surfaces/web/test_hub_repo_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_repo_read_model_routes.py
@@ -215,14 +215,13 @@ def test_worktree_detail_snapshot_is_scoped_and_does_not_include_global_tickets(
         worktree_of=hub_env.repo_id,
     )
     other_root = _add_workspace(hub_env.hub_root, repo_id="other")
-    _write_tickets(worktree_root, 30)
+    _write_tickets(worktree_root, 501)
     _write_tickets(other_root, 30)
 
     client = TestClient(create_hub_app(hub_env.hub_root))
     response = client.get(
         "/hub/read-models/worktrees/repo--feature/detail",
         params={
-            "ticket_limit": 5,
             "run_limit": 3,
             "chat_limit": 3,
             "artifact_limit": 3,
@@ -235,12 +234,13 @@ def test_worktree_detail_snapshot_is_scoped_and_does_not_include_global_tickets(
     assert payload["kind"] == "repo_worktree.detail.snapshot"
     assert payload["ownerKind"] == "worktree"
     assert payload["parentLinks"]["repo_id"] == hub_env.repo_id
-    assert len(payload["ticketQueue"]) == 5
+    assert len(payload["ticketQueue"]) == 501
     assert {ticket["workspace_id"] for ticket in payload["ticketQueue"]} == {
         "repo--feature"
     }
     assert payload["scopedTickets"] == payload["ticketQueue"]
-    assert payload["ticketWindow"]["limit"] == 5
+    assert payload["ticketWindow"]["limit"] == 501
+    assert payload["ticketWindow"]["totalEstimate"] == 501
 
 
 def test_ticket_detail_snapshot_uses_owner_scoped_ticket_queue(hub_env) -> None:


### PR DESCRIPTION
## Summary

- Return the full scoped ticket queue in repo/worktree detail read models instead of truncating to the original detail snapshot limit.
- Keep the route-level `ticket_limit` query accepted for compatibility, but ignore it until real ticket pagination exists.
- Remove the `PageWindow.limit <= 500` contract ceiling so large all-ticket snapshots do not fail validation.
- Strengthen the read-model route test with a 501-ticket scoped queue regression.

## Root Cause

The repo list used ticket-flow census data, while repo detail and scoped ticket pages used `ticketQueue` from the detail snapshot. That snapshot was capped by `ticket_limit` and then reported the truncated length as the window total, so detail pages could show stale counts like `25/25` while the repo list showed the true count.

## Validation

- Subagent review found and confirmed the >500-ticket contract risk; fixed before PR.
- Commit hook web-ui lane passed, including guardrails, ruff, mypy, full pytest suite (`9831 passed`), Web UI lab scenarios, frontend lint, frontend build, full web tests (`987 passed`, `2 skipped`), and SPA shell check.
- Targeted checks also passed before commit:
  - `.venv/bin/python -m pytest tests/surfaces/web/test_hub_repo_read_model_routes.py -q`
  - `pnpm web:test -- 'src/routes/repos/[repoId]/load.test.ts' 'src/routes/repos/[repoId]/tickets/load.test.ts' 'src/routes/worktrees/[worktreeId]/load.test.ts' 'src/routes/worktrees/[worktreeId]/tickets/load.test.ts' src/lib/data/scopedTicketSessions.test.ts`
  - `pnpm web:lint`