### PR TITLE
[codex] Render shared files inline in chat transcript

### DIFF
--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -114,33 +114,6 @@ def _refresh_failure_is_retryable(output_lines: list[str]) -> bool:
     )
 
 
-def _reset_update_cache_for_retry(
-    update_dir: Path,
-    *,
-    logger: logging.Logger,
-) -> bool:
-    if not update_dir.exists() or not _is_valid_git_repo(update_dir):
-        logger.warning(
-            "Skipping update refresh retry; cache at %s is not a valid git repo.",
-            update_dir,
-        )
-        return False
-    try:
-        logger.warning(
-            "Refresh failed with a retryable stale-build-artifact error; resetting tracked files and cleaning build artifacts in %s before retrying once.",
-            update_dir,
-        )
-        _run_cmd(["git", "reset", "--hard", "FETCH_HEAD"], cwd=update_dir)
-        _cleanup_update_build_artifacts(update_dir, logger)
-    except (RuntimeError, OSError) as exc:
-        logger.warning(
-            "Aggressive update cache cleanup failed; refresh retry skipped. %s",
-            exc,
-        )
-        return False
-    return True
-
-
 def _update_cache_refresh_failure_is_retryable(
     error: Union[BaseException, str],
 ) -> bool:

--- a/src/codex_autorunner/core/update/health.py
+++ b/src/codex_autorunner/core/update/health.py
@@ -300,14 +300,12 @@ class HealthChecker:
             time.sleep(self.interval)
 
     def _default_health_path(self) -> str:
-        if self.base_path:
-            return f"{self.base_path}/health"
-        return "/health"
+        health_path, _ = health_paths_for_base_path(self.base_path)
+        return health_path
 
     def _default_static_path(self) -> str:
-        if self.base_path:
-            return f"{self.base_path}/_app/version.json"
-        return "/_app/version.json"
+        _, static_path = health_paths_for_base_path(self.base_path)
+        return static_path
 
     def _http_ok(self, url: str) -> bool:
         request = urllib.request.Request(url, method="GET")

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatQueuedTurn } from '$lib/api/client';
-import type { ChatSummary, ChatRunProgress, SurfaceArtifact } from '$lib/viewModels/domain';
+import type { ArtifactDelivery, ChatSummary, ChatRunProgress, SurfaceArtifact } from '$lib/viewModels/domain';
 import type { ChatTranscriptCard } from '$lib/viewModels/chat';
 import {
   buildChatDetailDisplayReadModel,
@@ -33,7 +33,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [queuedTurn('queued-turn')],
       displayedProgress: { ...progress('run-1', 12, []), queueDepth: 1 },
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 1,
+      assistantSharedFiles: [delivery('delivery-1', 'spec.md', '2026-05-16T12:00:03.000Z')],
       streamState: 'connecting',
       loadingActive: false,
       activeError: null,
@@ -66,7 +66,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: progress('run-1', 5, []),
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: null,
@@ -93,7 +93,7 @@ describe('chat detail state composition', () => {
         })
       ]),
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: null,
@@ -134,7 +134,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: terminalProgress,
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: null,
@@ -148,6 +148,43 @@ describe('chat detail state composition', () => {
       'message:turn:run-1:assistant'
     ]);
     expect(model.transcriptListItems.map((item) => item.kind)).toEqual(['card', 'card', 'card', 'tail-spacer']);
+  });
+
+  it('keeps shared files anchored by delivery time when newer assistant replies arrive', () => {
+    const firstAssistant = assistantCardAt(
+      'turn:run-1:assistant',
+      'first reply',
+      '2026-05-16T12:00:10.000Z'
+    );
+    const laterAssistant = assistantCardAt(
+      'turn:run-2:assistant',
+      'later reply',
+      '2026-05-16T12:05:00.000Z'
+    );
+    const model = buildChatDetailDisplayReadModel({
+      transcriptCards: [
+        firstAssistant,
+        laterAssistant
+      ],
+      queuedTurns: [],
+      displayedProgress: null,
+      activeChat: chatSummary('chat-1'),
+      assistantSharedFiles: [
+        delivery('delivery-old', 'old-result.txt', '2026-05-16T12:00:30.000Z')
+      ],
+      streamState: 'connected',
+      loadingActive: false,
+      activeError: null,
+      draft: '',
+      pendingAttachmentCount: 0
+    });
+
+    expect(model.transcriptListItems.map((item) => `${item.kind}:${item.id}`)).toEqual([
+      'card:turn:run-1:assistant',
+      'shared-files:assistant-shared-files:0:delivery-old',
+      'card:turn:run-2:assistant',
+      'tail-spacer:status-bar-tail-spacer'
+    ]);
   });
 
   it('does not duplicate live progress already projected by the backend transcript', () => {
@@ -177,7 +214,7 @@ describe('chat detail state composition', () => {
         })
       ]),
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: null,
@@ -195,7 +232,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: progress('new-turn', 3, []),
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: null,
@@ -214,7 +251,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: null,
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: new Error('backend unavailable'),
@@ -226,7 +263,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: null,
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'interrupted',
       loadingActive: false,
       activeError: null,
