### PR TITLE
Detect opencode snapshot progress during stalls

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -260,24 +260,34 @@ async def collect_opencode_output_from_events(
     )
 
     last_recovered_snapshot_text = ""
+    messages_snapshot_progress_seeded = False
 
-    async def _messages_snapshot_made_progress() -> bool:
-        nonlocal last_recovered_snapshot_text
+    async def _recover_messages_snapshot_text(*, log_name: str) -> str:
         if messages_fetcher is None:
-            return False
+            return ""
         try:
             messages_payload = await messages_fetcher()
         except (httpx.HTTPError, ValueError, OSError, AttributeError) as exc:
             log_event(
                 logger,
                 logging.DEBUG,
-                "opencode.messages.progress_fetch_failed",
+                log_name,
                 session_id=session_id,
                 exc=exc,
             )
-            return False
+            return ""
         recovered = recover_last_assistant_message(messages_payload, prompt=prompt)
-        recovered_text = recovered.text.strip() if recovered.text else ""
+        return recovered.text.strip() if recovered.text else ""
+
+    async def _messages_snapshot_made_progress() -> bool:
+        nonlocal last_recovered_snapshot_text, messages_snapshot_progress_seeded
+        recovered_text = await _recover_messages_snapshot_text(
+            log_name="opencode.messages.progress_fetch_failed",
+        )
+        if not messages_snapshot_progress_seeded:
+            messages_snapshot_progress_seeded = True
+            last_recovered_snapshot_text = recovered_text
+            return False
         if not recovered_text or recovered_text == last_recovered_snapshot_text:
             return False
         last_recovered_snapshot_text = recovered_text

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -259,6 +259,30 @@ async def collect_opencode_output_from_events(
         logger=logger,
     )
 
+    last_recovered_snapshot_text = ""
+
+    async def _messages_snapshot_made_progress() -> bool:
+        nonlocal last_recovered_snapshot_text
+        if messages_fetcher is None:
+            return False
+        try:
+            messages_payload = await messages_fetcher()
+        except (httpx.HTTPError, ValueError, OSError, AttributeError) as exc:
+            log_event(
+                logger,
+                logging.DEBUG,
+                "opencode.messages.progress_fetch_failed",
+                session_id=session_id,
+                exc=exc,
+            )
+            return False
+        recovered = recover_last_assistant_message(messages_payload, prompt=prompt)
+        recovered_text = recovered.text.strip() if recovered.text else ""
+        if not recovered_text or recovered_text == last_recovered_snapshot_text:
+            return False
+        last_recovered_snapshot_text = recovered_text
+        return True
+
     lifecycle = StreamLifecycleController(
         session_id=session_id,
         event_stream_factory=event_stream_factory,
@@ -267,6 +291,7 @@ async def collect_opencode_output_from_events(
         first_event_timeout_seconds=first_event_timeout_seconds,
         status_event_handler=part_handler,
         turn_activity_fetcher=turn_activity_fetcher,
+        stall_progress_fetcher=_messages_snapshot_made_progress,
         logger=logger,
     )
 

--- a/src/codex_autorunner/agents/opencode/stream_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/stream_lifecycle.py
@@ -39,6 +39,7 @@ _OPENCODE_POST_STALL_IDLE_POLL_SECONDS = 5.0
 
 StatusEventHandler = Callable[[str, dict[str, Any], Optional[str]], Awaitable[None]]
 TurnActivityFetcher = Callable[[], bool | Awaitable[bool]]
+StallProgressFetcher = Callable[[], bool | Awaitable[bool]]
 
 
 class LifecycleAction(Enum):
@@ -79,12 +80,14 @@ class StreamLifecycleController:
         first_event_timeout_seconds: Optional[float],
         status_event_handler: Optional[StatusEventHandler],
         turn_activity_fetcher: Optional[TurnActivityFetcher] = None,
+        stall_progress_fetcher: Optional[StallProgressFetcher] = None,
         logger: Optional[logging.Logger] = None,
     ):
         self._session_id = session_id
         self._event_stream_factory = event_stream_factory
         self._session_fetcher = session_fetcher
         self._turn_activity_fetcher = turn_activity_fetcher
+        self._stall_progress_fetcher = stall_progress_fetcher
         self._stall_timeout_seconds = stall_timeout_seconds
         self._first_event_timeout_seconds = first_event_timeout_seconds
         self._status_event_handler = status_event_handler
@@ -300,6 +303,18 @@ class StreamLifecycleController:
             self._logger.debug("turn activity check failed", exc_info=True)
             return False
 
