### PR TITLE
Add web resume path for paused ticket flows

### DIFF
--- a/src/codex_autorunner/core/flows/action_policy.py
+++ b/src/codex_autorunner/core/flows/action_policy.py
@@ -109,7 +109,7 @@ def build_flow_action_policy(
             tone="success",
             style="success",
             disabled_reason=None if resume_enabled else "Run is not paused",
-            surface_visibility={"queue": False, "flow_status": True},
+            surface_visibility={"queue": True, "flow_status": True},
         )
     )
 

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -960,6 +960,20 @@ def build_flow_routes() -> APIRouter:
                 assert reuse.run is not None
                 if validate_tickets:
                     _ensure_ticket_flow_preflight(repo_root)
+                if reuse.run.status == FlowRunStatus.PAUSED:
+                    store = _require_flow_store(repo_root)
+                    try:
+                        response = _build_flow_status_response(
+                            reuse.run,
+                            repo_root,
+                            store=store,
+                        )
+                    finally:
+                        if store:
+                            store.close()
+                    response.state = response.state or {}
+                    response.state["hint"] = "paused_run_requires_resume"
+                    return response
                 _reap_dead_worker(reuse.run.id, state)
                 _start_flow_worker(repo_root, reuse.run.id, state)
                 store = _require_flow_store(repo_root)
@@ -1191,6 +1205,20 @@ def build_flow_routes() -> APIRouter:
         if reuse.action == "reuse_active":
             assert reuse.run is not None
             _ensure_ticket_flow_preflight(repo_root)
+            if reuse.run.status == FlowRunStatus.PAUSED:
+                store = _require_flow_store(repo_root)
+                try:
+                    resp = _build_flow_status_response(
+                        reuse.run,
+                        repo_root,
+                        store=store,
+                    )
+                finally:
+                    if store:
+                        store.close()
+                resp.state = resp.state or {}
+                resp.state["hint"] = "paused_run_requires_resume"
+                return resp
             _reap_dead_worker(reuse.run.id, state)
             _start_flow_worker(repo_root, reuse.run.id, state)
             store = _require_flow_store(repo_root)
@@ -1675,14 +1703,16 @@ def build_flow_routes() -> APIRouter:
             FlowRunStatus.PENDING,
             FlowRunStatus.RUNNING,
             FlowRunStatus.STOPPING,
-            FlowRunStatus.PAUSED,
         }:
             service = _build_flow_orchestration_service(repo_root, record.flow_type)
             _stop_worker(run_id, state)
             try:
                 await service.stop_flow_run(run_id)
             except ValueError as exc:
-                raise HTTPException(status_code=404, detail=str(exc)) from exc
+                status_code = 404 if "not found" in str(exc).lower() else 409
+                raise HTTPException(status_code=status_code, detail=str(exc)) from exc
+        elif record.status == FlowRunStatus.PAUSED:
+            _stop_worker(run_id, state)
 
         return await _start_flow(
             "ticket_flow",

--- a/src/codex_autorunner/surfaces/web/routes/messages.py
+++ b/src/codex_autorunner/surfaces/web/routes/messages.py
@@ -30,10 +30,12 @@ from ....core.flows.failure_diagnostics import (
     get_failure_payload,
 )
 from ....core.flows.models import FlowRunStatus
+from ....core.flows.start_policy import evaluate_ticket_start_policy
 from ....core.flows.store import FlowStore, _get_durable_writes
 from ....core.flows.workspace_root import resolve_ticket_flow_workspace_root
 from ....core.state_roots import resolve_repo_flows_db_path
 from ....core.utils import find_repo_root
+from ....flows.ticket_flow.runtime_helpers import resume_ticket_flow_run
 from ....tickets.files import safe_relpath
 from ....tickets.outbox import parse_dispatch, resolve_outbox_paths
 from ....tickets.replies import (
@@ -141,6 +143,96 @@ def _collect_reply_history(
     return history
 
 
+def _selected_active_dispatch(
+    history: list[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    for entry in history:
+        dispatch = entry.get("dispatch")
+        if isinstance(dispatch, dict) and dispatch.get("is_handoff") is True:
+            return entry
+    for entry in history:
+        dispatch = entry.get("dispatch")
+        if isinstance(dispatch, dict) and dispatch.get("mode") != "turn_summary":
+            return entry
+    return history[0] if history else None
+
+
+def _validate_ticket_queue(repo_root: Path) -> None:
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    lint_errors = list(evaluate_ticket_start_policy(ticket_dir).lint_errors)
+    if lint_errors:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "Ticket validation failed",
+                "errors": lint_errors,
+            },
+        )
+
+
+async def _write_live_user_reply(
+    *,
+    repo_root: Path,
+    run_id: str,
+    record_input: dict[str, Any],
+    body: str,
+    title: Optional[str],
+    files: list[UploadFile],
+) -> dict[str, Any]:
+    workspace_root = _resolve_workspace_root(record_input, repo_root)
+    reply_paths = resolve_reply_paths(workspace_root=workspace_root, run_id=run_id)
+    ensure_reply_dirs(reply_paths)
+
+    cleaned_title = title.strip() if isinstance(title, str) and title.strip() else None
+    cleaned_body = body or ""
+
+    if cleaned_title:
+        fm = yaml.safe_dump({"title": cleaned_title}, sort_keys=False).strip()
+        raw = f"---\n{fm}\n---\n\n{cleaned_body}\n"
+    else:
+        raw = cleaned_body
+        if raw and not raw.endswith("\n"):
+            raw += "\n"
+
+    try:
+        reply_paths.user_reply_path.parent.mkdir(parents=True, exist_ok=True)
+        reply_paths.user_reply_path.write_text(raw, encoding="utf-8")
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to write USER_REPLY.md: {exc}"
+        ) from exc
+
+    written_files: list[str] = []
+    for upload in files:
+        try:
+            filename = safe_attachment_name(upload.filename or "")
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        dest = reply_paths.reply_dir / filename
+        data = await upload.read()
+        try:
+            dest.write_bytes(data)
+            written_files.append(filename)
+            try:
+                ensure_structure(repo_root)
+                save_file(repo_root, "inbox", filename, data)
+            except (OSError, ValueError):
+                _logger.debug("Failed to mirror attachment into FileBox", exc_info=True)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to write attachment: {exc}"
+            ) from exc
+
+    reply, errors = parse_user_reply(reply_paths.user_reply_path)
+    if errors or reply is None:
+        raise HTTPException(status_code=400, detail=errors or ["Invalid reply"])
+    return {
+        "reply": {"title": reply.title, "body": reply.body},
+        "files": written_files,
+        "workspace_root": str(workspace_root),
+    }
+
+
 def build_messages_routes() -> APIRouter:
     router = APIRouter()
 
@@ -168,7 +260,9 @@ def build_messages_routes() -> APIRouter:
             )
             if not history:
                 continue
