### PR TITLE
[codex] Fix web artifact delivery visibility

### DIFF
--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Iterable, Optional
+from urllib.parse import quote
 
+from ..artifact_delivery import (
+    ArtifactDeliveryService,
+    DeliveryIntent,
+    artifact_delivery_db_path,
+    delivery_filename,
+)
 from ..ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
@@ -1450,6 +1458,105 @@ def _append_delivery_state_items(
     return sequence
 
 
+def _web_artifact_download_url(
+    *,
+    delivery_id: str,
+    repo_id: Optional[str],
+) -> str:
+    encoded_delivery_id = quote(delivery_id, safe="")
+    if repo_id:
+        return (
+            f"/hub/filebox/{quote(repo_id, safe='')}/artifacts/deliveries/"
+            f"{encoded_delivery_id}/download"
+        )
+    return f"/hub/artifacts/deliveries/{encoded_delivery_id}/download"
+
+
+def _web_artifact_delivery_payload(
+    *,
+    intent: DeliveryIntent,
+    artifact: Any,
+    repo_id: Optional[str],
+) -> dict[str, Any]:
+    filename = delivery_filename(intent, artifact)
+    url = _web_artifact_download_url(delivery_id=intent.delivery_id, repo_id=repo_id)
+    payload: dict[str, Any] = {
+        "artifact_kind": "artifact",
+        "kind": "attachment",
+        "id": intent.delivery_id,
+        "artifact_id": intent.artifact_id,
+        "delivery_id": intent.delivery_id,
+        "name": filename,
+        "title": filename,
+        "url": url,
+        "href": url,
+        "target_surface": intent.target_surface,
+        "target_conversation_key": intent.target_conversation_key,
+        "state": intent.state,
+        "created_at": intent.sent_at or intent.updated_at or intent.created_at,
+        "updated_at": intent.updated_at,
+        "sent_at": intent.sent_at,
+        "metadata": dict(intent.metadata_json),
+        "receipt": dict(intent.receipt_json or {}),
+    }
+    if artifact is not None:
+        payload.update(
+            {
+                "filename": artifact.filename,
+                "mime_type": artifact.mime_type,
+                "size": artifact.size,
+                "checksum_sha256": artifact.checksum_sha256,
+            }
+        )
+    return payload
+
+
+def _append_web_artifact_delivery_items(
+    items: list[ManagedThreadTimelineItem],
+    *,
+    thread: dict[str, Any],
+    managed_thread_id: str,
+    sequence: int,
+) -> int:
+    workspace_root = _normalize_optional_text(thread.get("workspace_root"))
+    if workspace_root is None:
+        return sequence
+    workspace_path = Path(workspace_root)
+    if not artifact_delivery_db_path(workspace_path).exists():
+        return sequence
+    service = ArtifactDeliveryService(workspace_path)
+    conversation_key = f"managed_thread:{managed_thread_id}"
+    repo_id = _normalize_optional_text(thread.get("repo_id"))
+    for intent in service.list_deliveries(
+        states=("sent",),
+        target_surface="web",
+        target_conversation_key=conversation_key,
+    ):
+        artifact = service.store.get_artifact(intent.artifact_id)
+        item_id = f"artifact_delivery:{intent.delivery_id}"
+        timestamp = intent.sent_at or intent.updated_at or intent.created_at
+        items.append(
+            ManagedThreadTimelineItem(
+                item_id=item_id,
+                kind="artifact",
+                order_key=_order_key(timestamp, sequence, item_id),
+                timestamp=timestamp,
+                managed_thread_id=managed_thread_id,
+                managed_turn_id=None,
+                status=intent.state,
+                identity=_timeline_identity(item_id),
+                provenance=_timeline_provenance(),
+                payload=_web_artifact_delivery_payload(
+                    intent=intent,
+                    artifact=artifact,
+                    repo_id=repo_id,
+                ),
+            )
+        )
+        sequence += 1
+    return sequence
+
+
 def _decode_action_payload(action: dict[str, Any]) -> dict[str, Any]:
     payload_json = action.get("payload_json")
     if not isinstance(payload_json, str) or not payload_json.strip():
@@ -1679,6 +1786,12 @@ def build_managed_thread_timeline(
             sequence=sequence,
         )
         action_index += 1
+    sequence = _append_web_artifact_delivery_items(
+        items,
+        thread=thread,
+        managed_thread_id=normalized_thread_id,
+        sequence=sequence,
+    )
     sequence = _append_delivery_state_items(
         items,
         hub_root=hub_root,

--- a/src/codex_autorunner/surfaces/cli/commands/artifacts.py
+++ b/src/codex_autorunner/surfaces/cli/commands/artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -222,6 +223,90 @@ def _legacy_pending(root: Path) -> list[dict[str, object]]:
     return findings
 
 
+def _parse_iso_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _age_seconds(value: str | None) -> float | None:
+    timestamp = _parse_iso_timestamp(value)
+    if timestamp is None:
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - timestamp).total_seconds()
+
+
+def _stale_unclaimed_pending_finding(
+    *,
+    root: Path,
+    intent,
+    stale_after_seconds: int,
+) -> dict[str, object] | None:
+    if intent.state != "pending" or intent.claimed_at is not None:
+        return None
+    age = _age_seconds(intent.created_at)
+    if age is None or age < stale_after_seconds:
+        return None
+    return {
+        "kind": "stale_unclaimed_pending_delivery",
+        "root": str(root),
+        "delivery_id": intent.delivery_id,
+        "target_surface": intent.target_surface,
+        "target_conversation_key": intent.target_conversation_key,
+        "state": intent.state,
+        "created_at": intent.created_at,
+        "age_seconds": int(age),
+        "message": (
+            "Delivery is pending and has never been claimed by a delivery consumer."
+        ),
+    }
+
+
+def _weak_web_sent_receipt_finding(
+    *,
+    root: Path,
+    intent,
+    artifact,
+) -> dict[str, object] | None:
+    if intent.state != "sent" or intent.target_surface != "web":
+        return None
+    if artifact is None:
+        return {
+            "kind": "unprojectable_web_sent_delivery",
+            "root": str(root),
+            "delivery_id": intent.delivery_id,
+            "target_surface": intent.target_surface,
+            "target_conversation_key": intent.target_conversation_key,
+            "state": intent.state,
+            "message": (
+                "Web delivery is marked sent but its artifact record is missing, "
+                "so it cannot be projected into the transcript."
+            ),
+        }
+    receipt = intent.receipt_json if isinstance(intent.receipt_json, dict) else {}
+    if receipt.get("visibility") == "managed_thread_transcript" and receipt.get(
+        "transcript_item_id"
+    ):
+        return None
+    return {
+        "kind": "weak_web_sent_receipt",
+        "root": str(root),
+        "delivery_id": intent.delivery_id,
+        "target_surface": intent.target_surface,
+        "target_conversation_key": intent.target_conversation_key,
+        "state": intent.state,
+        "message": (
+            "Web delivery is marked sent without transcript visibility receipt "
+            "metadata."
+        ),
+    }
+
+
 def register_artifacts_commands(app: typer.Typer) -> None:
     @app.command("list")
     def list_deliveries(
@@ -399,6 +484,11 @@ def register_artifacts_commands(app: typer.Typer) -> None:
         conversation: Optional[str] = typer.Option(
             None, "--conversation", help="Current conversation key for mismatch checks"
         ),
+        stale_after_seconds: int = typer.Option(
+            60,
+            "--stale-after-seconds",
+            help="Age threshold for pending unclaimed delivery findings",
+        ),
     ) -> None:
         """Find stranded or mismatched artifact deliveries."""
         current_root = _root(root)
@@ -410,6 +500,13 @@ def register_artifacts_commands(app: typer.Typer) -> None:
                 continue
             service = ArtifactDeliveryService(candidate)
             for intent in service.list_deliveries(states=ACTIVE_DELIVERY_STATES):
+                stale_finding = _stale_unclaimed_pending_finding(
+                    root=candidate,
+                    intent=intent,
+                    stale_after_seconds=stale_after_seconds,
+                )
+                if stale_finding is not None:
+                    findings.append(stale_finding)
                 if surface and intent.target_surface != surface:
                     findings.append(
                         {
@@ -431,4 +528,14 @@ def register_artifacts_commands(app: typer.Typer) -> None:
                             ),
                         }
                     )