+    async def _stall_made_progress(self) -> bool:
+        if self._stall_progress_fetcher is None:
+            return False
+        try:
+            progressed = self._stall_progress_fetcher()
+            if inspect.isawaitable(progressed):
+                progressed = await progressed
+            return bool(progressed)
+        except Exception:
+            self._logger.debug("stall progress check failed", exc_info=True)
+            return False
+
     async def _continue_silent_active_turn(
         self,
         *,
@@ -307,11 +322,43 @@ class StreamLifecycleController:
         timeout_kind: str,
         status_type: Optional[str],
     ) -> LifecycleDecision:
+        return await self._continue_silent_turn(
+            now=now,
+            timeout_kind=timeout_kind,
+            status_type=status_type,
+            log_name="opencode.stream.silent_while_turn_active",
+            status_payload_type="stream_silent_turn_active",
+        )
+
+    async def _continue_silent_stall_progress(
+        self,
+        *,
+        now: float,
+        timeout_kind: str,
+        status_type: Optional[str],
+    ) -> LifecycleDecision:
+        return await self._continue_silent_turn(
+            now=now,
+            timeout_kind=timeout_kind,
+            status_type=status_type,
+            log_name="opencode.stream.silent_stall_progress",
+            status_payload_type="stream_silent_stall_progress",
+        )
+
+    async def _continue_silent_turn(
+        self,
+        *,
+        now: float,
+        timeout_kind: str,
+        status_type: Optional[str],
+        log_name: str,
+        status_payload_type: str,
+    ) -> LifecycleDecision:
         idle_seconds = now - self._last_relevant_event_at
         log_event(
             self._logger,
             logging.WARNING,
-            "opencode.stream.silent_while_turn_active",
+            log_name,
             session_id=self._session_id,
             idle_seconds=idle_seconds,
             timeout_kind=timeout_kind,
@@ -320,7 +367,7 @@ class StreamLifecycleController:
         )
         await self._emit_status(
             {
-                "type": "stream_silent_turn_active",
+                "type": status_payload_type,
                 "idleSeconds": idle_seconds,
                 "timeoutKind": timeout_kind,
                 "status": status_type,
@@ -549,6 +596,12 @@ class StreamLifecycleController:
                         last_status_type = polled
                     if await self._turn_is_active():
                         return await self._continue_silent_active_turn(
+                            now=time.monotonic(),
+                            timeout_kind="stall",
+                            status_type=last_status_type,
+                        )
+                    if await self._stall_made_progress():
+                        return await self._continue_silent_stall_progress(
                             now=time.monotonic(),
                             timeout_kind="stall",
                             status_type=last_status_type,

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1423,6 +1423,80 @@ async def test_stream_lifecycle_bounds_post_stall_idle_wait(monkeypatch) -> None
 
 
 @pytest.mark.anyio
+async def test_collect_output_uses_message_snapshot_progress_during_post_stall_wait(
+    monkeypatch,
+) -> None:
+    progress_events: list[dict[str, object]] = []
+    stream_count = 0
+
+    async def _status_fetcher():
+        return {"status": {"type": "busy"}}
+
+    async def _messages_fetcher():
+        return {
+            "data": [
+                {
+                    "info": {"id": "assistant-1", "role": "assistant"},
+                    "parts": [{"type": "text", "text": "CI is still running."}],
+                }
+            ]
+        }
+
+    async def _status_handler(_event_type, payload, _event_id):
+        progress_events.append(payload)
+
+    async def _event_stream():
+        nonlocal stream_count
+        stream_count += 1
+        if stream_count == 1:
+            yield SSEEvent(
+                event="message.updated",
+                data=json.dumps({"sessionID": "s1", "info": {"role": "assistant"}}),
+            )
+            while True:
+                await asyncio.sleep(3600)
+                yield SSEEvent(event="server.heartbeat", data="")
+        yield SSEEvent(event="session.idle", data=json.dumps({"sessionID": "s1"}))
+
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_STREAM_RECONNECT_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_STREAM_MAX_STALL_RECONNECT_ATTEMPTS",
+        0,
+    )
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_POST_STALL_IDLE_POLL_SECONDS",
+        0.0,
+    )
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="s1",
+        event_stream_factory=lambda: _event_stream(),
+        session_fetcher=_status_fetcher,
+        messages_fetcher=_messages_fetcher,
+        part_handler=_status_handler,
+        turn_activity_fetcher=lambda: False,
+        stall_timeout_seconds=0.001,
+        first_event_timeout_seconds=None,
+    )
+
+    assert output.error is None
+    assert output.text == "CI is still running."
+    assert any(
+        event.get("type") == "stream_silent_stall_progress" for event in progress_events
+    )
+    assert not any(
+        event.get("type") == "stall_idle_wait_timeout" for event in progress_events
+    )
+
+
+@pytest.mark.anyio
 async def test_stream_lifecycle_preserves_idle_before_post_stall_deadline(
     monkeypatch,
 ) -> None:

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1428,11 +1428,16 @@ async def test_collect_output_uses_message_snapshot_progress_during_post_stall_w
 ) -> None:
     progress_events: list[dict[str, object]] = []
     stream_count = 0
