### PR TITLE
[codex] Fix staged update pipx layout detection

### DIFF
--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -801,25 +801,12 @@ def _system_update_check(
 
 def _capture_update_identity_hint() -> dict[str, Any]:
     from .detect import detect_supervisor_identity
+    from .engine import _resolve_car_wrapper_path, resolve_pipx_layout
 
-    pipx_root = Path(
-        os.environ.get("PIPX_ROOT", str(Path("~/.local/pipx").expanduser()))
-    ).expanduser()
-    current_link = Path(
-        os.environ.get(
-            "CURRENT_VENV_LINK",
-            str(pipx_root / "venvs" / "codex-autorunner.current"),
-        )
-    ).expanduser()
-    local_bin = Path(
-        os.environ.get("LOCAL_BIN", str(Path("~/.local/bin").expanduser()))
-    ).expanduser()
-    car_wrapper = Path(
-        os.environ.get("CAR_WRAPPER_PATH", str(local_bin / "car"))
-    ).expanduser()
+    layout = resolve_pipx_layout()
     identity = detect_supervisor_identity(
-        current_venv_link=current_link,
-        car_wrapper_path=car_wrapper,
+        current_venv_link=layout.current_link,
+        car_wrapper_path=_resolve_car_wrapper_path(),
         hub_pid=os.getpid(),
     )
     hint: dict[str, Any] = {

--- a/src/codex_autorunner/core/update/cutover.py
+++ b/src/codex_autorunner/core/update/cutover.py
@@ -31,15 +31,39 @@ class CutoverManager:
         self.keep_old_venvs = max(0, int(keep_old_venvs))
         self.logger = logger or logging.getLogger(__name__)
 
-    def initialize_current_link(self, default_target: Path) -> Path:
+    def initialize_current_link(
+        self,
+        default_target: Path,
+        *,
+        detected_candidates: tuple[Path, ...] = (),
+    ) -> Path:
         """Ensure ``current_venv_link`` exists and return its resolved target."""
         default_target = default_target.expanduser().resolve()
-        if not self.current_venv_link.is_symlink():
+        if self.current_venv_link.is_symlink():
+            current_target = self.resolve_link(self.current_venv_link)
+            if current_target is None:
+                raise CutoverError(
+                    f"Unable to resolve current venv from {self.current_venv_link}."
+                )
+            return current_target
+
+        if not self._is_usable_venv(default_target):
+            candidate_text = (
+                ", ".join(str(path) for path in detected_candidates)
+                if detected_candidates
+                else "none"
+            )
+            raise CutoverError(
+                "Unable to initialize current venv link because the default target "
+                f"is not a usable venv: {default_target}. Detected candidate venvs: "
+                f"{candidate_text}."
+            )
+        else:
             self.logger.info(
                 "Initializing %s -> %s", self.current_venv_link, default_target
             )
             self._symlink(default_target, self.current_venv_link)
-        current_target = self.resolve_link(self.current_venv_link)
+            current_target = self.resolve_link(self.current_venv_link)
         if current_target is None:
             raise CutoverError(
                 f"Unable to resolve current venv from {self.current_venv_link}."
@@ -129,6 +153,11 @@ class CutoverManager:
         except OSError:
             return None
         return resolved if resolved.exists() else None
+
+    @staticmethod
+    def _is_usable_venv(path: Path) -> bool:
+        python_bin = path / "bin" / "python"
+        return path.is_dir() and python_bin.exists() and os.access(python_bin, os.X_OK)
 
     def _symlink(self, target: Path, link: Path) -> None:
         link.parent.mkdir(parents=True, exist_ok=True)

--- a/src/codex_autorunner/core/update/engine.py
+++ b/src/codex_autorunner/core/update/engine.py
@@ -56,12 +56,26 @@ from .supervisors import (
 )
 
 _CMD_TIMEOUT_SECONDS = 300
-_DEFAULT_PIPX_ROOT = Path("~/.local/pipx").expanduser()
+_DEFAULT_PIPX_ROOT = Path("~/.local/pipx")
 _DEFAULT_CURRENT_VENV_LINK = _DEFAULT_PIPX_ROOT / "venvs" / "codex-autorunner.current"
 _DEFAULT_PREV_VENV_LINK = _DEFAULT_PIPX_ROOT / "venvs" / "codex-autorunner.prev"
-_DEFAULT_LOCAL_BIN = Path("~/.local/bin").expanduser()
+_DEFAULT_LOCAL_BIN = Path("~/.local/bin")
 _DEFAULT_SNAPSHOT_MAX_COUNT = 1
 _DEFAULT_KEEP_OLD_VENVS = 3
+
+
+@dataclass(frozen=True)
+class PipxLayout:
+    pipx_root: Path
+    current_link: Path
+    prev_link: Path
+    active_venv: Path
+    candidates: tuple[Path, ...] = ()
+
+    def __iter__(self):
+        yield self.pipx_root
+        yield self.current_link
+        yield self.prev_link
 
 
 @dataclass
@@ -120,8 +134,87 @@ def _resolve_linux_service_names(
     return merged
 
 
-def _resolve_venv_paths() -> tuple[Path, Path, Path]:
-    pipx_root = Path(os.environ.get("PIPX_ROOT", str(_DEFAULT_PIPX_ROOT))).expanduser()
+def _env_path(name: str) -> Path | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return Path(raw).expanduser()
+
+
+def _venv_from_bin_path(path: Path) -> Path | None:
+    """Return the enclosing pipx codex-autorunner venv for a bin path."""
+    try:
+        resolved = path.expanduser().resolve(strict=False)
+    except OSError:
+        resolved = path.expanduser()
+    if resolved.parent.name != "bin":
+        return None
+    venv = resolved.parent.parent
+    if venv.name != "codex-autorunner":
+        return None
+    if venv.parent.name != "venvs":
+        return None
+    return venv
+
+
+def _looks_like_codex_venv(path: Path) -> bool:
+    python_bin = path / "bin" / "python"
+    return path.is_dir() and python_bin.exists() and os.access(python_bin, os.X_OK)
+
+
+def _detect_active_codex_venv(
+    car_wrapper_path: Path,
+) -> tuple[Path | None, tuple[Path, ...]]:
+    candidates: list[Path] = []
+
+    executable = Path(sys.executable).expanduser() if sys.executable else None
+    if executable is not None:
+        executable_venv = _venv_from_bin_path(executable)
+        if executable_venv is not None:
+            candidates.append(executable_venv)
+
+    wrapper_venv = _venv_from_bin_path(car_wrapper_path)
+    if wrapper_venv is not None:
+        candidates.append(wrapper_venv)
+
+    default_roots = (
+        Path("~/.local/share/pipx").expanduser(),
+        _DEFAULT_PIPX_ROOT.expanduser(),
+    )
+    for root in default_roots:
+        candidates.append(root / "venvs" / "codex-autorunner")
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+
+    for candidate in deduped:
+        if _looks_like_codex_venv(candidate):
+            return candidate, tuple(deduped)
+    return None, tuple(deduped)
+
+
+def resolve_pipx_layout() -> PipxLayout:
+    car_wrapper_path = _resolve_car_wrapper_path()
+    explicit_pipx_venv = _env_path("PIPX_VENV")
+    detected_venv, candidates = _detect_active_codex_venv(car_wrapper_path)
+    active_venv = explicit_pipx_venv or detected_venv
+
+    explicit_pipx_root = _env_path("PIPX_ROOT")
+    if explicit_pipx_root is not None:
+        pipx_root = explicit_pipx_root
+        if explicit_pipx_venv is None:
+            active_venv = pipx_root / "venvs" / "codex-autorunner"
+    elif active_venv is not None and active_venv.parent.name == "venvs":
+        pipx_root = active_venv.parent.parent
+    else:
+        pipx_root = _DEFAULT_PIPX_ROOT.expanduser()
+
     current = Path(
         os.environ.get(
             "CURRENT_VENV_LINK", str(pipx_root / "venvs" / "codex-autorunner.current")
@@ -132,7 +225,19 @@ def _resolve_venv_paths() -> tuple[Path, Path, Path]:
             "PREV_VENV_LINK", str(pipx_root / "venvs" / "codex-autorunner.prev")
         )
     ).expanduser()
-    return pipx_root, current, prev
+    active_venv = active_venv or pipx_root / "venvs" / "codex-autorunner"
+    return PipxLayout(
+        pipx_root=pipx_root,
+        current_link=current,
+        prev_link=prev,
+        active_venv=active_venv,
+        candidates=candidates,
+    )
+
+
+def _resolve_venv_paths() -> tuple[Path, Path, Path]:
+    layout = resolve_pipx_layout()
+    return layout.pipx_root, layout.current_link, layout.prev_link
 
 
 def _resolve_car_wrapper_path() -> Path:
@@ -252,7 +357,10 @@ class UpdateEngine:
             self.reporter.write("error", msg)
             return
 
-        pipx_root, current_link, prev_link = _resolve_venv_paths()
+        pipx_layout = resolve_pipx_layout()
+        pipx_root = pipx_layout.pipx_root
+        current_link = pipx_layout.current_link
+        prev_link = pipx_layout.prev_link
         identity = detect_supervisor_identity(
             hint=self.config.identity_hint,
             current_venv_link=current_link,
@@ -330,6 +438,8 @@ class UpdateEngine:
                 pipx_root=pipx_root,
                 current_link=current_link,
                 prev_link=prev_link,
+                active_venv=pipx_layout.active_venv,
+                detected_venv_candidates=pipx_layout.candidates,
             )
         else:
             self._run_in_place_update(
@@ -387,6 +497,8 @@ class UpdateEngine:
         pipx_root: Path,
         current_link: Path,
         prev_link: Path,
+        active_venv: Path,
+        detected_venv_candidates: tuple[Path, ...],
     ) -> None:
         package_src = self.config.update_dir
         python_bin = Path(
@@ -413,10 +525,10 @@ class UpdateEngine:
             logger=self.logger,
         )
 
-        pipx_venv = Path(
-            os.environ.get("PIPX_VENV", str(pipx_root / "venvs" / "codex-autorunner"))
-        ).expanduser()
-        self._current_target = cutover.initialize_current_link(pipx_venv)
+        self._current_target = cutover.initialize_current_link(
+            active_venv,
+            detected_candidates=detected_venv_candidates,
+        )
 
         try:
             with self.reporter.timed_phase("venv_create"):
@@ -482,6 +594,7 @@ class UpdateEngine:
                     cutover.sync_car_wrapper(
                         package_src=package_src,
                         local_bin=local_bin,
+                        car_wrapper_path=_resolve_car_wrapper_path(),
                     )
             except Exception as exc:
                 warning = (

--- a/src/codex_autorunner/core/update/engine.py
+++ b/src/codex_autorunner/core/update/engine.py
@@ -525,12 +525,11 @@ class UpdateEngine:
             logger=self.logger,
         )
 
-        self._current_target = cutover.initialize_current_link(
-            active_venv,
-            detected_candidates=detected_venv_candidates,
-        )
-
         try:
+            self._current_target = cutover.initialize_current_link(
+                active_venv,
+                detected_candidates=detected_venv_candidates,
+            )
             with self.reporter.timed_phase("venv_create"):
                 self._candidate_venv = installer.create_staged_venv()
             wheel_dir = Path(f"{self._candidate_venv}.wheelhouse")

--- a/tests/core/test_update_install_cutover_health.py
+++ b/tests/core/test_update_install_cutover_health.py
@@ -19,6 +19,14 @@ from codex_autorunner.core.update.install import (
 )
 
 
+def _make_venv(path: Path) -> None:
+    bin_dir = path / "bin"
+    bin_dir.mkdir(parents=True)
+    python = bin_dir / "python"
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    python.chmod(0o755)
+
+
 def test_select_pip_extras_defaults_to_browser() -> None:
     assert select_pip_extras() == "[browser]"
 
@@ -62,8 +70,8 @@ def test_cutover_manager_flip_and_rollback(tmp_path: Path) -> None:
     prev = venvs / "codex-autorunner.prev"
     old = venvs / "codex-autorunner.old"
     candidate = venvs / "codex-autorunner.next-20260101-120000"
-    old.mkdir(parents=True)
-    candidate.mkdir(parents=True)
+    _make_venv(old)
+    _make_venv(candidate)
 
     manager = CutoverManager(
         current_venv_link=current,
@@ -96,11 +104,11 @@ def test_cutover_manager_prune_keeps_recent_and_active(tmp_path: Path) -> None:
     newer = venvs / "codex-autorunner.next-newer"
     older = venvs / "codex-autorunner.next-older"
     oldest = venvs / "codex-autorunner.next-oldest"
-    live.mkdir(parents=True)
+    _make_venv(live)
     os.symlink(live, current)
     os.symlink(live, prev)
     for index, path in enumerate((oldest, older, newer, newest)):
-        path.mkdir(parents=True)
+        _make_venv(path)
         os.utime(path, (index + 1, index + 1))
 
     manager = CutoverManager(
@@ -123,7 +131,7 @@ def test_cutover_sync_car_wrapper_writes_dispatch_path(tmp_path: Path) -> None:
     current = venvs / "codex-autorunner.current"
     prev = venvs / "codex-autorunner.prev"
     target = venvs / "codex-autorunner.live"
-    target.mkdir(parents=True)
+    _make_venv(target)
     os.symlink(target, current)
 
     local_bin = tmp_path / "bin"

--- a/tests/test_update_engine.py
+++ b/tests/test_update_engine.py
@@ -232,6 +232,57 @@ def test_engine_refuses_cutover_without_routing_or_allow_in_place(
     assert payload.get("error_type") == "cutover_routing_refused"
 
 
+def test_engine_reports_unusable_active_venv_as_staged_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_pipx_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    status_path = tmp_path / ".codex-autorunner" / "update_status.json"
+    lock_path = tmp_path / ".codex-autorunner" / "update.lock"
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.update.engine.prepare_update_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.update.engine.resolve_executable",
+        lambda _cmd: "/usr/bin/tool",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.update.engine.detect_supervisor_identity",
+        lambda **_kwargs: _linux_identity(hub_root=hub_root),
+    )
+
+    pipx_root = tmp_path / ".local" / "share" / "pipx"
+    unusable = pipx_root / "venvs" / "codex-autorunner"
+    unusable.mkdir(parents=True)
+    monkeypatch.setenv("PIPX_VENV", str(unusable))
+
+    config = UpdateEngineConfig(
+        repo_url="https://example.com/repo.git",
+        repo_ref="main",
+        update_dir=tmp_path / "cache",
+        update_target="web",
+        update_backend="systemd-user",
+        identity_hint={"hub_root": str(hub_root)},
+    )
+    UpdateEngine(
+        config,
+        logger=logging.getLogger("test"),
+        status_path=status_path,
+        lock_path=lock_path,
+    ).run()
+
+    payload = json.loads(status_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["phase"] == "staged_install_failed"
+    assert payload["error_type"] == "staged_install_failed"
+    assert "not a usable venv" in payload["message"]
+    assert str(unusable) in payload["message"]
+
+
 def test_engine_rollback_writes_status_on_health_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_update_engine.py
+++ b/tests/test_update_engine.py
@@ -6,9 +6,164 @@ from pathlib import Path
 
 import pytest
 
+from codex_autorunner.core.update import engine as update_engine
+from codex_autorunner.core.update.cutover import CutoverError, CutoverManager
 from codex_autorunner.core.update.detect import SupervisorIdentity
-from codex_autorunner.core.update.engine import UpdateEngine, UpdateEngineConfig
+from codex_autorunner.core.update.engine import (
+    UpdateEngine,
+    UpdateEngineConfig,
+    resolve_pipx_layout,
+)
 from codex_autorunner.core.update.supervisors import RestartResult, UpdateServices
+
+_PIPX_ENV_VARS = (
+    "PIPX_ROOT",
+    "PIPX_VENV",
+    "CURRENT_VENV_LINK",
+    "PREV_VENV_LINK",
+    "LOCAL_BIN",
+    "CAR_WRAPPER_PATH",
+)
+
+
+def _clear_pipx_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _PIPX_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _make_pipx_install(root: Path, local_bin: Path) -> Path:
+    venv = root / "venvs" / "codex-autorunner"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    python = bin_dir / "python"
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    python.chmod(0o755)
+    car = bin_dir / "car"
+    car.write_text("#!/bin/sh\n", encoding="utf-8")
+    car.chmod(0o755)
+    local_bin.mkdir(parents=True)
+    (local_bin / "car").symlink_to(car)
+    return venv
+
+
+def test_resolve_pipx_layout_detects_share_pipx_from_car_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_pipx_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(update_engine.sys, "executable", str(tmp_path / "python"))
+    pipx_root = tmp_path / ".local" / "share" / "pipx"
+    venv = _make_pipx_install(pipx_root, tmp_path / ".local" / "bin")
+
+    layout = resolve_pipx_layout()
+
+    assert layout.pipx_root == pipx_root
+    assert layout.active_venv == venv
+    assert layout.current_link == pipx_root / "venvs" / "codex-autorunner.current"
+    assert layout.prev_link == pipx_root / "venvs" / "codex-autorunner.prev"
+
+
+def test_resolve_pipx_layout_env_override_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_pipx_env(monkeypatch)
+    env_root = tmp_path / "env-pipx"
+    env_venv = tmp_path / "explicit" / "codex-autorunner"
+    current = tmp_path / "links" / "current"
+    prev = tmp_path / "links" / "prev"
+    wrapper = tmp_path / "bin" / "car"
+    monkeypatch.setenv("PIPX_ROOT", str(env_root))
+    monkeypatch.setenv("PIPX_VENV", str(env_venv))
+    monkeypatch.setenv("CURRENT_VENV_LINK", str(current))
+    monkeypatch.setenv("PREV_VENV_LINK", str(prev))
+    monkeypatch.setenv("CAR_WRAPPER_PATH", str(wrapper))
+
+    layout = resolve_pipx_layout()
+
+    assert layout.pipx_root == env_root
+    assert layout.active_venv == env_venv
+    assert layout.current_link == current
+    assert layout.prev_link == prev
+
+
+def test_resolve_pipx_layout_pipx_root_only_beats_conflicting_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_pipx_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(update_engine.sys, "executable", str(tmp_path / "python"))
+    wrapper_root = tmp_path / ".local" / "share" / "pipx"
+    _make_pipx_install(wrapper_root, tmp_path / ".local" / "bin")
+    env_root = tmp_path / "custom-pipx"
+    monkeypatch.setenv("PIPX_ROOT", str(env_root))
+
+    layout = resolve_pipx_layout()
+
+    assert layout.pipx_root == env_root
+    assert layout.active_venv == env_root / "venvs" / "codex-autorunner"
+    assert layout.current_link == env_root / "venvs" / "codex-autorunner.current"
+    assert layout.prev_link == env_root / "venvs" / "codex-autorunner.prev"
+
+
+def test_cutover_missing_default_target_fails_without_broken_current_link(
+    tmp_path: Path,
+) -> None:
+    pipx_root = tmp_path / "pipx"
+    current = pipx_root / "venvs" / "codex-autorunner.current"
+    prev = pipx_root / "venvs" / "codex-autorunner.prev"
+    missing = pipx_root / "venvs" / "codex-autorunner"
+    manager = CutoverManager(
+        current_venv_link=current,
+        prev_venv_link=prev,
+        pipx_root=pipx_root,
+    )
+
+    with pytest.raises(CutoverError, match="not a usable venv") as exc:
+        manager.initialize_current_link(
+            missing,
+            detected_candidates=(missing, tmp_path / "other"),
+        )
+
+    message = str(exc.value)
+    assert str(missing) in message
+    assert str(tmp_path / "other") in message
+    assert not current.exists()
+    assert not current.is_symlink()
+
+
+def test_resolve_pipx_layout_ignores_unusable_existing_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_pipx_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(update_engine.sys, "executable", str(tmp_path / "python"))
+    unusable_root = tmp_path / ".local" / "share" / "pipx"
+    unusable = unusable_root / "venvs" / "codex-autorunner"
+    unusable.mkdir(parents=True)
+
+    layout = resolve_pipx_layout()
+
+    assert layout.pipx_root == tmp_path / ".local" / "pipx"
+    assert (
+        layout.active_venv
+        == tmp_path / ".local" / "pipx" / "venvs" / "codex-autorunner"
+    )
+    assert unusable in layout.candidates
+
+
+def test_resolve_pipx_layout_detects_existing_legacy_pipx_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_pipx_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(update_engine.sys, "executable", str(tmp_path / "python"))
+    pipx_root = tmp_path / ".local" / "pipx"
+    venv = _make_pipx_install(pipx_root, tmp_path / ".local" / "bin")
+
+    layout = resolve_pipx_layout()
+
+    assert layout.pipx_root == pipx_root
+    assert layout.active_venv == venv
 
 
 def _linux_identity(*, hub_root: Path) -> SupervisorIdentity:
@@ -170,7 +325,7 @@ def test_engine_rollback_writes_status_on_health_failure(
     pipx_root = tmp_path / ".local" / "pipx"
     venvs = pipx_root / "venvs"
     live = venvs / "codex-autorunner"
-    live.mkdir(parents=True)
+    _make_pipx_install(pipx_root, tmp_path / ".local" / "bin")
     (venvs / "codex-autorunner.current").symlink_to(live)
     monkeypatch.setenv("PIPX_ROOT", str(pipx_root))
 


### PR DESCRIPTION
## Summary

- infer the staged updater pipx layout from explicit env vars, the running executable, and the resolved car wrapper
- support pipx installs under ~/.local/share/pipx while preserving legacy ~/.local/pipx and explicit env-configured installs
- refuse to initialize codex-autorunner.current unless the target is a usable venv, avoiding broken cutover symlinks

## Root Cause

The staged updater defaulted to ~/.local/pipx when PIPX_ROOT/PIPX_VENV were absent. On hosts where pipx installs live under ~/.local/share/pipx, the updater initialized codex-autorunner.current under the wrong root and then failed to resolve that broken symlink.

## Validation

- Subagent review completed; addressed findings for PIPX_ROOT-only precedence and usable-venv validation.
- .venv/bin/python -m ruff check src/codex_autorunner/core/update/engine.py src/codex_autorunner/core/update/cutover.py src/codex_autorunner/core/update/_facade.py tests/test_update_engine.py tests/core/test_update_install_cutover_health.py
- .venv/bin/python -m pytest tests/test_update_engine.py tests/core/test_update_install_cutover_health.py tests/test_update_paths.py tests/test_update_detect.py tests/test_update_runner.py
- Commit hook core lane: guardrails, ruff, mypy, and full pytest suite: 9902 passed