+            for intent in service.list_deliveries(
+                states=("sent",), target_surface="web"
+            ):
+                weak_receipt_finding = _weak_web_sent_receipt_finding(
+                    root=candidate,
+                    intent=intent,
+                    artifact=service.store.get_artifact(intent.artifact_id),
+                )
+                if weak_receipt_finding is not None:
+                    findings.append(weak_receipt_finding)
         _echo_json({"findings": findings})

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -8,17 +8,20 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import TYPE_CHECKING, Annotated, Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 
+from ....core.managed_thread_store import ManagedThreadStore
 from ..read_model_contracts import dump_read_model_contract
 from ..services.chat_read_models import (
     ChatIndexContractFilter,
     ChatReadModelService,
     hub_group_dict_to_contract,
 )
+from ..services.web_artifact_delivery import drain_web_artifact_deliveries_for_thread
 from .shared import SSE_HEADERS
 
 if TYPE_CHECKING:
@@ -196,13 +199,31 @@ def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
         )
 
     @router.get("/hub/read-models/chats/{chat_id}")
-    def chat_read_model_detail(
+    async def chat_read_model_detail(
         chat_id: str,
         timeline_limit: Annotated[int, Query(ge=1, le=200)] = 50,
     ):
         try:
+            thread_store = ManagedThreadStore.connect_readonly(
+                context.config.root,
+                durable=True,
+            )
+            thread = await asyncio.to_thread(thread_store.get_thread, chat_id)
+            try:
+                await drain_web_artifact_deliveries_for_thread(
+                    thread=thread,
+                    managed_thread_id=chat_id,
+                    logger=logging.getLogger("codex_autorunner.web_artifact_delivery"),
+                )
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "Failed to drain web artifact deliveries before chat detail "
+                    "snapshot (managed_thread_id=%s)",
+                    chat_id,
+                )
             return dump_read_model_contract(
-                service.chat_detail_contract(
+                await asyncio.to_thread(
+                    service.chat_detail_contract,
                     chat_id,
                     timeline_limit=timeline_limit,
                 )

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -84,6 +84,7 @@ from ...services.pma.managed_thread_scope import (
     provision_managed_thread_workspace,
     resolve_managed_thread_create_resolution,
 )
+from ...services.web_artifact_delivery import drain_web_artifact_deliveries_for_thread
 from .hermes_supervisors import resolve_cached_hermes_supervisor
 
 _logger = logging.getLogger(__name__)
@@ -897,7 +898,7 @@ def build_managed_thread_crud_routes(
         }
 
     @router.get("/threads/{managed_thread_id}/timeline")
-    def get_managed_thread_timeline(
+    async def get_managed_thread_timeline(
         managed_thread_id: str,
         request: Request,
         limit: int = Query(
@@ -914,7 +915,21 @@ def build_managed_thread_crud_routes(
         context = get_pma_request_context(request)
         store = context.thread_store()
         try:
-            return build_managed_thread_timeline(
+            thread = await asyncio.to_thread(store.get_thread, managed_thread_id)
+            try:
+                await drain_web_artifact_deliveries_for_thread(
+                    thread=thread,
+                    managed_thread_id=managed_thread_id,
+                    logger=logging.getLogger("codex_autorunner.web_artifact_delivery"),
+                )
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "Failed to drain web artifact deliveries before timeline snapshot "
+                    "(managed_thread_id=%s)",
+                    managed_thread_id,
+                )
+            return await asyncio.to_thread(
+                build_managed_thread_timeline,
                 context.hub_root,
                 thread_store=store,
                 managed_thread_id=managed_thread_id,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -24,6 +25,7 @@ from .....core.orchestration.runtime_thread_events import (
 from .....core.orchestration.turn_timeline import list_turn_timeline
 from ...services.pma import get_pma_request_context
 from ...services.pma.common import normalize_optional_text
+from ...services.web_artifact_delivery import drain_web_artifact_deliveries_for_thread
 from ..shared import SSE_HEADERS
 from .managed_thread_tail_serializers import (
     _canonical_turn_request_metadata,
@@ -738,6 +740,21 @@ async def _build_managed_thread_transcript_snapshot(
     runtime_projection_state: ProgressProjectionState | None = None,
 ) -> dict[str, Any]:
     context = get_pma_request_context(request)
+    thread = await asyncio.to_thread(
+        context.thread_store().get_thread, managed_thread_id
+    )
+    try:
+        await drain_web_artifact_deliveries_for_thread(
+            thread=thread,
+            managed_thread_id=managed_thread_id,
+            logger=logging.getLogger("codex_autorunner.web_artifact_delivery"),
+        )
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "Failed to drain web artifact deliveries before transcript snapshot "
+            "(managed_thread_id=%s)",
+            managed_thread_id,
+        )
     progress_snapshot = await _build_managed_thread_tail_snapshot(
         request=request,
         service=service,
@@ -948,6 +965,42 @@ def build_managed_thread_tail_routes(
                 await asyncio.sleep(_PERSISTED_TAIL_POLL_SECONDS)
                 if await request.is_disconnected():
                     return
+                artifact_delivery_changed = False
+                try:
+                    artifact_delivery_changed = (
+                        await drain_web_artifact_deliveries_for_thread(
+                            thread=thread_target,
+                            managed_thread_id=managed_thread_id,
+                            logger=logging.getLogger(
+                                "codex_autorunner.web_artifact_delivery"
+                            ),
+                        )
+                    )
+                except Exception:
+                    logging.getLogger(__name__).exception(
+                        "Failed to drain web artifact deliveries during transcript "
+                        "stream (managed_thread_id=%s)",
+                        managed_thread_id,
+                    )
+                if artifact_delivery_changed:
+                    artifact_snapshot = await _build_managed_thread_transcript_snapshot(
+                        request=request,
+                        service=service,
+                        managed_thread_id=managed_thread_id,
+                        harness=harness,
+                        limit=min(limit, _TRANSCRIPT_STREAM_LIMIT),
+                        level=normalized_level,
+                        runtime_projection_state=runtime_projection_state,
+                    )
+                    artifact_id_line = (
+                        f"id: {last_event_id}\n" if last_event_id > 0 else ""
+                    )
+                    yield (
+                        "event: transcript.snapshot\n"
+                        f"{artifact_id_line}"
+                        "data: "
+                        f"{json.dumps(artifact_snapshot, ensure_ascii=True)}\n\n"
+                    )
                 refreshed = await _build_managed_thread_tail_snapshot(
                     request=request,
                     service=service,

--- a/src/codex_autorunner/surfaces/web/services/web_artifact_delivery.py
+++ b/src/codex_autorunner/surfaces/web/services/web_artifact_delivery.py
@@ -27,6 +27,7 @@ from ....core.artifact_delivery import (
     ArtifactDeliveryService,
     ArtifactRecord,
     DeliveryIntent,
+    artifact_delivery_db_path,
 )
 from ....core.filebox import outbox_sent_dir
 from ....core.pma.message_options import (
@@ -48,6 +49,11 @@ class _WebArtifactTransport:
             "surface": WEB_ARTIFACT_SURFACE,
             "delivery_id": intent.delivery_id,
             "artifact_id": artifact.artifact_id,
+            "visibility": "managed_thread_transcript",
+            "transcript_item_id": f"artifact_delivery:{intent.delivery_id}",
+            "filename": artifact.filename,
+            "mime_type": artifact.mime_type,
+            "size": artifact.size,
         }
 
 
@@ -78,4 +84,45 @@ async def drain_web_artifact_deliveries(
     )
 
 
-__all__ = ["drain_web_artifact_deliveries"]
+def _thread_workspace_root(thread: Any) -> str | None:
+    if isinstance(thread, dict):
+        value = thread.get("workspace_root")
+    else:
+        value = getattr(thread, "workspace_root", None)
+    text = str(value or "").strip()
+    return text or None
+
+
+async def drain_web_artifact_deliveries_for_thread(
+    *,
+    thread: Any,
+    managed_thread_id: str,
+    logger: logging.Logger,
+) -> bool:
+    """Best-effort drain for a managed thread row with a workspace root."""
+
+    workspace_root_text = _thread_workspace_root(thread)
+    if not workspace_root_text:
+        return False
+    workspace_root = Path(workspace_root_text)
+    if not artifact_delivery_db_path(workspace_root).exists():
+        return False
+    conversation_key = web_artifact_conversation_key(managed_thread_id)
+    service = ArtifactDeliveryService(workspace_root)
+    pending_before = service.list_deliveries(
+        states=("pending",),
+        target_surface=WEB_ARTIFACT_SURFACE,
+        target_conversation_key=conversation_key,
+    )
+    await drain_web_artifact_deliveries(
+        workspace_root=workspace_root,
+        managed_thread_id=managed_thread_id,
+        logger=logger,
+    )
+    return bool(pending_before)
+
+
+__all__ = [
+    "drain_web_artifact_deliveries",
+    "drain_web_artifact_deliveries_for_thread",
+]

--- a/src/codex_autorunner/surfaces/web/services/web_artifact_delivery.py
+++ b/src/codex_autorunner/surfaces/web/services/web_artifact_delivery.py
@@ -114,12 +114,23 @@ async def drain_web_artifact_deliveries_for_thread(
         target_surface=WEB_ARTIFACT_SURFACE,
         target_conversation_key=conversation_key,
     )
+    pending_before_ids = {intent.delivery_id for intent in pending_before}
     await drain_web_artifact_deliveries(
         workspace_root=workspace_root,
         managed_thread_id=managed_thread_id,
         logger=logger,
     )
-    return bool(pending_before)
+    if not pending_before_ids:
+        return False
+    pending_after_ids = {
+        intent.delivery_id
+        for intent in service.list_deliveries(
+            states=("pending",),
+            target_surface=WEB_ARTIFACT_SURFACE,
+            target_conversation_key=conversation_key,
+        )
+    }
+    return bool(pending_before_ids - pending_after_ids)
 
 
 __all__ = [

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 from tests.pma_support import _enable_pma, _repo_owner
 
+from codex_autorunner.core.artifact_delivery import ArtifactDeliveryService
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import SQLiteChatSurfaceEventJournal
 from codex_autorunner.core.orchestration.cold_trace_store import ColdTraceWriter
@@ -215,6 +216,91 @@ def test_managed_thread_transcript_endpoint_returns_backend_owned_rows(hub_env) 
     assert rows[0]["message"]["text"] == "hello transcript"
     assert rows[1]["message"]["role"] == "assistant"
     assert rows[1]["message"]["text"] == "hello from transcript"
+
+
+def test_managed_thread_transcript_drains_and_projects_web_artifacts(hub_env) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        managed_thread_terminal_followup_default=False,
+    )
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        source = hub_env.repo_root / "report.txt"
+        source.write_text("artifact body\n", encoding="utf-8")
+        service = ArtifactDeliveryService(hub_env.repo_root)
+        intent = service.enqueue_file(
+            source,
+            target_surface="web",
+            target_conversation_key=f"managed_thread:{managed_thread_id}",
+            workspace_scope=f"repo:{hub_env.repo_root}",
+        )
+        assert intent.state == "pending"
+
+        transcript_resp = client.get(f"/hub/pma/threads/{managed_thread_id}/transcript")
+
+    assert transcript_resp.status_code == 200
+    payload = transcript_resp.json()
+    rows = payload["rows"]
+    artifact_rows = [row for row in rows if row["kind"] == "artifact"]
+    assert len(artifact_rows) == 1
+    artifact = artifact_rows[0]["artifact"]
+    assert artifact["delivery_id"] == intent.delivery_id
+    assert artifact["title"] == "report.txt"
+    assert artifact["url"].startswith(
+        f"/hub/filebox/{hub_env.repo_id}/artifacts/deliveries/"
+    )
+    sent = ArtifactDeliveryService(hub_env.repo_root).inspect(intent.delivery_id)
+    assert sent is not None
+    assert sent.state == "sent"
+    assert sent.receipt_json["visibility"] == "managed_thread_transcript"
+    assert sent.receipt_json["transcript_item_id"] == (
+        f"artifact_delivery:{intent.delivery_id}"
+    )
+
+
+def test_managed_thread_timeline_drains_and_projects_web_artifacts(hub_env) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        managed_thread_terminal_followup_default=False,
+    )
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        source = hub_env.repo_root / "timeline-report.txt"
+        source.write_text("artifact body\n", encoding="utf-8")
+        service = ArtifactDeliveryService(hub_env.repo_root)
+        intent = service.enqueue_file(
+            source,
+            target_surface="web",
+            target_conversation_key=f"managed_thread:{managed_thread_id}",
+            workspace_scope=f"repo:{hub_env.repo_root}",
+        )
+
+        timeline_resp = client.get(f"/hub/pma/threads/{managed_thread_id}/timeline")
+
+    assert timeline_resp.status_code == 200
+    payload = timeline_resp.json()
+    artifact_items = [item for item in payload["items"] if item["kind"] == "artifact"]
+    assert len(artifact_items) == 1
+    assert artifact_items[0]["payload"]["delivery_id"] == intent.delivery_id
+    sent = ArtifactDeliveryService(hub_env.repo_root).inspect(intent.delivery_id)
+    assert sent is not None
+    assert sent.state == "sent"
 
 
 def test_managed_thread_transcript_endpoint_exposes_capsule_visibility_contract(

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from codex_autorunner.core.artifact_delivery import ArtifactDeliveryService
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
     OrchestrationBindingStore,
@@ -1680,6 +1681,34 @@ def test_hub_read_models_chat_detail_contract_snapshot(hub_env) -> None:
     assert body["timeline"][0]["managedTurnId"] == running["managed_turn_id"]
     assert body["timeline"][0]["section"] == "user_message"
     assert body["timeline"][0]["sectionOrder"] == 10
+
+
+def test_hub_read_models_chat_detail_drains_web_artifacts(hub_env) -> None:
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    thread = store.create_thread("codex", hub_env.repo_root, repo_id=hub_env.repo_id)
+    thread_id = str(thread["managed_thread_id"])
+    source = hub_env.repo_root / "read-model-artifact.txt"
+    source.write_text("artifact\n", encoding="utf-8")
+    service = ArtifactDeliveryService(hub_env.repo_root)
+    intent = service.enqueue_file(
+        source,
+        target_surface="web",
+        target_conversation_key=f"managed_thread:{thread_id}",
+        workspace_scope=f"repo:{hub_env.repo_root}",
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(f"/hub/read-models/chats/{thread_id}")
+
+    assert response.status_code == 200
+    sent = ArtifactDeliveryService(hub_env.repo_root).inspect(intent.delivery_id)
+    assert sent is not None
+    assert sent.state == "sent"
+    body = response.json()
+    assert any(
+        item["kind"] == "artifact" and item["itemId"].startswith("artifact_delivery:")
+        for item in body["timeline"]
+    )
 
 
 def test_hub_read_models_chat_detail_patch_stream_is_repairable(hub_env) -> None:

--- a/tests/test_cli_artifacts.py
+++ b/tests/test_cli_artifacts.py
@@ -190,6 +190,87 @@ def test_artifacts_diagnose_flags_legacy_hub_pending_file(tmp_path: Path) -> Non
     )
 
 
+def test_artifacts_diagnose_flags_stale_unclaimed_pending_delivery(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "pending.txt"
+    source.write_text("pending\n", encoding="utf-8")
+    service = ArtifactDeliveryService(tmp_path)
+    intent = service.enqueue_file(
+        source,
+        target_surface="web",
+        target_conversation_key="managed_thread:abc",
+    )
+    with sqlite3.connect(service.store.db_path) as conn:
+        conn.execute(
+            """
+            UPDATE delivery_intents
+               SET created_at = ?, updated_at = ?
+             WHERE delivery_id = ?
+            """,
+            (
+                "2000-01-01T00:00:00Z",
+                "2000-01-01T00:00:00Z",
+                intent.delivery_id,
+            ),
+        )
+
+    result = runner.invoke(
+        app,
+        [
+            "artifacts",
+            "diagnose",
+            "--root",
+            str(tmp_path),
+            "--stale-after-seconds",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    findings = json.loads(result.output)["findings"]
+    assert any(
+        finding["kind"] == "stale_unclaimed_pending_delivery"
+        and finding["delivery_id"] == intent.delivery_id
+        for finding in findings
+    )
+
+
+def test_artifacts_diagnose_flags_weak_web_sent_receipt(tmp_path: Path) -> None:
+    source = tmp_path / "sent.txt"
+    source.write_text("sent\n", encoding="utf-8")
+    service = ArtifactDeliveryService(tmp_path)
+    intent = service.enqueue_file(
+        source,
+        target_surface="web",
+        target_conversation_key="managed_thread:abc",
+    )
+    claimed = service.claim_next(
+        target_surface="web",
+        target_conversation_key="managed_thread:abc",
+    )
+    assert claimed is not None
+    service.mark_sending(intent.delivery_id, claim_token=claimed.claim_token)
+    service.mark_sent(
+        intent.delivery_id,
+        receipt={"surface": "web", "delivery_id": intent.delivery_id},
+        claim_token=claimed.claim_token,
+    )
+
+    result = runner.invoke(
+        app,
+        ["artifacts", "diagnose", "--root", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    findings = json.loads(result.output)["findings"]
+    assert any(
+        finding["kind"] == "weak_web_sent_receipt"
+        and finding["delivery_id"] == intent.delivery_id
+        for finding in findings
+    )
+
+
 def test_artifacts_import_legacy_queues_scoped_delivery_records(tmp_path: Path) -> None:
     legacy = tmp_path / ".codex-autorunner" / "filebox" / "outbox" / "report.txt"
     legacy.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Project sent web artifact deliveries into managed-thread timeline/transcript rows with download URLs.
- Drain pending web artifact deliveries from transcript, timeline, chat detail read-model, and transcript SSE paths so queued files repair without requiring another agent turn.
- Expand `car artifacts diagnose` to flag stale unclaimed pending deliveries, weak web sent receipts, and sent web deliveries that cannot be projected.

## Root Cause
Web artifact delivery used a no-op transport that could mark a delivery `sent` without any user-visible transcript projection. Pending web deliveries were only drained during turn finalization, so files queued after a turn could remain pending until another turn happened. Diagnostics also missed stale unclaimed deliveries and weak web receipts.

## Validation
- Subagent review completed; blocking durable-store finding addressed.
- `.venv/bin/ruff check ...` on changed files.
- Focused pytest: `54 passed`.
- Expanded artifact/read-model pytest: `70 passed`.
- Commit hook `web-core-contract` lane passed, including guardrails, black, ruff, import boundaries, mypy, `9915 passed` Python tests, Web UI lab, frontend lint/build/test, and SPA shell check.

## Notes
- The hook reported existing non-blocking warnings: Starlette/httpx deprecation, Hypothesis norecursedirs warning, pydantic serializer warning, Click MultiCommand deprecation, and stale Svelte warning-baseline entries.