+    message_fetch_count = 0
 
     async def _status_fetcher():
         return {"status": {"type": "busy"}}
 
     async def _messages_fetcher():
+        nonlocal message_fetch_count
+        message_fetch_count += 1
+        if message_fetch_count == 1:
+            return {"data": []}
         return {
             "data": [
                 {
@@ -1494,6 +1499,84 @@ async def test_collect_output_uses_message_snapshot_progress_during_post_stall_w
     assert not any(
         event.get("type") == "stall_idle_wait_timeout" for event in progress_events
     )
+
+
+@pytest.mark.anyio
+async def test_collect_output_ignores_baseline_snapshot_during_post_stall_wait(
+    monkeypatch,
+) -> None:
+    progress_events: list[dict[str, object]] = []
+    stream_count = 0
+    message_fetch_count = 0
+
+    async def _status_fetcher():
+        return {"status": {"type": "busy"}}
+
+    async def _messages_fetcher():
+        nonlocal message_fetch_count
+        message_fetch_count += 1
+        text = "old answer" if message_fetch_count <= 2 else "new answer"
+        message_id = "assistant-old" if message_fetch_count <= 2 else "assistant-new"
+        return {
+            "data": [
+                {
+                    "info": {"id": message_id, "role": "assistant"},
+                    "parts": [{"type": "text", "text": text}],
+                }
+            ]
+        }
+
+    async def _status_handler(_event_type, payload, _event_id):
+        progress_events.append(payload)
+
+    async def _event_stream():
+        nonlocal stream_count
+        stream_count += 1
+        if stream_count == 1:
+            yield SSEEvent(
+                event="message.updated",
+                data=json.dumps({"sessionID": "s1", "info": {"role": "assistant"}}),
+            )
+            while True:
+                await asyncio.sleep(3600)
+                yield SSEEvent(event="server.heartbeat", data="")
+        yield SSEEvent(event="session.idle", data=json.dumps({"sessionID": "s1"}))
+
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_STREAM_RECONNECT_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_STREAM_MAX_STALL_RECONNECT_ATTEMPTS",
+        0,
+    )
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_POST_STALL_IDLE_POLL_SECONDS",
+        0.0,
+    )
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="s1",
+        event_stream_factory=lambda: _event_stream(),
+        session_fetcher=_status_fetcher,
+        messages_fetcher=_messages_fetcher,
+        part_handler=_status_handler,
+        turn_activity_fetcher=lambda: False,
+        stall_timeout_seconds=0.001,
+        first_event_timeout_seconds=None,
+    )
+
+    assert output.error is None
+    assert output.text == "new answer"
+    assert [
+        event.get("type")
+        for event in progress_events
+        if event.get("type") == "stream_silent_stall_progress"
+    ] == ["stream_silent_stall_progress"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Add a stalled-progress callback to the OpenCode stream lifecycle
- Poll the existing messages snapshot recovery path during post-stall busy-session idle waits
- Treat changed recovered assistant text as progress and reset the silent stream instead of failing with `opencode_stream_stalled_timeout_waiting_for_idle`
- Add a regression for the observed shape: prior SSE progress, silent stream, busy session status, inactive command fetcher, and assistant text only visible via messages snapshot

## Why
Execution `29e2b8df7ee04726912c737e7b521fd8` still failed after #2047 because the previous fix only consulted `turn_activity_fetcher`. In the Discord OpenCode backend that fetcher tracks the prompt submission task, not all server-side session progress. The recovered assistant output showed the model had produced fresh text while SSE was silent, but lifecycle recovery never polled messages before enforcing the 30s busy-session idle wait cap.

## Tests
- `.venv/bin/python -m pytest tests/test_opencode_runtime.py tests/agents/opencode/test_turn_runtime.py -q`
- `.venv/bin/python -m ruff check src/codex_autorunner/agents/opencode/stream_lifecycle.py src/codex_autorunner/agents/opencode/runtime.py tests/test_opencode_runtime.py tests/agents/opencode/test_turn_runtime.py`
- `.venv/bin/black --check src/codex_autorunner/agents/opencode/stream_lifecycle.py src/codex_autorunner/agents/opencode/runtime.py tests/test_opencode_runtime.py tests/agents/opencode/test_turn_runtime.py`
- `./scripts/check.sh` via commit hook: 9934 passed, 3 warnings; static/web checks passed

Follow-up to #2047 / #2046.