### PR TITLE
[codex] Fix update runner bootstrap

### DIFF
--- a/scripts/safe-refresh-local-linux-hub.sh
+++ b/scripts/safe-refresh-local-linux-hub.sh
@@ -39,6 +39,13 @@ LOG_PATH="$(dirname "${UPDATE_STATUS_PATH}")/update-standalone.log"
 REPO_URL="${REPO_URL:-https://github.com/cursor/codex-autorunner.git}"
 REPO_REF="${REPO_REF:-main}"
 
+PACKAGE_SRC_ROOT="$(cd "${PACKAGE_SRC}" && pwd)"
+PACKAGE_SRC_PYTHONPATH="${PACKAGE_SRC_ROOT}/src"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}:${PYTHONPATH}"
+else
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}"
+fi
 export HELPER_PYTHON
 export PACKAGE_SRC
 export UPDATE_STATUS_PATH

--- a/scripts/safe-refresh-local-linux-hub.sh
+++ b/scripts/safe-refresh-local-linux-hub.sh
@@ -39,6 +39,13 @@ LOG_PATH="$(dirname "${UPDATE_STATUS_PATH}")/update-standalone.log"
 REPO_URL="${REPO_URL:-https://github.com/cursor/codex-autorunner.git}"
 REPO_REF="${REPO_REF:-main}"
 
+PACKAGE_SRC_ROOT="$("${HELPER_PYTHON}" -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).expanduser().resolve(strict=False))' "${PACKAGE_SRC}")"
+PACKAGE_SRC_PYTHONPATH="${PACKAGE_SRC_ROOT}/src"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}:${PYTHONPATH}"
+else
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}"
+fi
 export HELPER_PYTHON
 export PACKAGE_SRC
 export UPDATE_STATUS_PATH

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -63,6 +63,13 @@ fi
 REPO_URL="${REPO_URL:-https://github.com/cursor/codex-autorunner.git}"
 REPO_REF="${REPO_REF:-main}"
 
+PACKAGE_SRC_ROOT="$("${HELPER_PYTHON}" -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).expanduser().resolve(strict=False))' "${PACKAGE_SRC}")"
+PACKAGE_SRC_PYTHONPATH="${PACKAGE_SRC_ROOT}/src"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}:${PYTHONPATH}"
+else
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}"
+fi
 export HELPER_PYTHON PACKAGE_SRC UPDATE_STATUS_PATH UPDATE_TARGET CURRENT_VENV_LINK PIPX_ROOT
 
 exec "${HELPER_PYTHON}" -m codex_autorunner.core.update.runner \

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -63,6 +63,13 @@ fi
 REPO_URL="${REPO_URL:-https://github.com/cursor/codex-autorunner.git}"
 REPO_REF="${REPO_REF:-main}"
 
+PACKAGE_SRC_ROOT="$(cd "${PACKAGE_SRC}" && pwd)"
+PACKAGE_SRC_PYTHONPATH="${PACKAGE_SRC_ROOT}/src"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}:${PYTHONPATH}"
+else
+  export PYTHONPATH="${PACKAGE_SRC_PYTHONPATH}"
+fi
 export HELPER_PYTHON PACKAGE_SRC UPDATE_STATUS_PATH UPDATE_TARGET CURRENT_VENV_LINK PIPX_ROOT
 
 exec "${HELPER_PYTHON}" -m codex_autorunner.core.update.runner \

--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -13,7 +13,7 @@ from typing import Any, Optional, Union
 from urllib.parse import unquote, urlparse
 
 from ..git_utils import GitError, run_git
