### PR TITLE
[codex] Fix OpenCode terminal completion stall handling

### DIFF
--- a/src/codex_autorunner/agents/opencode/output_assembly.py
+++ b/src/codex_autorunner/agents/opencode/output_assembly.py
@@ -277,7 +277,7 @@ class OutputAssembler:
 
     def on_primary_assistant_completion(
         self, payload: Any, message_role: Optional[str]
-    ) -> None:
+    ) -> bool:
         """Record primary-session assistant completion for final-output selection.
 
         Also checks whether the completion phase is ``commentary`` — commentary
@@ -286,14 +286,14 @@ class OutputAssembler:
         message_result = parse_message_response(payload)
         if message_role != "assistant":
             if message_role is not None:
-                return
+                return False
             if not message_result.text or prompt_echo_matches(
                 message_result.text,
                 prompt=self._prompt,
             ):
-                return
+                return False
         if not message_completion_is_turn_terminal(payload):
-            return
+            return False
         msg_id = extract_event_message_id(payload)
         if msg_id:
             self._last_terminal_assistant_message_id = msg_id
@@ -308,6 +308,7 @@ class OutputAssembler:
                     scope=msg_id or _NO_MESSAGE_SCOPE,
                 )
             )
+        return True
 
     async def on_text_delta(
         self,

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -720,17 +720,19 @@ async def collect_opencode_output_from_events(
                     payload, is_primary_session=is_primary_session
                 )
             if event.event == "message.completed" and is_primary_session:
-                assembler.on_primary_assistant_completion(payload, message_role)
+                assistant_completion_accepted = (
+                    assembler.on_primary_assistant_completion(payload, message_role)
+                )
                 completion_is_terminal = message_completion_is_turn_terminal(payload)
                 assistant_compatible_completion = message_role in {"assistant", None}
-                if assistant_compatible_completion and completion_is_terminal:
+                if assistant_completion_accepted and completion_is_terminal:
                     terminal_assistant_completion_seen = True
                 elif (
                     assistant_compatible_completion
                     and parse_message_response(payload).text
                 ):
                     nonterminal_assistant_checkpoint_seen = True
-                if assistant_compatible_completion and completion_is_terminal:
+                if assistant_completion_accepted and completion_is_terminal:
                     lifecycle.on_primary_completion()
             if event.event == "session.idle" or (
                 event.event == "session.status"

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -722,14 +722,15 @@ async def collect_opencode_output_from_events(
             if event.event == "message.completed" and is_primary_session:
                 assembler.on_primary_assistant_completion(payload, message_role)
                 completion_is_terminal = message_completion_is_turn_terminal(payload)
-                if message_role in {"assistant", None} and completion_is_terminal:
+                assistant_compatible_completion = message_role in {"assistant", None}
+                if assistant_compatible_completion and completion_is_terminal:
                     terminal_assistant_completion_seen = True
                 elif (
-                    message_role in {"assistant", None}
+                    assistant_compatible_completion
                     and parse_message_response(payload).text
                 ):
                     nonterminal_assistant_checkpoint_seen = True
-                if message_role == "assistant" and completion_is_terminal:
+                if assistant_compatible_completion and completion_is_terminal:
                     lifecycle.on_primary_completion()
             if event.event == "session.idle" or (
                 event.event == "session.status"
@@ -788,6 +789,18 @@ async def collect_opencode_output_from_events(
         and result.output_source == "messages_snapshot"
         and result.text
     ):
+        error = None
+    if error and terminal_assistant_completion_seen and result.text:
+        log_event(
+            logger,
+            logging.WARNING,
+            "opencode.output.error_after_terminal_completion_ignored",
+            session_id=session_id,
+            error=error,
+            output_source=result.output_source,
+            text_chars=len(result.text),
+            terminal_signal=terminal_signal,
+        )
         error = None
     if error and result.text:
         result = OutputAssemblyResult(

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1438,6 +1438,50 @@ async def test_stream_lifecycle_preserves_idle_before_post_stall_deadline(
 
 
 @pytest.mark.anyio
+async def test_role_missing_terminal_completion_uses_grace_not_stall(
+    monkeypatch,
+) -> None:
+    async def _status_fetcher():
+        return {"status": {"type": "busy"}}
+
+    async def _event_stream():
+        yield SSEEvent(
+            event="message.completed",
+            data=json.dumps(
+                {
+                    "sessionID": "s1",
+                    "info": {"id": "m1"},
+                    "finish": "stop",
+                    "parts": [{"type": "text", "text": "final answer"}],
+                }
+            ),
+        )
+        while True:
+            await asyncio.sleep(3600)
+            yield SSEEvent(event="keepalive", data="{}")
+
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_POST_COMPLETION_GRACE_SECONDS",
+        0.001,
+    )
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="s1",
+        event_stream_factory=lambda: _event_stream(),
+        session_fetcher=_status_fetcher,
+        stall_timeout_seconds=1.0,
+        first_event_timeout_seconds=None,
+    )
+
+    assert output.text == "final answer"
+    assert output.error is None
+    assert output.output_source == "event_stream"
+    assert output.terminal_signal == "message.completed"
+
+
+@pytest.mark.anyio
 async def test_collect_output_reconnects_when_stream_ends_while_session_busy(
     monkeypatch,
 ) -> None:

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -843,6 +843,47 @@ async def test_collect_output_does_not_start_grace_on_user_completion(
 
 
 @pytest.mark.anyio
+async def test_collect_output_does_not_start_grace_on_roleless_prompt_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _echo_then_assistant_completion():
+        yield SSEEvent(
+            event="message.completed",
+            data='{"sessionID":"s1","info":{"id":"u1"},'
+            '"parts":[{"type":"text","text":"User prompt"}]}',
+        )
+        for _ in range(10):
+            await asyncio.sleep(0.002)
+            yield SSEEvent(
+                event="session.status",
+                data='{"sessionID":"s1","status":{"type":"busy"}}',
+            )
+        yield SSEEvent(
+            event="message.completed",
+            data='{"sessionID":"s1","info":{"id":"a1","role":"assistant"},'
+            '"parts":[{"type":"text","text":"Hello"}]}',
+        )
+        yield SSEEvent(event="session.idle", data='{"sessionID":"s1"}')
+
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_POST_COMPLETION_GRACE_SECONDS",
+        0.01,
+    )
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="s1",
+        prompt="User prompt",
+        event_stream_factory=lambda: _echo_then_assistant_completion(),
+        stall_timeout_seconds=30.0,
+    )
+
+    assert output.text == "Hello"
+    assert output.error is None
+
+
+@pytest.mark.anyio
 async def test_collect_output_ignores_completed_text_when_role_missing() -> None:
     events = [
         SSEEvent(


### PR DESCRIPTION
## Summary

- Fixes #2032.
- Treat role-missing OpenCode `message.completed` events as assistant-compatible for stream lifecycle completion, matching output assembly behavior.
- Preserve terminal assistant text when a post-terminal stream recovery error is attached, and log that ignored error for observability.
- Add a regression test for role-missing terminal completion followed by silence while session status remains busy.

## Root Cause

OpenCode can emit a terminal `message.completed` event with `finish: "stop"` and usable text while omitting the assistant role. CAR already accepted that event for output assembly via `message_role in {"assistant", None}`, but only armed the post-completion lifecycle grace path when `message_role == "assistant"`. That mismatch sent role-missing terminal completions into the stall recovery path, where busy session status could produce `opencode_stream_stalled_timeout_waiting_for_idle` and discard valid final text.

## Validation

- `.venv/bin/python -m pytest tests/test_opencode_runtime.py::test_role_missing_terminal_completion_uses_grace_not_stall tests/test_opencode_runtime.py::test_stream_lifecycle_bounds_post_stall_idle_wait tests/test_opencode_runtime.py::test_stream_lifecycle_preserves_idle_before_post_stall_deadline tests/test_opencode_runtime.py::test_collect_output_uses_stall_timeout_after_first_relevant_event`
- `.venv/bin/python -m ruff check src/codex_autorunner/agents/opencode/runtime.py tests/test_opencode_runtime.py`
- `.venv/bin/python -m black --check src/codex_autorunner/agents/opencode/runtime.py tests/test_opencode_runtime.py`
- `git diff --check`
- Commit hook aggregate lane passed during commit creation.