-            latest = history[0]
+            latest = _selected_active_dispatch(history)
+            if latest is None:
+                continue
             return {
                 "active": True,
                 "run_id": record.id,
@@ -310,49 +404,14 @@ def build_messages_routes() -> APIRouter:
         input_data = dict(record.input_data or {})
         workspace_root = _resolve_workspace_root(input_data, repo_root)
         reply_paths = resolve_reply_paths(workspace_root=workspace_root, run_id=run_id)
-        ensure_reply_dirs(reply_paths)
-
-        cleaned_title = (
-            title.strip() if isinstance(title, str) and title.strip() else None
+        await _write_live_user_reply(
+            repo_root=repo_root,
+            run_id=run_id,
+            record_input=input_data,
+            body=body,
+            title=title,
+            files=files,
         )
-        cleaned_body = body or ""
-
-        if cleaned_title:
-            fm = yaml.safe_dump({"title": cleaned_title}, sort_keys=False).strip()
-            raw = f"---\n{fm}\n---\n\n{cleaned_body}\n"
-        else:
-            raw = cleaned_body
-            if raw and not raw.endswith("\n"):
-                raw += "\n"
-
-        try:
-            reply_paths.user_reply_path.parent.mkdir(parents=True, exist_ok=True)
-            reply_paths.user_reply_path.write_text(raw, encoding="utf-8")
-        except OSError as exc:
-            raise HTTPException(
-                status_code=500, detail=f"Failed to write USER_REPLY.md: {exc}"
-            ) from exc
-
-        for upload in files:
-            try:
-                filename = safe_attachment_name(upload.filename or "")
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            dest = reply_paths.reply_dir / filename
-            data = await upload.read()
-            try:
-                dest.write_bytes(data)
-                try:
-                    ensure_structure(repo_root)
-                    save_file(repo_root, "inbox", filename, data)
-                except (OSError, ValueError):
-                    _logger.debug(
-                        "Failed to mirror attachment into FileBox", exc_info=True
-                    )
-            except OSError as exc:
-                raise HTTPException(
-                    status_code=500, detail=f"Failed to write attachment: {exc}"
-                ) from exc
 
         seq = next_reply_seq(reply_paths.reply_history_dir)
         dispatch, errors = dispatch_reply(reply_paths, next_seq=seq)
@@ -364,6 +423,52 @@ def build_messages_routes() -> APIRouter:
             "status": "ok",
             "seq": dispatch.seq,
             "reply": {"title": dispatch.reply.title, "body": dispatch.reply.body},
+        }
+
+    @router.post("/api/messages/{run_id}/reply-and-resume")
+    async def post_reply_and_resume(
+        run_id: str,
+        body: str = Form(""),
+        title: Optional[str] = Form(None),
+        files: list[UploadFile] = File(default=[]),  # noqa: B006,B008
+    ):
+        repo_root = find_repo_root()
+        db_path = _flows_db_path(repo_root)
+        if not db_path.exists():
+            raise HTTPException(status_code=404, detail="No flows database")
+        try:
+            with FlowStore(db_path, durable=_get_durable_writes(repo_root)) as store:
+                record = store.get_flow_run(run_id)
+        except (sqlite3.Error, OSError, ValueError, KeyError):
+            raise HTTPException(
+                status_code=404, detail="Flows database unavailable"
+            ) from None
+        if not record:
+            raise HTTPException(status_code=404, detail="Run not found")
+        if record.status != FlowRunStatus.PAUSED:
+            raise HTTPException(status_code=409, detail="Run is not paused")
+        _validate_ticket_queue(repo_root)
+
+        written = await _write_live_user_reply(
+            repo_root=repo_root,
+            run_id=run_id,
+            record_input=dict(record.input_data or {}),
+            body=body,
+            title=title,
+            files=files,
+        )
+
+        try:
+            resumed = await resume_ticket_flow_run(repo_root, run_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "status": "ok",
+            "run_id": resumed.id,
+            "run_status": resumed.status.value,
+            "reply": written["reply"],
+            "files": written["files"],
         }
 
     return router

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -433,6 +433,20 @@ a {
   text-align: center;
 }
 
+.nav-attention-badge {
+  min-width: 18px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--color-warning-soft);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 42%, transparent);
+  color: var(--color-warning-ink, var(--color-warning));
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1.35;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
 .nav-link.active .nav-badge {
   background: var(--color-accent-soft);
   color: var(--color-accent);
@@ -7239,6 +7253,7 @@ textarea:disabled {
 .sidebar-collapsed .brand-copy,
 .sidebar-collapsed .nav-label,
 .sidebar-collapsed .nav-badge,
+.sidebar-collapsed .nav-attention-badge,
 .sidebar-collapsed .nav-group-label,
 .sidebar-collapsed .sidebar-footer-copy {
   display: none;

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeIndex.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeIndex.svelte
@@ -358,6 +358,11 @@
                     {#if row.status !== 'idle' && row.status !== 'done'}
                       <span class={`repo-status status-pill ${row.status}`}>{statusLabel(row.status)}</span>
                     {/if}
+                    {#if row.signalWaiting > 0}
+                      <span class="response-needed-pill" title="A paused dispatch needs your response">
+                        Respond
+                      </span>
+                    {/if}
                     {#if row.chatBound}
                       <span class="chat-binding-pill" title={chatBindingLabel(row)}>
                         Chat-bound
@@ -554,6 +559,11 @@
                           <a class="worktree-name" href={href(worktree.href)}>{worktree.label}</a>
                           {#if worktree.status !== 'idle' && worktree.status !== 'done'}
                             <span class={`status-pill ${worktree.status}`}>{statusLabel(worktree.status)}</span>
+                          {/if}
+                          {#if worktree.signalWaiting > 0}
+                            <span class="response-needed-pill" title="A paused dispatch needs your response">
+                              Respond
+                            </span>
                           {/if}
                           {#if worktree.chatBound}
                             <span class="chat-binding-pill" title={chatBindingLabel(worktree)}>

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.css
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.css
@@ -502,6 +502,24 @@
     text-transform: uppercase;
   }
 
+  .response-needed-pill {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    min-height: 18px;
+    padding: 0 6px;
+    border-radius: 4px;
+    border: 1px solid color-mix(in srgb, var(--color-warning) 42%, transparent);
+    background: var(--color-warning-soft);
+    color: var(--color-warning-ink, var(--color-warning));
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    text-transform: uppercase;
+  }
+
   .archive-pill {
     display: inline-flex;
     align-items: center;

--- a/src/codex_autorunner/web_frontend/src/lib/components/TicketViews.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/TicketViews.svelte
@@ -47,6 +47,7 @@
     onRetry = undefined,
     onCommand = undefined,
     onQueueCommand = undefined,
+    onReplyAndResume = undefined,
     onReorderTicket = undefined,
     onRepairWithPma = undefined,
     onSave = undefined
@@ -71,7 +72,8 @@
     onFilter?: ((filter: TicketFilter) => void) | undefined;
     onRetry?: (() => void) | undefined;
     onCommand?: ((command: 'resume' | 'bootstrap') => void) | undefined;
-    onQueueCommand?: ((command: 'start' | 'stop' | 'restart') => void) | undefined;
+    onQueueCommand?: ((command: 'start' | 'resume' | 'stop' | 'restart') => void) | undefined;
+    onReplyAndResume?: ((body: string) => void | Promise<void>) | undefined;
     onReorderTicket?: ((sourceRouteId: string, destinationRouteId: string, placeAfter: boolean) => boolean | Promise<boolean>) | undefined;
     onRepairWithPma?: ((detail: TicketDetailViewModel) => void | Promise<void>) | undefined;
     onSave?: ((payload: TicketEditPayload) => boolean | Promise<boolean>) | undefined;
@@ -138,6 +140,7 @@
   let lastSettingsSignature = $state<string | null>(null);
   let settingsSaveTimer: ReturnType<typeof setTimeout> | null = null;
   let queueOpen = $state(false);
+  let handoffReply = $state('');
   let repairOpen = $state(initialDetail?.needsRepair ?? false);
   let lastRepairTicketId = $state<string | null>(initialDetail?.id ?? null);
   $effect(() => {
@@ -308,16 +311,23 @@
     await onReorderTicket?.(sourceRouteId, destinationRouteId, placeAfter);
   }
 
-  function queueActionLabel(action: 'start' | 'stop' | 'restart'): string {
-    return queueActions.find((candidate) => candidate.action === action)?.label ?? (action === 'start' ? 'Start queue' : action === 'stop' ? 'Stop queue' : 'Restart queue');
+  function queueActionLabel(action: 'start' | 'resume' | 'stop' | 'restart'): string {
+    return queueActions.find((candidate) => candidate.action === action)?.label ?? (action === 'start' ? 'Start queue' : action === 'resume' ? 'Resume' : action === 'stop' ? 'Stop queue' : 'Restart queue');
   }
 
-  function queueActionEnabled(action: 'start' | 'stop' | 'restart'): boolean {
+  function queueActionEnabled(action: 'start' | 'resume' | 'stop' | 'restart'): boolean {
     return queueActions.find((candidate) => candidate.action === action)?.enabled === true;
   }
 
-  function queueActionReason(action: 'start' | 'stop' | 'restart'): string | null {
+  function queueActionReason(action: 'start' | 'resume' | 'stop' | 'restart'): string | null {
     return queueActions.find((candidate) => candidate.action === action)?.disabledReason ?? null;
+  }
+
+  async function submitHandoffReply(): Promise<void> {
+    const body = handoffReply.trim();
+    if (!body || !onReplyAndResume) return;
+    await onReplyAndResume(body);
+    handoffReply = '';
   }
 
   function ticketTranscriptStartsOpen(status: string): boolean {
@@ -344,11 +354,11 @@
       {#snippet actions()}
         {#if list.scopedOwner}
           <div class="ticket-queue-actions" role="group" aria-label="Ticket flow controls">
-            {#each (['start', 'stop', 'restart'] as const) as action}
+            {#each (['start', 'resume', 'stop', 'restart'] as const) as action}
               {#if queueActionEnabled(action)}
                 <button
                   type="button"
-                  class={action === 'start' ? 'primary-button' : 'ghost-button'}
+                  class={action === 'start' || action === 'resume' ? 'primary-button' : 'ghost-button'}
                   title={queueActionReason(action)}
                   onclick={() => onQueueCommand?.(action)}
                 >
@@ -396,6 +406,34 @@
     </header>
 
     <AutoDismissNotice message={actionStatus} tone={noticeTone(actionStatus)} />
+
+    {#if list.handoff && onReplyAndResume}
+      <section class="ticket-handoff-panel" aria-label="Paused ticket flow handoff">
+        <div class="ticket-handoff-copy">
+          <span class="ticket-handoff-kicker">Response needed</span>
+          <strong>{list.handoff.title}</strong>
+          {#if list.handoff.body}
+            <div class="ticket-handoff-body markdown-body">
+              {@html renderMarkdownToHtml(list.handoff.body)}
+            </div>
+          {/if}
+        </div>
+        <label class="ticket-handoff-reply">
+          <span class="sr-only">Reply to paused ticket flow</span>
+          <textarea bind:value={handoffReply} rows="3" placeholder="Reply to the agent..."></textarea>
+        </label>
+        <div class="ticket-handoff-actions">
+          <button
+            class="primary-button"
+            type="button"
+            disabled={!handoffReply.trim()}
+            onclick={() => void submitHandoffReply()}
+          >
+            Reply and continue
+          </button>
+        </div>
+      </section>
+    {/if}
 
     <section class="ticket-list-section">
       {#if list.scopedOwner}
@@ -871,6 +909,76 @@
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
+  }
+
+  .ticket-handoff-panel {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 0.9fr) auto;
+    align-items: end;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border: 1px solid color-mix(in srgb, var(--color-warning) 45%, var(--color-border-subtle));
+    border-left: 3px solid var(--color-warning);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-warning) 9%, var(--color-surface));
+  }
+
+  .ticket-handoff-copy {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .ticket-handoff-kicker {
+    color: var(--color-warning-ink, var(--color-warning));
+    font-size: var(--font-size-0);
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .ticket-handoff-body {
+    color: var(--color-ink-muted);
+    font-size: var(--font-size-1);
+    max-height: 8rem;
+    overflow: auto;
+  }
+
+  .ticket-handoff-body :global(p) {
+    margin: 0;
+  }
+
+  .ticket-handoff-reply {
+    min-width: 0;
+  }
+
+  .ticket-handoff-reply textarea {
+    width: 100%;
+    min-height: 76px;
+    resize: vertical;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-surface);
+    color: var(--color-ink);
+    padding: var(--space-2);
+    font: inherit;
+    line-height: 1.4;
+  }
+
+  .ticket-handoff-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  @media (max-width: 860px) {
+    .ticket-handoff-panel {
+      grid-template-columns: minmax(0, 1fr);
+      align-items: stretch;
+    }
+    .ticket-handoff-actions {
+      justify-content: flex-start;
+    }
   }
 
   .ticket-card {

--- a/src/codex_autorunner/web_frontend/src/lib/components/TicketViews.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/TicketViews.test.ts
@@ -201,6 +201,7 @@ describe('TicketViews', () => {
               repo_id: 'repo-1',
               action_policy: [
                 { action: 'start', enabled: false, label: 'Start queue', disabled_reason: 'Ticket flow is already active', surface_visibility: { queue: true } },
+                { action: 'resume', enabled: false, label: 'Resume', disabled_reason: 'Run is not paused', surface_visibility: { queue: true } },
                 { action: 'stop', enabled: true, label: 'Stop', route: '/api/flows/run-policy/stop', surface_visibility: { queue: true } },
                 { action: 'restart', enabled: false, label: 'Restart', route: '/api/flows/run-policy/restart', requires_confirmation: true, disabled_reason: 'No restartable flow run', surface_visibility: { queue: true } }
               ]
@@ -215,6 +216,7 @@ describe('TicketViews', () => {
 
     expect(list.queueActions).toEqual([
       { action: 'start', enabled: false, label: 'Start queue', requiresConfirmation: false, disabledReason: 'Ticket flow is already active', method: 'POST', route: null },
+      { action: 'resume', enabled: false, label: 'Resume', requiresConfirmation: false, disabledReason: 'Run is not paused', method: 'POST', route: null },
       { action: 'stop', enabled: true, label: 'Stop', requiresConfirmation: false, disabledReason: null, method: 'POST', route: '/api/flows/run-policy/stop' },
       { action: 'restart', enabled: false, label: 'Restart', requiresConfirmation: true, disabledReason: 'No restartable flow run', method: 'POST', route: '/api/flows/run-policy/restart' }
     ]);
@@ -246,6 +248,7 @@ describe('TicketViews', () => {
       {
         actions: [
           { action_id: 'ticket_flow.start', enabled: false, label: 'Start queue', disabled_reason: 'Ticket flow is already active', method: 'POST', route: '/api/flows/ticket_flow/bootstrap' },
+          { action_id: 'ticket_flow.resume', enabled: true, label: 'Resume', disabled_reason: null, method: 'POST', route: '/api/flows/run-policy/resume' },
           { action_id: 'ticket_flow.stop', enabled: true, label: 'Stop', disabled_reason: null, method: 'POST', route: '/api/flows/run-policy/stop' },
           { action_id: 'ticket_flow.restart', enabled: false, label: 'Restart', requires_confirmation: true, disabled_reason: 'No restartable flow run', method: 'POST', route: '/api/flows/run-policy/restart' }
         ]
@@ -254,6 +257,7 @@ describe('TicketViews', () => {
 
     expect(list.queueActions).toEqual([
       { action: 'start', enabled: false, label: 'Start queue', requiresConfirmation: false, disabledReason: 'Ticket flow is already active', method: 'POST', route: '/api/flows/ticket_flow/bootstrap' },
+      { action: 'resume', enabled: true, label: 'Resume', requiresConfirmation: false, disabledReason: null, method: 'POST', route: '/api/flows/run-policy/resume' },
       { action: 'stop', enabled: true, label: 'Stop', requiresConfirmation: false, disabledReason: null, method: 'POST', route: '/api/flows/run-policy/stop' },
       { action: 'restart', enabled: false, label: 'Restart', requiresConfirmation: true, disabledReason: 'No restartable flow run', method: 'POST', route: '/api/flows/run-policy/restart' }
     ]);

--- a/src/codex_autorunner/web_frontend/src/lib/data/scopedTicketSessions.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/scopedTicketSessions.ts
@@ -31,6 +31,7 @@ import {
   resolveTicketRouteId,
   ticketDetailFromSummary,
   type SurfaceActionManifest,
+  type TicketHandoff,
   type TicketDetailViewModel,
   type TicketOwnerScope
 } from '$lib/viewModels/ticket';
@@ -65,6 +66,7 @@ export type ScopedTicketListSession =
       tickets: TicketSummary[];
       runs: ChatRunProgress[];
       actionManifest: SurfaceActionManifest | null;
+      handoff: TicketHandoff | null;
       sectionIssues: PartialPageIssue[];
       parentRepoId: string | null;
       redirectTo: string | null;
@@ -120,8 +122,11 @@ export async function loadScopedTicketListSession(
 
   const manifest = await loadScopedActionManifest(api, { ...config, parentRepoId: config.parentRepoId ?? parentRepoId });
   const actionManifest = dataOr(manifest, null);
+  const activeMessage = await api.requestJson<JsonRecord>(`${config.apiBasePath.replace(/\/api\/flows$/, '/api/messages')}/active`);
+  const handoff = activeMessage.ok ? handoffFromActiveMessage(activeMessage.data) : null;
   const sectionIssues = [
-    !manifest.ok ? partialPageIssue('action_manifest', 'Action manifest unavailable', manifest.error) : null
+    !manifest.ok ? partialPageIssue('action_manifest', 'Action manifest unavailable', manifest.error) : null,
+    !activeMessage.ok ? partialPageIssue('active_dispatch', 'Paused dispatch unavailable', activeMessage.error) : null
   ].filter((issue): issue is PartialPageIssue => Boolean(issue));
 
   return {
@@ -132,9 +137,25 @@ export async function loadScopedTicketListSession(
     tickets,
     runs,
     actionManifest,
+    handoff,
     sectionIssues,
     parentRepoId,
     redirectTo
+  };
+}
+
+function handoffFromActiveMessage(payload: JsonRecord): TicketHandoff | null {
+  if (payload.active !== true) return null;
+  const dispatch = recordValue(payload.dispatch);
+  if (!dispatch || dispatch.is_handoff !== true) return null;
+  const runId = stringValue(payload.run_id);
+  if (!runId) return null;
+  return {
+    runId,
+    seq: numberValue(payload.seq),
+    title: stringValue(dispatch.title) ?? 'Agent needs input',
+    body: stringValue(dispatch.body) ?? '',
+    isHandoff: true
   };
 }
 
@@ -311,4 +332,13 @@ function parentRepoIdFromSnapshot(snapshot: RepoWorktreeDetailSnapshot): string 
 
 function stringValue(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function numberValue(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function recordValue(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : null;
 }

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/scopedTicketQueue.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/scopedTicketQueue.test.ts
@@ -102,7 +102,7 @@ describe('scoped ticket queue helpers', () => {
     expect(ticketScopeHref({ kind: 'hub' })).toBeNull();
   });
 
-  it('builds start, stop, and restart command requests', () => {
+  it('builds start, resume, stop, and restart command requests', () => {
     expect(buildScopedTicketQueueCommandPlan('start', repoConfig, null)).toEqual({
       requests: [
         {
@@ -115,6 +115,14 @@ describe('scoped ticket queue helpers', () => {
       requests: [
         {
           path: '/repos/repo%201/api/flows/run%2F1/stop',
+          options: { method: 'POST' }
+        }
+      ]
+    });
+    expect(buildScopedTicketQueueCommandPlan('resume', repoConfig, 'run/1')).toEqual({
+      requests: [
+        {
+          path: '/repos/repo%201/api/flows/run%2F1/resume',
           options: { method: 'POST' }
         }
       ]
@@ -133,7 +141,8 @@ describe('scoped ticket queue helpers', () => {
     });
   });
 
-  it('returns null command plans when stop or restart has no run id', () => {
+  it('returns null command plans when resume, stop, or restart has no run id', () => {
+    expect(buildScopedTicketQueueCommandPlan('resume', repoConfig, null)).toBeNull();
     expect(buildScopedTicketQueueCommandPlan('stop', repoConfig, null)).toBeNull();
     expect(buildScopedTicketQueueCommandPlan('restart', repoConfig, null)).toBeNull();
   });
@@ -142,6 +151,7 @@ describe('scoped ticket queue helpers', () => {
     expect(scopedTicketActionStatus('create', repoConfig)).toBe('Creating repo ticket...');
     expect(scopedTicketActionStatus('reorder', worktreeConfig)).toBe('Reordering worktree tickets...');
     expect(scopedTicketActionStatus('start', repoConfig)).toBe('Starting repo ticket flow...');
+    expect(scopedTicketActionStatus('resume', repoConfig)).toBe('Continuing repo ticket flow...');
     expect(scopedTicketActionStatus('stop', worktreeConfig)).toBe('Stopping worktree ticket flow...');
     expect(scopedTicketActionStatus('restart', worktreeConfig)).toBe('Restarting worktree ticket flow...');
     expect(scopedTicketMissingRunStatus(repoConfig)).toBe('No repo ticket flow run found.');

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/scopedTicketQueue.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/scopedTicketQueue.ts
@@ -48,7 +48,7 @@ export function ticketScopeUrn(scope: ScopeRef): string {
 export function ticketScopeHref(scope: ScopeRef): string | null {
   return scopeTicketRoute(scope);
 }
-export type ScopedTicketQueueCommand = 'start' | 'stop' | 'restart';
+export type ScopedTicketQueueCommand = 'start' | 'resume' | 'stop' | 'restart';
 export type ScopedTicketQueueOwner = { repo: string } | { worktree: string };
 
 export type ScopedTicketQueueConfig = {
@@ -157,6 +157,8 @@ export function scopedTicketActionStatus(
       return `Reordering ${config.displayLabel} tickets...`;
     case 'start':
       return `Starting ${config.displayLabel} ticket flow...`;
+    case 'resume':
+      return `Continuing ${config.displayLabel} ticket flow...`;
     case 'stop':
       return `Stopping ${config.displayLabel} ticket flow...`;
     case 'restart':
@@ -173,7 +175,7 @@ export function buildScopedTicketQueueCommandPlan(
   config: Pick<ScopedTicketQueueConfig, 'apiBasePath'>,
   runId: string | null
 ): ScopedTicketQueueCommandPlan | null {
-  if ((command === 'stop' || command === 'restart') && !runId) return null;
+  if ((command === 'resume' || command === 'stop' || command === 'restart') && !runId) return null;
   if (command === 'start') {
     return {
       requests: [{ path: `${config.apiBasePath}/ticket_flow/bootstrap`, options: { method: 'POST', body: {} } }]
@@ -183,6 +185,16 @@ export function buildScopedTicketQueueCommandPlan(
     path: `${config.apiBasePath}/${encodeURIComponent(runId!)}/stop`,
     options: { method: 'POST' }
   };
+  if (command === 'resume') {
+    return {
+      requests: [
+        {
+          path: `${config.apiBasePath}/${encodeURIComponent(runId!)}/resume`,
+          options: { method: 'POST' }
+        }
+      ]
+    };
+  }
   if (command === 'stop') return { requests: [stopRequest] };
   return {
     requests: [
@@ -217,7 +229,7 @@ export async function runScopedTicketQueueCommand(
       shouldReload: true
     };
   }
-  if ((command === 'stop' || command === 'restart') && !runId) {
+  if ((command === 'resume' || command === 'stop' || command === 'restart') && !runId) {
     return { status: scopedTicketMissingRunStatus(config), shouldReload: false };
   }
   if (command === 'restart' && !(await confirmRestart())) {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/ticket.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/ticket.ts
@@ -92,13 +92,21 @@ export type TicketQueueRun = {
 };
 
 export type TicketQueueAction = {
-  action: 'start' | 'stop' | 'restart';
+  action: 'start' | 'resume' | 'stop' | 'restart';
   enabled: boolean;
   label: string;
   requiresConfirmation: boolean;
   disabledReason: string | null;
   method: 'GET' | 'POST';
   route: string | null;
+};
+
+export type TicketHandoff = {
+  runId: string;
+  seq: number | null;
+  title: string;
+  body: string;
+  isHandoff: boolean;
 };
 
 export type SurfaceActionManifestAction = {
@@ -128,6 +136,7 @@ export type TicketListViewModel = {
   workspaceFilters: { id: string; label: string; count: number }[];
   queueRun: TicketQueueRun | null;
   queueActions: TicketQueueAction[];
+  handoff: TicketHandoff | null;
   flowStatus: TicketFlowStatusViewModel;
   /** Managed-thread id of the chat for the currently running ticket, when one exists. */
   currentChatId: string | null;
@@ -283,6 +292,7 @@ export function buildTicketListViewModel(
     workspaceFilters: buildWorkspaceFilters(rowsWithCurrent),
     queueRun,
     queueActions: buildQueueActions(queueRun, source.runs, actionManifest),
+    handoff: null,
     flowStatus,
     currentChatId,
     rows: rowsWithCurrent
@@ -846,7 +856,7 @@ function actionsFromManifest(manifest: SurfaceActionManifest | null): TicketQueu
 function queueActionFromManifest(action: SurfaceActionManifestAction): TicketQueueAction | null {
   const rawId = typeof action.action_id === 'string' ? action.action_id : '';
   const name = rawId.replace(/^ticket_flow\./, '');
-  if (name !== 'start' && name !== 'stop' && name !== 'restart') return null;
+  if (name !== 'start' && name !== 'resume' && name !== 'stop' && name !== 'restart') return null;
   return {
     action: name,
     enabled: action.enabled === true,
@@ -863,7 +873,7 @@ function queueActionFromPolicy(value: unknown): TicketQueueAction | null {
   const visibility = asRecord(action.surface_visibility);
   if (visibility.queue !== true) return null;
   const name = stringFromRaw(action, ['action']);
-  if (name !== 'start' && name !== 'stop' && name !== 'restart') return null;
+  if (name !== 'start' && name !== 'resume' && name !== 'stop' && name !== 'restart') return null;
   return {
     action: name,
     enabled: action.enabled === true,
@@ -877,7 +887,7 @@ function queueActionFromPolicy(value: unknown): TicketQueueAction | null {
 
 function orderQueueActions(actions: TicketQueueAction[]): TicketQueueAction[] {
   const byAction = new Map(actions.map((action) => [action.action, action]));
-  return (['start', 'stop', 'restart'] as const)
+  return (['start', 'resume', 'stop', 'restart'] as const)
     .map((action) => byAction.get(action))
     .filter((action): action is TicketQueueAction => Boolean(action));
 }

--- a/src/codex_autorunner/web_frontend/src/routes/+layout.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/+layout.svelte
@@ -28,12 +28,16 @@
   import '../app.css';
   import '../theme-presets.css';
 
+  const REPO_ATTENTION_CHANGED_EVENT = 'car:repo-attention-changed';
+
   let { children }: { children: Snippet } = $props();
   let collapsed = $state(false);
   let mobileOpen = $state(false);
   let hubTitle = $state('Web Hub');
   let titleDraft = $state('Web Hub');
   let titleSaving = $state(false);
+  let repoAttentionCount = $state(0);
+  let repoAttentionRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   const currentPath = $derived(stripRuntimeBasePath(page.url.pathname));
   const breadcrumbs = $derived(breadcrumbsForPath(currentPath));
 
@@ -58,9 +62,15 @@
       /* private mode / quota */
     }
     void loadHubState();
+    void loadRepoAttention();
     const unsubscribeReadModels = readModelEntityStore.subscribe(refreshPaletteSources);
+    window.addEventListener(REPO_ATTENTION_CHANGED_EVENT, handleRepoAttentionChanged);
     void loadPaletteSources();
-    return () => unsubscribeReadModels();
+    return () => {
+      unsubscribeReadModels();
+      window.removeEventListener(REPO_ATTENTION_CHANGED_EVENT, handleRepoAttentionChanged);
+      clearRepoAttentionRefreshTimer();
+    };
   });
 
   onDestroy(() => {
@@ -79,6 +89,40 @@
     if (!result.ok) return;
     hubTitle = result.data.title;
     titleDraft = result.data.title;
+  }
+
+  async function loadRepoAttention(): Promise<void> {
+    const result = await webApi.hub.getDashboard();
+    if (!result.ok) return;
+    const raw = result.data.raw as Record<string, unknown>;
+    const items = Array.isArray(raw.items) ? raw.items : [];
+    repoAttentionCount = items.filter((item) => {
+      if (!item || typeof item !== 'object') return false;
+      const record = item as Record<string, unknown>;
+      return record.item_type === 'run_dispatch' || record.next_action === 'reply_and_resume';
+    }).length;
+  }
+
+  function handleRepoAttentionChanged(event: Event): void {
+    const delta = event instanceof CustomEvent ? numericDelta(event.detail) : null;
+    if (delta !== null) repoAttentionCount = Math.max(0, repoAttentionCount + delta);
+    clearRepoAttentionRefreshTimer();
+    repoAttentionRefreshTimer = setTimeout(() => {
+      repoAttentionRefreshTimer = null;
+      void loadRepoAttention();
+    }, 8000);
+  }
+
+  function numericDelta(detail: unknown): number | null {
+    if (!detail || typeof detail !== 'object') return null;
+    const value = (detail as Record<string, unknown>).delta;
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  }
+
+  function clearRepoAttentionRefreshTimer(): void {
+    if (repoAttentionRefreshTimer === null) return;
+    clearTimeout(repoAttentionRefreshTimer);
+    repoAttentionRefreshTimer = null;
   }
 
   async function loadPaletteSources(): Promise<void> {
@@ -208,6 +252,11 @@
           >
             <span class="nav-initial" aria-hidden="true">{item.label.slice(0, 1)}</span>
             <span class="nav-label">{item.label}</span>
+            {#if item.href === '/repos' && repoAttentionCount > 0}
+              <span class="nav-attention-badge" aria-label={`${repoAttentionCount} repo item${repoAttentionCount === 1 ? '' : 's'} need response`}>
+                {repoAttentionCount > 9 ? '9+' : repoAttentionCount}
+              </span>
+            {/if}
           </a>
         {/each}
       </div>

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/+page.svelte
@@ -18,8 +18,9 @@
     scopedTicketQueueScope,
     type ScopedTicketQueueConfig
   } from '$lib/viewModels/scopedTicketQueue';
-  import type { SurfaceActionManifest } from '$lib/viewModels/ticket';
-  import type { TicketFilter, TicketListViewModel } from '$lib/viewModels/ticket';
+  import type { SurfaceActionManifest, TicketFilter, TicketHandoff, TicketListViewModel } from '$lib/viewModels/ticket';
+
+  const REPO_ATTENTION_CHANGED_EVENT = 'car:repo-attention-changed';
 
   const repoId = $derived(page.params.repoId ?? 'unknown-repo');
   const queueConfig = $derived<ScopedTicketQueueConfig>({
@@ -31,8 +32,12 @@
   let readModelState = $state(readModelEntityStore.snapshot());
   let unsubscribeReadModels: (() => void) | null = null;
   let actionManifest = $state<SurfaceActionManifest | null>(null);
+  let handoff = $state<TicketHandoff | null>(null);
   const ownerScope = $derived(scopedTicketQueueScope(queueConfig));
-  const list = $derived<TicketListViewModel | null>(selectTicketListView(readModelState, ownerScope, actionManifest));
+  const list = $derived.by<TicketListViewModel | null>(() => {
+    const base = selectTicketListView(readModelState, ownerScope, actionManifest);
+    return base ? { ...base, handoff } : null;
+  });
   let selectedFilter = $state<TicketFilter>('all');
   let loading = $state(true);
   let error = $state<ApiError | null>(null);
@@ -58,6 +63,7 @@
     if (!session.ok) error = session.error;
     else {
       actionManifest = session.actionManifest;
+      handoff = session.handoff;
       sectionIssues = session.sectionIssues;
     }
     selectedFilter = 'all';
@@ -77,7 +83,7 @@
     return result.ok;
   }
 
-  async function runQueueCommand(command: 'start' | 'stop' | 'restart'): Promise<void> {
+  async function runQueueCommand(command: 'start' | 'resume' | 'stop' | 'restart'): Promise<void> {
     const runId = list?.queueRun?.id ?? null;
     const action = list?.queueActions.find((candidate) => candidate.action === command) ?? null;
     actionStatus = scopedTicketActionStatus(command, queueConfig);
@@ -98,6 +104,23 @@
     actionStatus = result.status;
     if (result.shouldReload) await loadTickets();
   }
+
+  async function replyAndResume(body: string): Promise<void> {
+    if (!handoff) return;
+    actionStatus = 'Replying and continuing ticket flow...';
+    const form = new FormData();
+    form.set('body', body);
+    const result = await webApi.uploadForm(`/repos/${encodeURIComponent(repoId)}/api/messages/${encodeURIComponent(handoff.runId)}/reply-and-resume`, form);
+    actionStatus = result.ok ? 'Ticket flow continued.' : result.error.message;
+    if (result.ok) {
+      window.dispatchEvent(new CustomEvent(REPO_ATTENTION_CHANGED_EVENT, { detail: { delta: -1 } }));
+      await invalidateReadModelTags([
+        readModelEntityTags.ticketIndex,
+        readModelEntityTags.repo(repoId)
+      ]);
+      await loadTickets(false);
+    }
+  }
 </script>
 
 <TicketViews
@@ -111,6 +134,7 @@
   onRetry={loadTickets}
   onFilter={(filter) => (selectedFilter = filter)}
   onQueueCommand={runQueueCommand}
+  onReplyAndResume={replyAndResume}
   onReorderTicket={reorderTicket}
   errorMessage={error?.message ?? null}
 />

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/+page.svelte
@@ -20,7 +20,9 @@
     scopedTicketQueueScope,
     type ScopedTicketQueueConfig
   } from '$lib/viewModels/scopedTicketQueue';
-  import type { SurfaceActionManifest, TicketFilter, TicketListViewModel } from '$lib/viewModels/ticket';
+  import type { SurfaceActionManifest, TicketFilter, TicketHandoff, TicketListViewModel } from '$lib/viewModels/ticket';
+
+  const REPO_ATTENTION_CHANGED_EVENT = 'car:repo-attention-changed';
 
   const worktreeId = $derived(page.params.worktreeId ?? 'unknown-worktree');
   const routeRepoId = $derived(page.params.repoId ?? null);
@@ -37,8 +39,12 @@
   let readModelState = $state(readModelEntityStore.snapshot());
   let unsubscribeReadModels: (() => void) | null = null;
   let actionManifest = $state<SurfaceActionManifest | null>(null);
+  let handoff = $state<TicketHandoff | null>(null);
   const ownerScope = $derived(scopedTicketQueueScope(queueConfig));
-  const list = $derived<TicketListViewModel | null>(selectTicketListView(readModelState, ownerScope, actionManifest));
+  const list = $derived.by<TicketListViewModel | null>(() => {
+    const base = selectTicketListView(readModelState, ownerScope, actionManifest);
+    return base ? { ...base, handoff } : null;
+  });
   let selectedFilter = $state<TicketFilter>('all');
   let loading = $state(true);
   let error = $state<ApiError | null>(null);
@@ -75,6 +81,7 @@
       return;
     }
     actionManifest = session.actionManifest;
+    handoff = session.handoff;
     sectionIssues = session.sectionIssues;
     selectedFilter = 'all';
     loading = false;
@@ -93,7 +100,7 @@
     return result.ok;
   }
 
-  async function runQueueCommand(command: 'start' | 'stop' | 'restart'): Promise<void> {
+  async function runQueueCommand(command: 'start' | 'resume' | 'stop' | 'restart'): Promise<void> {
     const runId = list?.queueRun?.id ?? null;
     const action = list?.queueActions.find((candidate) => candidate.action === command) ?? null;
     actionStatus = scopedTicketActionStatus(command, queueConfig);
@@ -114,6 +121,23 @@
     actionStatus = result.status;
     if (result.shouldReload) await loadTickets();
   }
+
+  async function replyAndResume(body: string): Promise<void> {
+    if (!handoff) return;
+    actionStatus = 'Replying and continuing ticket flow...';
+    const form = new FormData();
+    form.set('body', body);
+    const result = await webApi.uploadForm(`/repos/${encodeURIComponent(worktreeId)}/api/messages/${encodeURIComponent(handoff.runId)}/reply-and-resume`, form);
+    actionStatus = result.ok ? 'Ticket flow continued.' : result.error.message;
+    if (result.ok) {
+      window.dispatchEvent(new CustomEvent(REPO_ATTENTION_CHANGED_EVENT, { detail: { delta: -1 } }));
+      await invalidateReadModelTags([
+        readModelEntityTags.ticketIndex,
+        readModelEntityTags.worktree(worktreeId)
+      ]);
+      await loadTickets(false);
+    }
+  }
 </script>
 
 <TicketViews
@@ -127,6 +151,7 @@
   onRetry={loadTickets}
   onFilter={(filter) => (selectedFilter = filter)}
   onQueueCommand={runQueueCommand}
+  onReplyAndResume={replyAndResume}
   onReorderTicket={reorderTicket}
   errorMessage={error?.message ?? null}
 />

--- a/tests/routes/test_flow_bootstrap_guard.py
+++ b/tests/routes/test_flow_bootstrap_guard.py
@@ -176,6 +176,94 @@ def test_ticket_flow_restart_route_starts_force_new_run(
     assert payload["status"] in {"pending", "running"}
 
 
+def test_ticket_flow_restart_route_replaces_paused_run(
+    tmp_path, monkeypatch, _flow_client
+):
+    _reset_state()
+    seed_hub_files(tmp_path, force=True)
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / "TICKET-001.md").write_text(
+        '---\nticket_id: "tkt_restart_paused001"\nagent: codex\ndone: false\n---\n',
+        encoding="utf-8",
+    )
+
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    store = FlowStore(db_path)
+    store.initialize()
+    old_run_id = str(uuid.uuid4())
+    store.create_flow_run(
+        run_id=old_run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        metadata={},
+        state={"ticket_engine": {"status": "paused"}},
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(old_run_id, FlowRunStatus.PAUSED)
+    store.close()
+
+    monkeypatch.setattr(
+        flow_routes, "_start_flow_worker", lambda *_args, **_kwargs: None
+    )
+
+    resp = _flow_client.post(f"/api/flows/{old_run_id}/restart", json={})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["id"] != old_run_id
+    assert payload["flow_type"] == "ticket_flow"
+    assert payload["status"] in {"pending", "running"}
+
+
+def test_bootstrap_does_not_worker_resume_paused_run(
+    tmp_path, monkeypatch, _flow_client
+):
+    _reset_state()
+    seed_hub_files(tmp_path, force=True)
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / "TICKET-001.md").write_text(
+        '---\nticket_id: "tkt_paused_bootstrap001"\nagent: codex\ndone: false\n---\n',
+        encoding="utf-8",
+    )
+
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    store = FlowStore(db_path)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        metadata={},
+        state={"ticket_engine": {"status": "paused"}},
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(run_id, FlowRunStatus.PAUSED)
+    store.close()
+
+    spawned = {"count": 0}
+
+    def fake_start_worker(*_args, **_kwargs):
+        spawned["count"] += 1
+
+    monkeypatch.setattr(flow_routes, "_start_flow_worker", fake_start_worker)
+
+    resp = _flow_client.post("/api/flows/ticket_flow/bootstrap", json={})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["id"] == run_id
+    assert payload["status"] == "paused"
+    assert payload["state"]["hint"] == "paused_run_requires_resume"
+    assert spawned["count"] == 0
+
+
 def test_start_reuses_active_run_when_latest_is_terminal(
     tmp_path, monkeypatch, _flow_client
 ):

--- a/tests/routes/test_messages_routes.py
+++ b/tests/routes/test_messages_routes.py
@@ -7,9 +7,18 @@ from tests.support.web_test_helpers import build_messages_app
 
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
+from codex_autorunner.surfaces.web.routes import messages as messages_routes
 
 
-def _write_dispatch_history(repo_root: Path, run_id: str, seq: int = 1) -> None:
+def _write_dispatch_history(
+    repo_root: Path,
+    run_id: str,
+    seq: int = 1,
+    *,
+    mode: str = "pause",
+    title: str = "Review",
+    body: str = "Please review this change.",
+) -> None:
     entry_dir = (
         repo_root
         / ".codex-autorunner"
@@ -20,7 +29,7 @@ def _write_dispatch_history(repo_root: Path, run_id: str, seq: int = 1) -> None:
     )
     entry_dir.mkdir(parents=True, exist_ok=True)
     (entry_dir / "DISPATCH.md").write_text(
-        "---\nmode: pause\ntitle: Review\n---\n\nPlease review this change.\n",
+        f"---\nmode: {mode}\ntitle: {title}\n---\n\n{body}\n",
         encoding="utf-8",
     )
     (entry_dir / "design.md").write_text("draft", encoding="utf-8")
@@ -85,6 +94,43 @@ def test_messages_active_and_reply_archive(tmp_path, monkeypatch):
         fetched = client.get(file_url)
         assert fetched.status_code == 200
         assert fetched.content == b"hello"
+
+
+def test_active_message_prefers_pause_handoff_over_newer_turn_summary(
+    tmp_path, monkeypatch
+):
+    repo_root = Path(tmp_path)
+    run_id = "55555555-5555-4555-8555-555555555555"
+
+    _seed_paused_run(repo_root, run_id)
+    _write_dispatch_history(
+        repo_root,
+        run_id,
+        seq=1,
+        mode="pause",
+        title="Choose direction",
+        body="Which path should the agent take?",
+    )
+    _write_dispatch_history(
+        repo_root,
+        run_id,
+        seq=2,
+        mode="turn_summary",
+        title="Turn summary",
+        body="The agent paused for input.",
+    )
+
+    app = build_messages_app(repo_root, monkeypatch)
+
+    with TestClient(app) as client:
+        active = client.get("/api/messages/active")
+
+    assert active.status_code == 200
+    payload = active.json()
+    assert payload["active"] is True
+    assert payload["seq"] == 1
+    assert payload["dispatch"]["is_handoff"] is True
+    assert payload["dispatch"]["title"] == "Choose direction"
 
 
 def test_reply_archive_rejects_relative_workspace_root(tmp_path, monkeypatch):
@@ -167,6 +213,76 @@ def test_reply_archive_preserves_file_url_within_workspace(tmp_path, monkeypatch
         fetched = client.get(f"/{file_entry['url']}")
         assert fetched.status_code == 200
         assert fetched.content == b"data"
+
+
+def test_reply_and_resume_writes_live_reply_before_resume(tmp_path, monkeypatch):
+    repo_root = Path(tmp_path)
+    run_id = "44444444-4444-4444-4444-444444444444"
+
+    _seed_paused_run(repo_root, run_id)
+    _write_dispatch_history(repo_root, run_id, seq=1)
+
+    observed = {}
+
+    async def fake_resume(root: Path, requested_run_id: str, *, force: bool = False):
+        observed["root"] = root
+        observed["run_id"] = requested_run_id
+        observed["force"] = force
+        live_reply = repo_root / ".codex-autorunner" / "runs" / run_id / "USER_REPLY.md"
+        observed["live_reply"] = live_reply.read_text(encoding="utf-8")
+        with FlowStore(repo_root / ".codex-autorunner" / "flows.db") as store:
+            store.update_flow_run_status(run_id, FlowRunStatus.RUNNING)
+            record = store.get_flow_run(run_id)
+            assert record is not None
+            return record
+
+    monkeypatch.setattr(messages_routes, "resume_ticket_flow_run", fake_resume)
+
+    app = build_messages_app(repo_root, monkeypatch)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/api/messages/{run_id}/reply-and-resume",
+            data={"body": "Proceed with option B"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["run_status"] == "running"
+    assert observed["run_id"] == run_id
+    assert observed["force"] is False
+    assert "Proceed with option B" in observed["live_reply"]
+
+
+def test_reply_and_resume_validates_tickets_before_writing_reply(tmp_path, monkeypatch):
+    repo_root = Path(tmp_path)
+    run_id = "66666666-6666-4666-8666-666666666666"
+
+    _seed_paused_run(repo_root, run_id)
+    _write_dispatch_history(repo_root, run_id, seq=1)
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / "TICKET-001.md").write_text(
+        "---\nticket_id: [broken\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+
+    async def fail_resume(*_args, **_kwargs):
+        raise AssertionError("reply-and-resume should validate before resume")
+
+    monkeypatch.setattr(messages_routes, "resume_ticket_flow_run", fail_resume)
+
+    app = build_messages_app(repo_root, monkeypatch)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/api/messages/{run_id}/reply-and-resume",
+            data={"body": "Proceed anyway"},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["message"] == "Ticket validation failed"
+    live_reply = repo_root / ".codex-autorunner" / "runs" / run_id / "USER_REPLY.md"
+    assert not live_reply.exists()
 
 
 def test_reply_archive_rejects_reply_to_unknown_run(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a web reply-and-resume endpoint that writes live USER_REPLY.md for paused ticket-flow runs before resuming
- make paused runs resumable from ticket queue controls and prevent bootstrap/start from silently worker-resuming paused runs
- add web dispatch affordances: response panel, Repos nav attention badge, and repo-row RESPOND pill
- keep the Repos badge from staying stale after a successful web reply by optimistically clearing one attention item and reconciling later

## Validation
- .venv/bin/python -m pytest -q tests/routes/test_messages_routes.py tests/routes/test_flow_bootstrap_guard.py
- pnpm lint (src/codex_autorunner/web_frontend)
- pnpm test (src/codex_autorunner/web_frontend)
- pnpm build (src/codex_autorunner/web_frontend)
- screenshot QA via Chromium against a seeded paused-dispatch fixture: repo index desktop, ticket page desktop, ticket page mobile
- final subagent review: clear, no remaining blocking or medium findings

## Known unrelated hook failure
- normal pre-commit was run twice; guardrails/static/web checks passed after formatting, but the full core pytest lane failed on existing process/preview-service tests unrelated to this diff
- reproduced one failing preview-service test in isolation: tests/surfaces/web/test_preview_services_routes.py::test_preview_services_managed_lifecycle_logs_and_force_semantics