-from ..locks import process_matches_identity
+from ..locks import process_alive, process_matches_identity
 from ..update_paths import resolve_update_paths
 from ..update_targets import (
     UpdateTargetDefinition,
@@ -607,12 +607,16 @@ def _update_lock_active() -> Optional[dict]:
         return None
     pid = lock.get("pid")
     if isinstance(pid, int):
-        pid_matches = process_matches_identity(
-            pid,
-            expected_cmd_substrings=_UPDATE_LOCK_CMD_HINTS,
-        )
-        if pid_matches:
-            return lock
+        if lock.get("bootstrap"):
+            if process_alive(pid):
+                return lock
+        else:
+            pid_matches = process_matches_identity(
+                pid,
+                expected_cmd_substrings=_UPDATE_LOCK_CMD_HINTS,
+            )
+            if pid_matches:
+                return lock
     try:
         _update_lock_path().unlink()
     except OSError:
@@ -621,7 +625,12 @@ def _update_lock_active() -> Optional[dict]:
 
 
 def _acquire_update_lock(
-    *, repo_url: str, repo_ref: str, update_target: str, logger: logging.Logger
+    *,
+    repo_url: str,
+    repo_ref: str,
+    update_target: str,
+    logger: logging.Logger,
+    bootstrap: bool = False,
 ) -> bool:
     lock_path = _update_lock_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -632,6 +641,8 @@ def _acquire_update_lock(
         "repo_ref": repo_ref,
         "update_target": update_target,
     }
+    if bootstrap:
+        payload["bootstrap"] = True
     try:
         fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
     except FileExistsError as exc:
@@ -908,11 +919,16 @@ def _spawn_update_process(
     server_port: int = 4173,
     server_base_path: str = "",
 ) -> None:
-    active = _update_lock_active()
-    if active:
-        raise UpdateInProgressError(
-            f"Update already running (pid {active.get('pid')})."
+    try:
+        _acquire_update_lock(
+            repo_url=repo_url,
+            repo_ref=repo_ref,
+            update_target=update_target,
+            logger=logger,
+            bootstrap=True,
         )
+    except UpdateInProgressError:
+        raise
     status_path = _update_status_path()
     log_path = status_path.parent / "update-standalone.log"
     _write_update_status(
@@ -980,6 +996,7 @@ def _spawn_update_process(
         cmd.append("--no-skip-checks")
     try:
         prepare_update_source(update_dir, repo_url, repo_ref, logger)
+        _release_update_lock()
         env = _env_with_source_pythonpath(update_dir)
         with log_path.open("a", encoding="utf-8") as log_file:
             subprocess.Popen(
@@ -992,6 +1009,7 @@ def _spawn_update_process(
             )
     except Exception:  # intentional: top-level error handler
         logger.exception("Failed to spawn update worker")
+        _release_update_lock()
         _write_update_status(
             "error",
             "Failed to spawn update worker; see hub logs for details.",

--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -22,6 +22,7 @@ from ..update_targets import (
     normalize_update_target,
 )
 from ..utils import resolve_executable
+from .source import prepare_update_source
 
 
 class UpdateInProgressError(RuntimeError):
@@ -144,6 +145,17 @@ def _run_refresh_script(
             output_tail.append(rendered)
     proc.wait()
     return proc.returncode, list(output_tail)
+
+
+def _env_with_source_pythonpath(update_dir: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    source_path = str(update_dir / "src")
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        env["PYTHONPATH"] = f"{source_path}{os.pathsep}{existing_pythonpath}"
+    else:
+        env["PYTHONPATH"] = source_path
+    return env
 
 
 def _normalize_update_target(raw: Optional[str]) -> str:
@@ -572,6 +584,10 @@ def _update_lock_path() -> Path:
     return resolve_update_paths().lock_path
 
 
+def _update_cache_lock_path() -> Path:
+    return _update_lock_path().with_suffix(".cache.lock")
+
+
 def _read_update_lock() -> Optional[dict[str, object]]:
     path = _update_lock_path()
     if not path.exists():
@@ -608,6 +624,49 @@ def _update_lock_active() -> Optional[dict]:
     return None
 
 
+def _read_update_cache_lock() -> Optional[dict[str, object]]:
+    path = _update_cache_lock_path()
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _update_cache_lock_active() -> Optional[dict[str, object]]:
+    lock = _read_update_cache_lock()
+    if not lock:
+        try:
+            _update_cache_lock_path().unlink()
+        except OSError:
+            pass
+        return None
+    pid = lock.get("pid")
+    if isinstance(pid, int) and _pid_is_running(pid):
+        return lock
+    try:
+        _update_cache_lock_path().unlink()
+    except OSError:
+        pass
+    return None
+
+
 def _acquire_update_lock(
     *, repo_url: str, repo_ref: str, update_target: str, logger: logging.Logger
 ) -> bool:
@@ -639,12 +698,53 @@ def _acquire_update_lock(
     return True
 
 
+def _acquire_update_cache_lock(
+    *, repo_url: str, repo_ref: str, update_target: str, logger: logging.Logger
+) -> bool:
+    lock_path = _update_cache_lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "pid": os.getpid(),
+        "started_at": time.time(),
+        "repo_url": repo_url,
+        "repo_ref": repo_ref,
+        "update_target": update_target,
+    }
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as exc:
+        existing = _update_cache_lock_active()
+        if existing:
+            msg = f"Update source preparation already running (pid {existing.get('pid')})."
+            logger.info(msg)
+            raise UpdateInProgressError(msg) from exc
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError as exc:
+            msg = "Update source preparation already running."
+            logger.info(msg)
+            raise UpdateInProgressError(msg) from exc
+    with os.fdopen(fd, "w") as handle:
+        handle.write(json.dumps(payload))
+    return True
+
+
 def _release_update_lock() -> None:
     lock = _read_update_lock()
     if not lock or lock.get("pid") != os.getpid():
         return
     try:
         _update_lock_path().unlink()
+    except OSError:
+        pass
+
+
+def _release_update_cache_lock() -> None:
+    lock = _read_update_cache_lock()
+    if not lock or lock.get("pid") != os.getpid():
+        return
+    try:
+        _update_cache_lock_path().unlink()
     except OSError:
         pass
 
@@ -901,12 +1001,17 @@ def _spawn_update_process(
         raise UpdateInProgressError(
             f"Update already running (pid {active.get('pid')})."
         )
+    active_cache = _update_cache_lock_active()
+    if active_cache:
+        raise UpdateInProgressError(
+            f"Update source preparation already running (pid {active_cache.get('pid')})."
+        )
     status_path = _update_status_path()
     log_path = status_path.parent / "update-standalone.log"
     _write_update_status(
-        "running",
-        "Update spawned.",
-        phase="spawned",
+        "preparing",
+        "Preparing update source.",
+        phase="source_prep",
         repo_url=repo_url,
         update_dir=str(update_dir),
         repo_ref=repo_ref,
@@ -966,18 +1071,51 @@ def _spawn_update_process(
         cmd.append("--skip-checks")
     else:
         cmd.append("--no-skip-checks")
+    cache_lock_acquired = False
     try:
+        cache_lock_acquired = _acquire_update_cache_lock(
+            repo_url=repo_url,
+            repo_ref=repo_ref,
+            update_target=update_target,
+            logger=logger,
+        )
+        prepare_update_source(update_dir, repo_url, repo_ref, logger)
+        env = _env_with_source_pythonpath(update_dir)
         with log_path.open("a", encoding="utf-8") as log_file:
             subprocess.Popen(
                 cmd,
                 cwd=str(update_dir.parent),
+                env=env,
                 start_new_session=True,
                 stdout=log_file,
                 stderr=log_file,
             )
+        _write_update_status(
+            "running",
+            "Update spawned.",
+            phase="spawned",
+            repo_url=repo_url,
+            update_dir=str(update_dir),
+            repo_ref=repo_ref,
+            update_target=update_target,
+            update_backend=update_backend,
+            linux_hub_service_name=linux_hub_service_name,
+            linux_telegram_service_name=linux_telegram_service_name,
+            linux_discord_service_name=linux_discord_service_name,
+            log_path=str(log_path),
+            notify_chat_id=notify_chat_id,
+            notify_thread_id=notify_thread_id,
+            notify_reply_to=notify_reply_to,
+            notify_platform=notify_platform,
+            notify_context=notify_context if isinstance(notify_context, dict) else None,
+            notify_sent_at=None,
+        )
     except Exception:  # intentional: top-level error handler
         logger.exception("Failed to spawn update worker")
         _write_update_status(
             "error",
             "Failed to spawn update worker; see hub logs for details.",
         )
+    finally:
+        if cache_lock_acquired:
+            _release_update_cache_lock()

--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -22,6 +22,7 @@ from ..update_targets import (
     normalize_update_target,
 )
 from ..utils import resolve_executable
+from .source import prepare_update_source
 
 
 class UpdateInProgressError(RuntimeError):
@@ -144,6 +145,17 @@ def _run_refresh_script(
             output_tail.append(rendered)
     proc.wait()
     return proc.returncode, list(output_tail)
+
+
+def _env_with_source_pythonpath(update_dir: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    source_path = str(update_dir / "src")
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        env["PYTHONPATH"] = f"{source_path}{os.pathsep}{existing_pythonpath}"
+    else:
+        env["PYTHONPATH"] = source_path
+    return env
 
 
 def _normalize_update_target(raw: Optional[str]) -> str:
@@ -967,10 +979,13 @@ def _spawn_update_process(
     else:
         cmd.append("--no-skip-checks")
     try:
+        prepare_update_source(update_dir, repo_url, repo_ref, logger)
+        env = _env_with_source_pythonpath(update_dir)
         with log_path.open("a", encoding="utf-8") as log_file:
             subprocess.Popen(
                 cmd,
                 cwd=str(update_dir.parent),
+                env=env,
                 start_new_session=True,
                 stdout=log_file,
                 stderr=log_file,

--- a/src/codex_autorunner/core/update/install.py
+++ b/src/codex_autorunner/core/update/install.py
@@ -18,12 +18,21 @@ _WHEEL_REQUIRED_PREFIXES = (
     "codex_autorunner/workspace/",
     "codex_autorunner/tickets/",
     "codex_autorunner/adapters/docker/",
+    "codex_autorunner/core/update/",
 )
-_WHEEL_REQUIRED_FILES = ("codex_autorunner/web_static/index.html",)
+_WHEEL_REQUIRED_FILES = (
+    "codex_autorunner/web_static/index.html",
+    "codex_autorunner/core/update/__init__.py",
+    "codex_autorunner/core/update/runner.py",
+    "codex_autorunner/core/update_runner.py",
+)
 _REQUIRED_IMPORT_MODULES = (
     "codex_autorunner.workspace",
     "codex_autorunner.tickets",
     "codex_autorunner.adapters.docker",
+    "codex_autorunner.core.update",
+    "codex_autorunner.core.update.runner",
+    "codex_autorunner.core.update_runner",
 )
 _INSTALL_CMD_TIMEOUT_SECONDS = 600
 _PIP_CMD_TIMEOUT_SECONDS = 300

--- a/tests/core/test_update_install_cutover_health.py
+++ b/tests/core/test_update_install_cutover_health.py
@@ -63,6 +63,25 @@ def test_validate_wheel_contents_requires_packages(tmp_path: Path) -> None:
         _validate_wheel_contents(wheel_path)
 
 
+def test_validate_wheel_contents_requires_update_runner(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "missing-runner.whl"
+    import zipfile
+
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        for name in (
+            "codex_autorunner/workspace/__init__.py",
+            "codex_autorunner/tickets/__init__.py",
+            "codex_autorunner/adapters/docker/__init__.py",
+            "codex_autorunner/web_static/index.html",
+            "codex_autorunner/core/update/__init__.py",
+            "codex_autorunner/core/update_runner.py",
+        ):
+            zf.writestr(name, "")
+
+    with pytest.raises(StagedInstallError, match="core/update/runner.py"):
+        _validate_wheel_contents(wheel_path)
+
+
 def test_cutover_manager_flip_and_rollback(tmp_path: Path) -> None:
     pipx_root = tmp_path / "pipx"
     venvs = pipx_root / "venvs"

--- a/tests/test_safe_refresh_local_linux_hub_script.py
+++ b/tests/test_safe_refresh_local_linux_hub_script.py
@@ -50,6 +50,42 @@ def test_linux_wrapper_requires_status_path(tmp_path: Path) -> None:
     assert "syntax error" not in output
 
 
+def test_linux_wrapper_execs_runner_with_source_pythonpath(tmp_path: Path) -> None:
+    fake_python = tmp_path / "fake-python"
+    argv_log = tmp_path / "argv.txt"
+    env_log = tmp_path / "env.txt"
+    fake_python.write_text(
+        (
+            '#!/bin/sh\nprintf "%s\\n" "$@" > "$ARGV_LOG"\n'
+            'printf "%s\\n" "$PYTHONPATH" > "$ENV_LOG"\nexit 0\n'
+        ),
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT.resolve())],
+        cwd=SCRIPT.resolve().parent.parent,
+        env={
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HELPER_PYTHON": str(fake_python),
+            "ARGV_LOG": str(argv_log),
+            "ENV_LOG": str(env_log),
+            "UPDATE_STATUS_PATH": str(tmp_path / "update_status.json"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    argv = argv_log.read_text(encoding="utf-8")
+    assert "codex_autorunner.core.update.runner" in argv
+    pythonpath = env_log.read_text(encoding="utf-8")
+    assert str(SCRIPT.resolve().parent.parent / "src") in pythonpath
+
+
 def test_linux_wrapper_passes_syntax_check() -> None:
     result = subprocess.run(
         ["bash", "-n", str(SCRIPT.resolve())],

--- a/tests/test_safe_refresh_local_linux_hub_script.py
+++ b/tests/test_safe_refresh_local_linux_hub_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 SCRIPT = Path("scripts/safe-refresh-local-linux-hub.sh")
@@ -48,6 +49,82 @@ def test_linux_wrapper_requires_status_path(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "UPDATE_STATUS_PATH is required" in output
     assert "syntax error" not in output
+
+
+def test_linux_wrapper_execs_runner_with_source_pythonpath(tmp_path: Path) -> None:
+    fake_python = tmp_path / "fake-python"
+    argv_log = tmp_path / "argv.txt"
+    env_log = tmp_path / "env.txt"
+    fake_python.write_text(
+        (
+            '#!/bin/sh\nif [ "$1" = "-c" ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+            'printf "%s\\n" "$@" > "$ARGV_LOG"\n'
+            'printf "%s\\n" "$PYTHONPATH" > "$ENV_LOG"\nexit 0\n'
+        ),
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT.resolve())],
+        cwd=SCRIPT.resolve().parent.parent,
+        env={
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HELPER_PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
+            "ARGV_LOG": str(argv_log),
+            "ENV_LOG": str(env_log),
+            "UPDATE_STATUS_PATH": str(tmp_path / "update_status.json"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    argv = argv_log.read_text(encoding="utf-8")
+    assert "codex_autorunner.core.update.runner" in argv
+    pythonpath = env_log.read_text(encoding="utf-8")
+    assert str(SCRIPT.resolve().parent.parent / "src") in pythonpath
+
+
+def test_linux_wrapper_allows_missing_package_src(tmp_path: Path) -> None:
+    fake_python = tmp_path / "fake-python"
+    argv_log = tmp_path / "argv.txt"
+    env_log = tmp_path / "env.txt"
+    missing_src = tmp_path / "missing-cache"
+    fake_python.write_text(
+        (
+            '#!/bin/sh\nif [ "$1" = "-c" ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+            'printf "%s\\n" "$@" > "$ARGV_LOG"\n'
+            'printf "%s\\n" "$PYTHONPATH" > "$ENV_LOG"\nexit 0\n'
+        ),
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT.resolve())],
+        cwd=SCRIPT.resolve().parent.parent,
+        env={
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HELPER_PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
+            "ARGV_LOG": str(argv_log),
+            "ENV_LOG": str(env_log),
+            "UPDATE_STATUS_PATH": str(tmp_path / "update_status.json"),
+            "PACKAGE_SRC": str(missing_src),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert str(missing_src / "src") in env_log.read_text(encoding="utf-8")
+    assert str(missing_src) in argv_log.read_text(encoding="utf-8")
 
 
 def test_linux_wrapper_passes_syntax_check() -> None:

--- a/tests/test_safe_refresh_local_mac_hub_script.py
+++ b/tests/test_safe_refresh_local_mac_hub_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 SCRIPT = Path("scripts/safe-refresh-local-mac-hub.sh")
@@ -33,8 +34,13 @@ def test_mac_wrapper_execs_runner_with_launchd_backend(tmp_path: Path) -> None:
     # a real update.
     fake_python = tmp_path / "fake-python"
     argv_log = tmp_path / "argv.txt"
+    env_log = tmp_path / "env.txt"
     fake_python.write_text(
-        '#!/bin/sh\nprintf "%s\\n" "$@" > "$ARGV_LOG"\nexit 0\n',
+        (
+            '#!/bin/sh\nif [ "$1" = "-c" ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+            'printf "%s\\n" "$@" > "$ARGV_LOG"\n'
+            'printf "%s\\n" "$PYTHONPATH" > "$ENV_LOG"\nexit 0\n'
+        ),
         encoding="utf-8",
     )
     fake_python.chmod(0o755)
@@ -45,7 +51,9 @@ def test_mac_wrapper_execs_runner_with_launchd_backend(tmp_path: Path) -> None:
             "HOME": str(tmp_path),
             "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
             "HELPER_PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
             "ARGV_LOG": str(argv_log),
+            "ENV_LOG": str(env_log),
             "UPDATE_STATUS_PATH": str(tmp_path / "update_status.json"),
         },
         capture_output=True,
@@ -57,6 +65,46 @@ def test_mac_wrapper_execs_runner_with_launchd_backend(tmp_path: Path) -> None:
     assert "codex_autorunner.core.update.runner" in argv
     assert "--backend" in argv
     assert "launchd" in argv
+    pythonpath = env_log.read_text(encoding="utf-8")
+    assert str(SCRIPT.resolve().parent.parent / "src") in pythonpath
+
+
+def test_mac_wrapper_allows_missing_package_src(tmp_path: Path) -> None:
+    fake_python = tmp_path / "fake-python"
+    argv_log = tmp_path / "argv.txt"
+    env_log = tmp_path / "env.txt"
+    missing_src = tmp_path / "missing-cache"
+    fake_python.write_text(
+        (
+            '#!/bin/sh\nif [ "$1" = "-c" ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+            'printf "%s\\n" "$@" > "$ARGV_LOG"\n'
+            'printf "%s\\n" "$PYTHONPATH" > "$ENV_LOG"\nexit 0\n'
+        ),
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT.resolve())],
+        cwd=SCRIPT.resolve().parent.parent,
+        env={
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HELPER_PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
+            "ARGV_LOG": str(argv_log),
+            "ENV_LOG": str(env_log),
+            "UPDATE_STATUS_PATH": str(tmp_path / "update_status.json"),
+            "PACKAGE_SRC": str(missing_src),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert str(missing_src / "src") in env_log.read_text(encoding="utf-8")
+    assert str(missing_src) in argv_log.read_text(encoding="utf-8")
 
 
 def test_mac_wrapper_passes_syntax_check() -> None:

--- a/tests/test_safe_refresh_local_mac_hub_script.py
+++ b/tests/test_safe_refresh_local_mac_hub_script.py
@@ -33,8 +33,12 @@ def test_mac_wrapper_execs_runner_with_launchd_backend(tmp_path: Path) -> None:
     # a real update.
     fake_python = tmp_path / "fake-python"
     argv_log = tmp_path / "argv.txt"
+    env_log = tmp_path / "env.txt"
     fake_python.write_text(
-        '#!/bin/sh\nprintf "%s\\n" "$@" > "$ARGV_LOG"\nexit 0\n',
+        (
+            '#!/bin/sh\nprintf "%s\\n" "$@" > "$ARGV_LOG"\n'
+            'printf "%s\\n" "$PYTHONPATH" > "$ENV_LOG"\nexit 0\n'
+        ),
         encoding="utf-8",
     )
     fake_python.chmod(0o755)
@@ -46,6 +50,7 @@ def test_mac_wrapper_execs_runner_with_launchd_backend(tmp_path: Path) -> None:
             "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
             "HELPER_PYTHON": str(fake_python),
             "ARGV_LOG": str(argv_log),
+            "ENV_LOG": str(env_log),
             "UPDATE_STATUS_PATH": str(tmp_path / "update_status.json"),
         },
         capture_output=True,
@@ -57,6 +62,8 @@ def test_mac_wrapper_execs_runner_with_launchd_backend(tmp_path: Path) -> None:
     assert "codex_autorunner.core.update.runner" in argv
     assert "--backend" in argv
     assert "launchd" in argv
+    pythonpath = env_log.read_text(encoding="utf-8")
+    assert str(SCRIPT.resolve().parent.parent / "src") in pythonpath
 
 
 def test_mac_wrapper_passes_syntax_check() -> None:

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -352,11 +352,29 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     def fake_popen(*args, **kwargs):  # type: ignore[no-untyped-def]
         calls["cmd"] = args[0] if args else kwargs.get("cmd")
         calls["cwd"] = kwargs.get("cwd") or (args[1] if len(args) > 1 else None)
+        calls["env"] = kwargs.get("env")
         return _FakeProc()
+
+    def fake_prepare_update_source(
+        update_dir: Path,
+        repo_url: str,
+        repo_ref: str,
+        logger: logging.Logger,
+    ) -> None:
+        calls["prepared"] = {
+            "update_dir": update_dir,
+            "repo_url": repo_url,
+            "repo_ref": repo_ref,
+        }
+        (update_dir / "src").mkdir(parents=True)
 
     monkeypatch.setattr(
         "codex_autorunner.core.update._facade.subprocess.Popen",
         fake_popen,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.update._facade.prepare_update_source",
+        fake_prepare_update_source,
     )
     monkeypatch.setattr(
         "codex_autorunner.core.update._facade._capture_update_identity_hint",
@@ -386,6 +404,11 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     assert payload["notify_platform"] == "discord"
     assert payload["notify_context"] == {"chat_id": "channel-1"}
     assert "log_path" in payload
+    assert calls["prepared"] == {
+        "update_dir": update_dir,
+        "repo_url": "https://example.com/repo.git",
+        "repo_ref": "main",
+    }
     cmd = calls["cmd"]
     assert "--repo-url" in cmd
     assert str(update_dir) in cmd
@@ -397,6 +420,9 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     assert "car-discord" in cmd
     assert "codex_autorunner.core.update.runner" in cmd
     assert "--identity-hint" in cmd
+    env = calls["env"]
+    assert isinstance(env, dict)
+    assert str(update_dir / "src") in str(env.get("PYTHONPATH", ""))
 
 
 def test_system_update_worker_rejects_invalid_target(

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -288,6 +289,32 @@ def test_read_update_status_marks_stale_running_without_lock(
     assert payload["previous_status"] == "running"
 
 
+def test_read_update_status_preserves_preparing_without_lock(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    status_path = system._update_status_path()
+    status_path.parent.mkdir(parents=True, exist_ok=True)
+    status_path.write_text(
+        json.dumps(
+            {
+                "status": "preparing",
+                "message": "Preparing update source.",
+                "phase": "source_prep",
+                "at": 1.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(system.update_core, "_update_lock_active", lambda: None)
+
+    payload = system._read_update_status()
+
+    assert payload is not None
+    assert payload["status"] == "preparing"
+    assert payload["phase"] == "source_prep"
+
+
 def test_cleanup_update_build_artifacts_removes_packaging_outputs(
     tmp_path: Path,
 ) -> None:
@@ -352,11 +379,29 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     def fake_popen(*args, **kwargs):  # type: ignore[no-untyped-def]
         calls["cmd"] = args[0] if args else kwargs.get("cmd")
         calls["cwd"] = kwargs.get("cwd") or (args[1] if len(args) > 1 else None)
+        calls["env"] = kwargs.get("env")
         return _FakeProc()
+
+    def fake_prepare_update_source(
+        update_dir: Path,
+        repo_url: str,
+        repo_ref: str,
+        logger: logging.Logger,
+    ) -> None:
+        calls["prepared"] = {
+            "update_dir": update_dir,
+            "repo_url": repo_url,
+            "repo_ref": repo_ref,
+        }
+        (update_dir / "src").mkdir(parents=True)
 
     monkeypatch.setattr(
         "codex_autorunner.core.update._facade.subprocess.Popen",
         fake_popen,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.update._facade.prepare_update_source",
+        fake_prepare_update_source,
     )
     monkeypatch.setattr(
         "codex_autorunner.core.update._facade._capture_update_identity_hint",
@@ -386,6 +431,11 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     assert payload["notify_platform"] == "discord"
     assert payload["notify_context"] == {"chat_id": "channel-1"}
     assert "log_path" in payload
+    assert calls["prepared"] == {
+        "update_dir": update_dir,
+        "repo_url": "https://example.com/repo.git",
+        "repo_ref": "main",
+    }
     cmd = calls["cmd"]
     assert "--repo-url" in cmd
     assert str(update_dir) in cmd
@@ -397,6 +447,30 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     assert "car-discord" in cmd
     assert "codex_autorunner.core.update.runner" in cmd
     assert "--identity-hint" in cmd
+    env = calls["env"]
+    assert isinstance(env, dict)
+    assert str(update_dir / "src") in str(env.get("PYTHONPATH", ""))
+
+
+def test_spawn_update_process_rejects_active_cache_prep(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    logger = logging.getLogger("test")
+    lock_path = system._update_lock_path().with_suffix(".cache.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(
+        json.dumps({"pid": os.getpid(), "started_at": 1.0}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(system.UpdateInProgressError, match="source preparation"):
+        system._spawn_update_process(
+            repo_url="https://example.com/repo.git",
+            repo_ref="main",
+            update_dir=tmp_path / "update",
+            logger=logger,
+        )
 
 
 def test_system_update_worker_rejects_invalid_target(

--- a/tests/test_update_runner.py
+++ b/tests/test_update_runner.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from codex_autorunner.core import update_runner
@@ -56,3 +59,35 @@ def test_update_runner_allows_checks_explicitly(monkeypatch, tmp_path: Path) -> 
 
     assert result == 0
     assert captured["skip_checks"] is False
+
+
+def test_update_runner_resolves_from_source_before_stale_flat_module(
+    tmp_path: Path,
+) -> None:
+    old_root = tmp_path / "old"
+    old_core = old_root / "codex_autorunner" / "core"
+    old_core.mkdir(parents=True)
+    (old_root / "codex_autorunner" / "__init__.py").write_text("", encoding="utf-8")
+    (old_core / "__init__.py").write_text("", encoding="utf-8")
+    (old_core / "update.py").write_text("LEGACY = True\n", encoding="utf-8")
+
+    repo_src = Path(__file__).resolve().parents[1] / "src"
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([str(repo_src), str(old_root)]),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "codex_autorunner.core.update.runner",
+            "--help",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Run codex-autorunner update worker" in result.stdout


### PR DESCRIPTION
## Summary

- Fix macOS and Linux refresh wrappers so freshly cloned `PACKAGE_SRC/src` is first on `PYTHONPATH` before invoking the update runner.
- Prepare the update cache before spawning the detached update worker, then launch it with source-first `PYTHONPATH` so corrupt or missing caches cannot fall through to an old flat `core/update.py` install.
- Require update runner modules in staged wheel/import validation and add stale-install regression coverage.

## Root Cause

The refresh/update bootstrap could execute `python -m codex_autorunner.core.update.runner` with an old installed package ahead of the freshly cloned source. If that install still contained flat `codex_autorunner/core/update.py`, Python treated `codex_autorunner.core.update` as a module instead of a package and failed before loading `runner`.

## Validation

- Focused update suite: `25 passed`
- Ruff on touched Python files: passed
- Commit aggregate hook: `9906 passed`, mypy passed, Ruff passed, web lint/build/tests passed, Web UI lab fast check passed, guardrails passed
