### PR TITLE
Keep active opencode turns alive after stalls

### DIFF
--- a/src/codex_autorunner/agents/opencode/stream_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/stream_lifecycle.py
@@ -496,6 +496,12 @@ class StreamLifecycleController:
                 idle_wait_started_at = time.monotonic()
                 last_status_type = status_type
                 while True:
+                    if await self._turn_is_active():
+                        return await self._continue_silent_active_turn(
+                            now=time.monotonic(),
+                            timeout_kind="stall",
+                            status_type=last_status_type,
+                        )
                     elapsed_wait = time.monotonic() - idle_wait_started_at
                     if elapsed_wait >= _OPENCODE_POST_STALL_IDLE_WAIT_SECONDS:
                         error_msg = (

--- a/src/codex_autorunner/agents/opencode/stream_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/stream_lifecycle.py
@@ -496,12 +496,6 @@ class StreamLifecycleController:
                 idle_wait_started_at = time.monotonic()
                 last_status_type = status_type
                 while True:
-                    if await self._turn_is_active():
-                        return await self._continue_silent_active_turn(
-                            now=time.monotonic(),
-                            timeout_kind="stall",
-                            status_type=last_status_type,
-                        )
                     elapsed_wait = time.monotonic() - idle_wait_started_at
                     if elapsed_wait >= _OPENCODE_POST_STALL_IDLE_WAIT_SECONDS:
                         error_msg = (
@@ -553,6 +547,12 @@ class StreamLifecycleController:
                         break
                     if polled:
                         last_status_type = polled
+                    if await self._turn_is_active():
+                        return await self._continue_silent_active_turn(
+                            now=time.monotonic(),
+                            timeout_kind="stall",
+                            status_type=last_status_type,
+                        )
                 return LifecycleDecision(
                     action=LifecycleAction.BREAK,
                     should_flush_if_pending=False,

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -241,8 +241,14 @@ async def test_stream_lifecycle_keeps_active_command_leniency_after_relevant_eve
     monkeypatch.setattr(
         stream_lifecycle_module,
         "_OPENCODE_POST_STALL_IDLE_POLL_SECONDS",
-        0.0,
+        0.25,
     )
+    sleeps: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(stream_lifecycle_module.asyncio, "sleep", _sleep)
 
     async def _event_stream():
         if False:
@@ -269,6 +275,7 @@ async def test_stream_lifecycle_keeps_active_command_leniency_after_relevant_eve
 
     assert decision.action is LifecycleAction.CONTINUE
     assert decision.error is None
+    assert sleeps == [0.25]
 
 
 @pytest.mark.asyncio

--- a/tests/agents/opencode/test_turn_runtime.py
+++ b/tests/agents/opencode/test_turn_runtime.py
@@ -225,63 +225,50 @@ async def test_turn_runtime_collector_handles_question_tool_part() -> None:
 
 
 @pytest.mark.asyncio
-async def test_collector_fails_stalled_stream_after_relevant_event_when_command_active(
+async def test_stream_lifecycle_keeps_active_command_leniency_after_relevant_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         stream_lifecycle_module,
-        "_OPENCODE_STREAM_RECONNECT_BACKOFF_SECONDS",
-        (0.0,),
+        "_OPENCODE_STREAM_MAX_STALL_RECONNECT_ATTEMPTS",
+        0,
     )
     monkeypatch.setattr(
         stream_lifecycle_module,
-        "_OPENCODE_STREAM_MAX_STALL_RECONNECT_ATTEMPTS",
-        1,
+        "_OPENCODE_POST_STALL_IDLE_WAIT_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        stream_lifecycle_module,
+        "_OPENCODE_POST_STALL_IDLE_POLL_SECONDS",
+        0.0,
     )
 
-    stream_count = 0
-
     async def _event_stream():
-        nonlocal stream_count
-        stream_count += 1
-        if stream_count == 1:
-            yield SSEEvent(
-                event="message.part.updated",
-                data=json.dumps(
-                    {
-                        "sessionID": "session-1",
-                        "properties": {
-                            "part": {
-                                "id": "tool-1",
-                                "type": "tool",
-                                "tool": "bash",
-                                "state": {"status": "running"},
-                            }
-                        },
-                    }
-                ),
-            )
-        while True:
-            await asyncio.sleep(3600)
+        if False:
             yield SSEEvent(event="server.heartbeat", data="")
 
     async def _session_status() -> dict[str, object]:
-        return {}
+        return {"status": {"type": "busy"}}
 
-    output = await asyncio.wait_for(
-        collect_opencode_output_from_events(
-            session_id="session-1",
-            event_stream_factory=_event_stream,
-            session_fetcher=_session_status,
-            turn_activity_fetcher=lambda: True,
-            stall_timeout_seconds=0.001,
-            first_event_timeout_seconds=1.0,
-        ),
-        timeout=1.0,
+    controller = StreamLifecycleController(
+        session_id="session-1",
+        event_stream_factory=_event_stream,
+        session_fetcher=_session_status,
+        stall_timeout_seconds=0.001,
+        first_event_timeout_seconds=1.0,
+        status_event_handler=None,
+        turn_activity_fetcher=lambda: True,
     )
+    controller.on_relevant_event(now=999.0)
 
-    assert output.error is not None
-    assert output.error.startswith("opencode_stream_stalled_timeout")
+    try:
+        decision = await controller.on_timeout_error(now=1000.0)
+    finally:
+        await controller.close()
+
+    assert decision.action is LifecycleAction.CONTINUE
+    assert decision.error is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Check `turn_activity_fetcher` during post-stall busy-session idle waits
- Continue silent-but-active opencode turns instead of timing them out after the fixed idle wait
- Update the opencode lifecycle regression test to cover active turns after prior stream progress

## Tests
- `.venv/bin/python -m pytest tests/agents/opencode/test_turn_runtime.py tests/test_opencode_runtime.py -q`
- `.venv/bin/python -m ruff check src/codex_autorunner/agents/opencode/stream_lifecycle.py tests/agents/opencode/test_turn_runtime.py`
- `./scripts/check.sh`
- commit hook: aggregate validation

Closes #2046