### PR TITLE
[codex] Add chat drag-and-drop attachments

### DIFF
--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -1753,9 +1753,72 @@ a.scope-chip-label:hover {
 .active-chat {
   display: flex;
   flex-direction: column;
+  position: relative;
   min-width: 0;
   min-height: 0;
   padding: var(--space-3) var(--space-4);
+}
+
+.active-chat.drop-active {
+  border-color: color-mix(in srgb, var(--color-accent) 54%, var(--color-border));
+  box-shadow: 0 0 0 3px var(--color-accent-ring);
+}
+
+.chat-drop-indicator {
+  position: absolute;
+  inset: var(--space-3);
+  z-index: 9;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  border: 1px dashed color-mix(in srgb, var(--color-accent) 62%, var(--color-border));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+  backdrop-filter: blur(2px);
+}
+
+.chat-drop-card {
+  display: grid;
+  gap: 2px;
+  justify-items: center;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-3);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.chat-drop-indicator strong {
+  color: var(--color-ink);
+  font-size: var(--font-size-2);
+  font-weight: 760;
+}
+
+.chat-drop-indicator em {
+  color: var(--color-ink-muted);
+  font-size: var(--font-size-0);
+  font-style: normal;
+}
+
+.chat-drop-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-2);
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.chat-drop-icon svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.9;
 }
 
 /* Two-column grid at every width: title/scope/subtitle in column 1. Tools stay

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -1097,6 +1097,11 @@
   });
 
   $effect(() => {
+    activeChatId;
+    resetChatDragState();
+  });
+
+  $effect(() => {
     // Once a draft's first send mints the managed thread, the backend row appears
     // in `persistedChats`. Drop the now-stale local draft record so the chat stops
     // being treated as an unsent draft.
@@ -2513,7 +2518,7 @@
   }
 
   function handleChatDragLeave(event: DragEvent): void {
-    if (!activeChat || !dragHasFiles(event)) return;
+    if (chatDragDepth === 0) return;
     event.preventDefault();
     chatDragDepth = Math.max(0, chatDragDepth - 1);
     if (chatDragDepth === 0) chatDropFileCount = 0;

--- a/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/routes/ChatsPage.svelte
@@ -428,6 +428,8 @@
   let slashSelectedIndex = $state(0);
   let composerFocused = $state(false);
   let composerEditVersion = 0;
+  let chatDragDepth = $state(0);
+  let chatDropFileCount = $state(0);
   let pendingInitialDraftCreate = false;
   let pendingPointerChatId: string | null = null;
   let removeDocumentChatPointerCapture: (() => void) | null = null;
@@ -814,6 +816,7 @@
   const canInterruptWithDraft = $derived(chatDetailDisplay.canInterruptWithDraft);
   const canStopRun = $derived(chatDetailDisplay.canStopRun);
   const composerWillQueue = $derived(chatDetailDisplay.composerWillQueue);
+  const chatDropActive = $derived(chatDragDepth > 0 && Boolean(activeChat));
   const slashSuggestions = $derived<SlashCommandSuggestion[]>(
     buildSlashCommandSuggestions(draft, {
       hasActiveChat: Boolean(activeChat),
@@ -2475,6 +2478,56 @@
     markComposerEdited();
   }
 
+  function dragHasFiles(event: DragEvent): boolean {
+    const transfer = event.dataTransfer;
+    if (!transfer) return false;
+    if (Array.from(transfer.items ?? []).some((item) => item.kind === 'file')) return true;
+    return Array.from(transfer.types ?? []).includes('Files');
+  }
+
+  function dragFileCount(event: DragEvent): number {
+    const files = event.dataTransfer?.files;
+    if (files?.length) return files.length;
+    const itemCount = Array.from(event.dataTransfer?.items ?? []).filter((item) => item.kind === 'file').length;
+    return itemCount || 0;
+  }
+
+  function resetChatDragState(): void {
+    chatDragDepth = 0;
+    chatDropFileCount = 0;
+  }
+
+  function handleChatDragEnter(event: DragEvent): void {
+    if (!activeChat || !dragHasFiles(event)) return;
+    event.preventDefault();
+    chatDragDepth += 1;
+    chatDropFileCount = dragFileCount(event);
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+  }
+
+  function handleChatDragOver(event: DragEvent): void {
+    if (!activeChat || !dragHasFiles(event)) return;
+    event.preventDefault();
+    chatDropFileCount = dragFileCount(event) || chatDropFileCount;
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+  }
+
+  function handleChatDragLeave(event: DragEvent): void {
+    if (!activeChat || !dragHasFiles(event)) return;
+    event.preventDefault();
+    chatDragDepth = Math.max(0, chatDragDepth - 1);
+    if (chatDragDepth === 0) chatDropFileCount = 0;
+  }
+
+  function handleChatDrop(event: DragEvent): void {
+    if (!activeChat || !dragHasFiles(event)) return;
+    event.preventDefault();
+    const files = event.dataTransfer?.files;
+    if (files?.length) addFiles(files);
+    resetChatDragState();
+    composerTextarea?.focus();
+  }
+
   function openLinkDialog(): void {
     linkDraft = '';
     linkDialogOpen = true;
@@ -3025,7 +3078,31 @@
       </span>
     </div>
   {/snippet}
-  <div class="active-chat">
+  <div
+    class="active-chat"
+    class:drop-active={chatDropActive}
+    role="region"
+    aria-label="Chat pane"
+    ondragenter={handleChatDragEnter}
+    ondragover={handleChatDragOver}
+    ondragleave={handleChatDragLeave}
+    ondrop={handleChatDrop}
+  >
+    {#if chatDropActive}
+      <div class="chat-drop-indicator" role="status" aria-live="polite">
+        <span class="chat-drop-card">
+          <span class="chat-drop-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path d="M12 3v12" />
+              <path d="m7 10 5 5 5-5" />
+              <path d="M5 19h14" />
+            </svg>
+          </span>
+          <strong>Drop to attach</strong>
+          <em>{chatDropFileCount > 1 ? `${chatDropFileCount} files will be added` : 'File will be added to this message'}</em>
+        </span>
+      </div>
+    {/if}
     <div class="chat-header">
       <div class="chat-header-copy">
         {#if activeChat && titleEditorOpen}
@@ -3507,7 +3584,10 @@
         type="file"
         multiple
         aria-label="Upload file attachment"
-        onchange={(event) => addFiles(event.currentTarget.files ?? [])}
+        onchange={(event) => {
+          addFiles(event.currentTarget.files ?? []);
+          event.currentTarget.value = '';
+        }}
       />
       <input
         bind:this={imageInput}
@@ -3516,7 +3596,10 @@
         accept="image/*"
         multiple
         aria-label="Upload image attachment"
-        onchange={(event) => addFiles(event.currentTarget.files ?? [], 'image')}
+        onchange={(event) => {
+          addFiles(event.currentTarget.files ?? [], 'image');
+          event.currentTarget.value = '';
+        }}
       />
       <div class="attachment-actions" aria-label="Attachment controls">
         <button class="icon-button attachment-button file" type="button" aria-label="Attach files" title="Attach files" onclick={() => fileInput?.click()}>

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -258,6 +258,17 @@ describe('/chats page', () => {
     expect(body).toContain('Attach files');
   });
 
+  it('wires chat-pane file drag and drop into pending attachments', () => {
+    const pageSource = chatDetailPageSource();
+
+    expect(pageSource).toContain('ondragenter={handleChatDragEnter}');
+    expect(pageSource).toContain('ondragover={handleChatDragOver}');
+    expect(pageSource).toContain('ondragleave={handleChatDragLeave}');
+    expect(pageSource).toContain('ondrop={handleChatDrop}');
+    expect(pageSource).toContain('Drop to attach');
+    expect(pageSource).toContain('if (files?.length) addFiles(files);');
+  });
+
   it('does not re-apply chat search locally after requesting a backend search window', () => {
     const pageSource = chatDetailPageSource();
     const listReadModelSource = chatDetailListReadModelSource();


### PR DESCRIPTION
## Summary
- Add file drag/drop handling to the active chat pane.
- Show a clean in-pane drop indicator while files hover over the chat.
- Reuse the existing pending attachment flow so dropped files upload with the composer send path.

## Validation
- pre-commit web-ui lane
- Python guardrails, ruff, mypy, and pytest: 9908 passed
- Web Hub lint, build, frontend tests: 990 passed / 2 skipped
- Focused local check: pnpm lint; pnpm test -- --run src/routes/chats/page.test.ts

## Notes
Review screenshots were copied to .codex-autorunner/filebox/outbox locally for inspection; runtime outbox files are ignored and not part of this PR.