@@ -239,7 +276,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: failedProgress,
       activeChat: chatSummary('chat-1'),
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'connected',
       loadingActive: false,
       activeError: null,
@@ -258,7 +295,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: null,
       activeChat: { ...chatSummary('chat-1'), status: 'idle' },
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'idle',
       loadingActive: false,
       activeError: null,
@@ -279,7 +316,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: null,
       activeChat: { ...chatSummary('chat-1'), status: 'idle' },
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'idle',
       loadingActive: false,
       activeError: null,
@@ -300,7 +337,7 @@ describe('chat detail state composition', () => {
       queuedTurns: [],
       displayedProgress: null,
       activeChat: { ...chatSummary('chat-1'), status: 'done' },
-      assistantSharedFileCount: 0,
+      assistantSharedFiles: [],
       streamState: 'idle',
       loadingActive: false,
       activeError: null,
@@ -342,6 +379,40 @@ function assistantCard(id: string, text: string): MessageTranscriptCard {
       ...base.message,
       role: 'assistant'
     }
+  };
+}
+
+function assistantCardAt(id: string, text: string, createdAt: string): MessageTranscriptCard {
+  const card = assistantCard(id, text);
+  return {
+    ...card,
+    timestamp: createdAt,
+    message: {
+      ...card.message,
+      createdAt
+    }
+  };
+}
+
+function delivery(id: string, filename: string, sentAt: string): ArtifactDelivery {
+  return {
+    deliveryId: id,
+    artifactId: `artifact:${id}`,
+    filename,
+    state: 'sent',
+    targetSurface: 'discord',
+    targetConversation: 'channel:1',
+    workspaceScope: null,
+    attempts: 1,
+    size: 1024,
+    mimeType: 'text/plain',
+    downloadUrl: `/download/${id}`,
+    createdAt: sentAt,
+    updatedAt: sentAt,
+    sentAt,
+    failedAt: null,
+    lastError: null,
+    raw: {}
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailReadModel.ts
@@ -1,5 +1,5 @@
 import type { ChatQueuedTurn } from '$lib/api/client';
-import type { ChatSummary, ChatRunProgress } from '$lib/viewModels/domain';
+import type { ArtifactDelivery, ChatSummary, ChatRunProgress } from '$lib/viewModels/domain';
 import {
   buildChatActivityCards,
   buildChatStatusBar,
@@ -12,7 +12,7 @@ import type { ChatDetailStreamState } from './chatDetailLiveProjection';
 export type ChatTranscriptListItem =
   | { kind: 'card'; id: string; card: ChatTranscriptCard }
   | { kind: 'typing'; id: string; title: string }
-  | { kind: 'shared-files'; id: string }
+  | { kind: 'shared-files'; id: string; files: ArtifactDelivery[] }
   | { kind: 'tail-spacer'; id: string };
 
 export type ChatDetailDisplayReadModelInput = {
@@ -20,7 +20,7 @@ export type ChatDetailDisplayReadModelInput = {
   queuedTurns: ChatQueuedTurn[];
   displayedProgress: ChatRunProgress | null;
   activeChat: ChatSummary | null;
-  assistantSharedFileCount: number;
+  assistantSharedFiles: ArtifactDelivery[];
   streamState: ChatDetailStreamState;
   loadingActive: boolean;
   activeError: unknown;
@@ -77,7 +77,8 @@ export function buildChatDetailDisplayReadModel(
   const streamingMessageId = activeStreamingMessageId(input.displayedProgress, lastAssistantMessageCard);
   const showTypingIndicator = shouldShowTypingIndicator(input.displayedProgress, activeCards);
   const showStatusBar = shouldShowChatDetailStatusBar(statusBar, input.displayedProgress, activeCards);
-  const chatHasActivity = activeCards.length > 0 || showStatusBar;
+  const sharedFileItems = buildSharedFileListItems(displayTranscriptCards, input.assistantSharedFiles);
+  const chatHasActivity = activeCards.length > 0 || sharedFileItems.length > 0 || showStatusBar;
   const hasRunnableDraft = Boolean(input.activeChat && (input.draft.trim() || input.pendingAttachmentCount > 0));
   const composerWillQueue = shouldQueueComposerDraft(
     input.activeChat,
@@ -92,9 +93,8 @@ export function buildChatDetailDisplayReadModel(
     streamingMessageId,
     showTypingIndicator,
     transcriptListItems: [
-      ...displayTranscriptCards.map((card) => ({ kind: 'card' as const, id: card.id, card })),
+      ...mergeTranscriptCardsWithSharedFiles(displayTranscriptCards, sharedFileItems),
       ...(showTypingIndicator ? [{ kind: 'typing' as const, id: 'typing-indicator', title: 'Assistant is typing' }] : []),
-      ...(input.assistantSharedFileCount > 0 ? [{ kind: 'shared-files' as const, id: 'assistant-shared-files' }] : []),
       ...(showStatusBar ? [{ kind: 'tail-spacer' as const, id: 'status-bar-tail-spacer' }] : [])
     ],
     statusAnnouncement: screenReaderStatusAnnouncement(input, statusBar, lastAssistantMessageCard),
@@ -114,6 +114,75 @@ export function buildChatDetailDisplayReadModel(
     queueDepthForCommands: input.queuedTurns.length || input.displayedProgress?.queueDepth || 0,
     runActive: isRunActiveForToolDisplay(input.displayedProgress, input.activeChat, activeCards)
   };
+}
+
+function mergeTranscriptCardsWithSharedFiles(
+  cards: ChatTranscriptCard[],
+  sharedFileItems: Array<{ afterIndex: number; item: Extract<ChatTranscriptListItem, { kind: 'shared-files' }> }>
+): ChatTranscriptListItem[] {
+  const items: ChatTranscriptListItem[] = [];
+  for (const pending of sharedFileItems.filter((entry) => entry.afterIndex < 0)) {
+    items.push(pending.item);
+  }
+  cards.forEach((card, index) => {
+    items.push({ kind: 'card', id: card.id, card });
+    for (const pending of sharedFileItems.filter((entry) => entry.afterIndex === index)) {
+      items.push(pending.item);
+    }
+  });
+  return items;
+}
+
+function buildSharedFileListItems(
+  cards: ChatTranscriptCard[],
+  files: ArtifactDelivery[]
+): Array<{ afterIndex: number; item: Extract<ChatTranscriptListItem, { kind: 'shared-files' }> }> {
+  if (files.length === 0) return [];
+  const grouped = new Map<number, ArtifactDelivery[]>();
+  for (const file of files) {
+    const afterIndex = transcriptInsertionIndex(cards, deliveryTimestamp(file));
+    grouped.set(afterIndex, [...(grouped.get(afterIndex) ?? []), file]);
+  }
+  return [...grouped.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([afterIndex, groupedFiles]) => ({
+      afterIndex,
+      item: {
+        kind: 'shared-files' as const,
+        id: `assistant-shared-files:${afterIndex}:${groupedFiles.map((file) => file.deliveryId).join(':')}`,
+        files: groupedFiles
+      }
+    }));
+}
+
+function transcriptInsertionIndex(cards: ChatTranscriptCard[], timestamp: number): number {
+  if (cards.length === 0) return -1;
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return cards.length - 1;
+  let index = -1;
+  for (let i = 0; i < cards.length; i += 1) {
+    const cardTime = cardTimestamp(cards[i]);
+    if (Number.isFinite(cardTime) && cardTime > 0 && cardTime <= timestamp) index = i;
+  }
+  return index >= 0 ? index : -1;
+}
+
+function deliveryTimestamp(file: ArtifactDelivery): number {
+  return firstValidTimestamp(file.sentAt, file.updatedAt, file.createdAt, file.failedAt);
+}
+
+function cardTimestamp(card: ChatTranscriptCard): number {
+  if (card.kind === 'message') return firstValidTimestamp(card.message.createdAt, card.timestamp);
+  if ('timestamp' in card) return firstValidTimestamp(card.timestamp);
+  return 0;
+}
+
+function firstValidTimestamp(...values: Array<string | null | undefined>): number {
+  for (const value of values) {
+    if (!value) continue;
+    const timestamp = Date.parse(value);
+    if (Number.isFinite(timestamp)) return timestamp;
+  }
+  return 0;
 }
 
 function isRunActiveForToolDisplay(

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -356,6 +356,76 @@
   const displayCards = $derived(displayCardsFor(cards));
 </script>
 
+{#snippet sharedFilesGrid(files: ArtifactDelivery[])}
+  <ul class="shared-files-grid" aria-label="Files shared by assistant">
+    {#each files as file (file.deliveryId)}
+      {@const stateLabel = deliveryStateLabel(file.state)}
+      {@const previewKind = deliveryPreviewKind(file)}
+      {@const sizeLabel = formatDeliverySize(file.size)}
+      {@const downloadHref = file.downloadUrl ? href(file.downloadUrl) : null}
+      {@const previewHref = file.downloadUrl ? inlineDeliveryUrl(file.downloadUrl) : null}
+      {@const canPreview =
+        stateLabel === 'sent' &&
+        previewHref !== null &&
+        (previewKind === 'image' || previewKind === 'video' || previewKind === 'audio')}
+      {@const hasMedia = canPreview && (previewKind === 'image' || previewKind === 'video')}
+      <li class={`shared-file-card kind-${previewKind} delivery-${stateLabel}`} class:has-media={hasMedia}>
+        {#if hasMedia && previewHref}
+          <div class="shared-file-media-wrap">
+            {#if previewKind === 'image'}
+              <button type="button" class="shared-file-media" onclick={() => openLightbox(file)} title={`Open ${file.filename}`}>
+                <img src={previewHref} alt={file.filename} loading="lazy" />
+              </button>
+            {:else}
+              <!-- svelte-ignore a11y_media_has_caption -->
+              <video class="shared-file-media" controls preload="metadata" src={previewHref}></video>
+            {/if}
+            <button type="button" class="shared-file-expand" onclick={() => openLightbox(file)} title="Expand preview" aria-label="Expand preview">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M15 3h6v6" />
+                <path d="M9 21H3v-6" />
+                <path d="M21 3l-7 7" />
+                <path d="M3 21l7-7" />
+              </svg>
+            </button>
+          </div>
+        {/if}
+        {#if canPreview && previewHref && previewKind === 'audio'}
+          <audio class="shared-file-audio" controls preload="metadata" src={previewHref}></audio>
+        {/if}
+        <div class="shared-file-foot">
+          <span class="shared-file-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
+              <path d="M13 2v7h7" />
+            </svg>
+          </span>
+          <span class="shared-file-info">
+            {#if downloadHref}
+              <a class="shared-file-name" href={canPreview ? previewHref : downloadHref} target="_blank" rel="noopener" title={file.filename}>{file.filename}</a>
+            {:else}
+              <span class="shared-file-name" title={file.filename}>{file.filename}</span>
+            {/if}
+            <span class="shared-file-meta">
+              {#if sizeLabel}<span>{sizeLabel}</span>{/if}
+              {#if stateLabel !== 'sent'}<em class={`shared-file-state state-${stateLabel}`}>{stateLabel}</em>{/if}
+            </span>
+          </span>
+          {#if downloadHref}
+            <a class="shared-file-download" href={downloadHref} download title={`Download ${file.filename}`} aria-label={`Download ${file.filename}`}>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 3v12" />
+                <path d="m7 10 5 5 5-5" />
+                <path d="M5 21h14" />
+              </svg>
+            </a>
+          {/if}
+        </div>
+      </li>
+    {/each}
+  </ul>
+{/snippet}
+
 {#snippet toolGroupCard(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>, nested: boolean)}
   {@const groupState = toolGroupState(card)}
   <details
@@ -436,6 +506,9 @@
         <div class="message-markdown markdown-body">
           {@html renderMarkdownToHtml(visibleText, { openLinksInNewTab: true })}
         </div>
+      {/if}
+      {#if card.message.role === 'assistant' && sharedFiles.length > 0}
+        {@render sharedFilesGrid(sharedFiles)}
       {/if}
       {#if card.message.role === 'user' && card.message.artifacts.length > 0}
         <ul class="message-attachments" aria-label="Attachments">
@@ -671,76 +744,10 @@
   {/if}
 {/each}
 
-{#if sharedFiles.length > 0}
+{#if sharedFiles.length > 0 && displayCards.length === 0}
   <article class="message assistant shared-files-message">
     <span>{assistantLabel}</span>
-    <ul class="shared-files-grid" aria-label="Files shared by assistant">
-      {#each sharedFiles as file (file.deliveryId)}
-        {@const stateLabel = deliveryStateLabel(file.state)}
-        {@const previewKind = deliveryPreviewKind(file)}
-        {@const sizeLabel = formatDeliverySize(file.size)}
-        {@const downloadHref = file.downloadUrl ? href(file.downloadUrl) : null}
-        {@const previewHref = file.downloadUrl ? inlineDeliveryUrl(file.downloadUrl) : null}
-        {@const canPreview =
-          stateLabel === 'sent' &&
-          previewHref !== null &&
-          (previewKind === 'image' || previewKind === 'video' || previewKind === 'audio')}
-        {@const hasMedia = canPreview && (previewKind === 'image' || previewKind === 'video')}
-        <li class={`shared-file-card kind-${previewKind} delivery-${stateLabel}`} class:has-media={hasMedia}>
-          {#if hasMedia && previewHref}
-            <div class="shared-file-media-wrap">
-              {#if previewKind === 'image'}
-                <button type="button" class="shared-file-media" onclick={() => openLightbox(file)} title={`Open ${file.filename}`}>
-                  <img src={previewHref} alt={file.filename} loading="lazy" />
-                </button>
-              {:else}
-                <!-- svelte-ignore a11y_media_has_caption -->
-                <video class="shared-file-media" controls preload="metadata" src={previewHref}></video>
-              {/if}
-              <button type="button" class="shared-file-expand" onclick={() => openLightbox(file)} title="Expand preview" aria-label="Expand preview">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M15 3h6v6" />
-                  <path d="M9 21H3v-6" />
-                  <path d="M21 3l-7 7" />
-                  <path d="M3 21l7-7" />
-                </svg>
-              </button>
-            </div>
-          {/if}
-          {#if canPreview && previewHref && previewKind === 'audio'}
-            <audio class="shared-file-audio" controls preload="metadata" src={previewHref}></audio>
-          {/if}
-          <div class="shared-file-foot">
-            <span class="shared-file-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
-                <path d="M13 2v7h7" />
-              </svg>
-            </span>
-            <span class="shared-file-info">
-              {#if downloadHref}
-                <a class="shared-file-name" href={canPreview ? previewHref : downloadHref} target="_blank" rel="noopener" title={file.filename}>{file.filename}</a>
-              {:else}
-                <span class="shared-file-name" title={file.filename}>{file.filename}</span>
-              {/if}
-              <span class="shared-file-meta">
-                {#if sizeLabel}<span>{sizeLabel}</span>{/if}
-                {#if stateLabel !== 'sent'}<em class={`shared-file-state state-${stateLabel}`}>{stateLabel}</em>{/if}
-              </span>
-            </span>
-            {#if downloadHref}
-              <a class="shared-file-download" href={downloadHref} download title={`Download ${file.filename}`} aria-label={`Download ${file.filename}`}>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M12 3v12" />
-                  <path d="m7 10 5 5 5-5" />
-                  <path d="M5 21h14" />
-                </svg>
-              </a>
-            {/if}
-          </div>
-        </li>
-      {/each}
-    </ul>
+    {@render sharedFilesGrid(sharedFiles)}
   </article>
 {/if}
 

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -545,10 +545,10 @@ describe('ChatTranscriptCards', () => {
     expect(summary).not.toContain('`origin/main`');
   });
 
-  it('renders assistant shared delivery files as downloadable pills', () => {
+  it('renders assistant shared delivery files inside an assistant message', () => {
     const { body } = render(ChatTranscriptCards, {
       props: {
-        cards: [],
+        cards: [assistantMessageCard('assistant-1', 'Done.')],
         assistantLabel: 'Codex',
         sharedFiles: [
           {
@@ -574,10 +574,12 @@ describe('ChatTranscriptCards', () => {
       }
     });
 
-    expect(body).toContain('class="message assistant shared-files-message"');
+    expect(body).toContain('class="message assistant"');
+    expect(body).not.toContain('shared-files-message');
     expect(body).toContain('Codex');
     expect(body).toContain('spec.md');
     expect(body).toContain('delivery-sent');
     expect(body).toContain('/hub/filebox/repo/artifacts/deliveries/delivery%3Aabc/download');
+    expect(body.indexOf('Done.')).toBeLessThan(body.indexOf('spec.md'));
   });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -721,7 +721,7 @@
       queuedTurns,
       displayedProgress,
       activeChat,
-      assistantSharedFileCount: assistantSharedFiles.length,
+      assistantSharedFiles,
       streamState,
       loadingActive: refreshingActive,
       activeError,
@@ -794,6 +794,7 @@
   const streamingMessageId = $derived(chatDetailDisplay.streamingMessageId);
   const runActive = $derived(chatDetailDisplay.runActive);
   const transcriptListItems = $derived<ChatTranscriptListItem[]>(chatDetailDisplay.transcriptListItems);
+  const transcriptHasRenderableItems = $derived(transcriptListItems.some((item) => item.kind !== 'tail-spacer'));
   const srStatusAnnouncement = $derived(chatDetailDisplay.statusAnnouncement);
   const srAlertAnnouncement = $derived(chatDetailDisplay.alertAnnouncement);
   // Keep the detail header aligned with sidebar row badges. PMA is a manager-agent
@@ -3178,9 +3179,9 @@
             onScopeChange={handleScopePickerChange}
           />
         </div>
-      {:else if activeCards.length === 0 && liveActivity}
+      {:else if !transcriptHasRenderableItems && liveActivity}
         {@render typingDots(liveActivity.title)}
-      {:else if activeCards.length === 0}
+      {:else if !transcriptHasRenderableItems}
         <div class="state-panel empty-state">
           <strong>No transcript available</strong>
           <p>This chat has no visible timeline yet.</p>
@@ -3212,7 +3213,7 @@
               <ChatTranscriptCards
                 cards={[]}
                 assistantLabel={chatAgentDisplayLabel}
-                sharedFiles={assistantSharedFiles}
+                sharedFiles={item.files}
               />
             {:else if item.kind === 'tail-spacer'}
               <div class="chat-transcript-tail-spacer" aria-hidden="true"></div>

--- a/tests/test_update_launchd.py
+++ b/tests/test_update_launchd.py
@@ -316,7 +316,7 @@ def test_telegram_cli_health_invokes_state_check_and_health(
     console = bin_dir / "codex-autorunner"
     console.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     console.chmod(0o755)
-    checker = HealthChecker(logger=LOGGER, timeout=1.0)
+    checker = HealthChecker(logger=LOGGER, timeout=5.0)
     assert checker.telegram_cli_healthy(
         python_bin=bin_dir / "python", hub_root=tmp_path
     )


### PR DESCRIPTION
## Summary

- Render assistant shared delivery attachments as inline transcript items instead of a synthetic bottom row.
- Insert shared file items by delivery timestamp so attachments stay anchored as later replies arrive.
- Reuse the existing shared-file card renderer for inline transcript rendering.
- Stabilize the launchd health test timeout so the repo hook passes under parallel validation load.

## Root Cause

Web chat treated assistant outbox deliveries as a chat-level tail item. Because that row was appended after all transcript cards, attachments always stuck to the bottom instead of scrolling with the related conversation content.

## Review

A subagent reviewed the initial diff and found that attaching files to the latest assistant message would make older files drift to newer replies. This PR addresses that by timestamp-bucketing shared deliveries into the transcript list and adds a regression test for the drift case.

## Validation

- `pnpm exec vitest run src/lib/application/chatDetailReadModel.test.ts src/lib/components/ChatTranscriptCards.test.ts src/routes/chats/page.test.ts`
- `pnpm web:test`
- `pnpm web:lint`
- `pnpm --filter @codex-autorunner/web-hub run build`
- `.venv/bin/python -m pytest tests/test_update_launchd.py::test_telegram_cli_health_invokes_state_check_and_health`
- pre-commit hook: `scripts/check.sh` auto-selected `web-core-contract` and passed
