### PR TITLE
Share inbound attachments across chat surfaces

### DIFF
--- a/src/codex_autorunner/adapters/chat/attachments.py
+++ b/src/codex_autorunner/adapters/chat/attachments.py
@@ -1,0 +1,77 @@
+"""Shared inbound attachment transcript metadata helpers."""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from typing import Any, Optional
+
+
+def build_inbound_attachment_metadata(
+    *,
+    path: Path,
+    original_name: str,
+    source_surface: str,
+    source_message_id: Optional[str] = None,
+    source_thread_id: Optional[str] = None,
+    mime_type: Optional[str] = None,
+    size_bytes: Optional[int] = None,
+    box: str = "inbox",
+    kind: Optional[str] = None,
+) -> dict[str, Any]:
+    """Return compact metadata suitable for managed-turn transcript payloads."""
+
+    saved_path = Path(path)
+    name = saved_path.name
+    title = str(original_name or name).strip() or name
+    resolved_mime = _normalize_optional_text(mime_type) or (
+        mimetypes.guess_type(name)[0] or "application/octet-stream"
+    )
+    resolved_kind = _normalize_optional_text(kind) or _kind_from_mime(resolved_mime)
+    size = size_bytes
+    if size is None:
+        try:
+            size = saved_path.stat().st_size
+        except OSError:
+            size = None
+    payload: dict[str, Any] = {
+        "id": f"{source_surface}:{source_message_id or name}:{name}",
+        "kind": resolved_kind,
+        "title": title,
+        "name": name,
+        "filename": name,
+        "box": box,
+        "source": "surface_upload",
+        "source_surface": source_surface,
+        "mime_type": resolved_mime,
+    }
+    if size is not None:
+        payload["size"] = size
+        payload["size_bytes"] = size
+    if source_message_id:
+        payload["source_message_id"] = source_message_id
+    if source_thread_id:
+        payload["source_thread_id"] = source_thread_id
+    return payload
+
+
+def _kind_from_mime(mime_type: str) -> str:
+    lowered = mime_type.lower()
+    if lowered.startswith("image/"):
+        return "image"
+    if lowered.startswith("audio/"):
+        return "audio"
+    if lowered.startswith("video/"):
+        return "video"
+    return "file"
+
+
+def _normalize_optional_text(value: object) -> Optional[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+__all__ = ["build_inbound_attachment_metadata"]

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -635,11 +635,14 @@ async def _submit_discord_flow_reply(
             failed_attachments,
             transcript_message,
             _native_input_items,
+            _transcript_attachments,
         ) = await dispatch.service._with_attachment_context(
             prompt_text=dispatch.flow_reply_text,
             workspace_root=dispatch.workspace_root,
             attachments=dispatch.event.attachments,
             channel_id=dispatch.channel_id,
+            source_message_id=dispatch.event.message.message_id,
+            source_thread_id=dispatch.event.thread.thread_id,
         )
         if transcript_message:
             await dispatch.service._send_channel_message_safe(
@@ -1049,11 +1052,14 @@ async def _execute_discord_thread_message(
         failed_attachments,
         transcript_message,
         attachment_input_items,
+        transcript_attachments,
     ) = await dispatch.service._with_attachment_context(
         prompt_text=prompt_text,
         workspace_root=request_workspace_root,
         attachments=dispatch.event.attachments,
         channel_id=dispatch.channel_id,
+        source_message_id=dispatch.event.message.message_id,
+        source_thread_id=dispatch.event.thread.thread_id,
     )
     if transcript_message:
         await dispatch.service._send_channel_message_safe(
@@ -1300,6 +1306,11 @@ async def _execute_discord_thread_message(
                     surface_key=resolved_managed_thread_surface_key
                     or dispatch.channel_id,
                 ),
+            ),
+            metadata=(
+                {"attachments": transcript_attachments}
+                if transcript_attachments
+                else {}
             ),
         )
         run_turn_kwargs["turn_envelope"] = turn_envelope

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1286,7 +1286,10 @@ async def _execute_discord_thread_message(
     visible_seed = dispatch.turn_text.strip()
     if not visible_seed and transcript_message:
         visible_seed = transcript_message
-    if visible_seed:
+    envelope_user_text = visible_seed
+    if not envelope_user_text and transcript_attachments:
+        envelope_user_text = prompt_text.strip() or "(attachment)"
+    if envelope_user_text or transcript_attachments:
         turn_envelope = ChatTurnEnvelope(
             source=ChatTurnSource(
                 surface_kind="discord",
@@ -1295,9 +1298,9 @@ async def _execute_discord_thread_message(
                 thread_id=dispatch.event.thread.thread_id,
                 update_id=dispatch.event.update_id,
             ),
-            user_visible_text=visible_seed,
+            user_visible_text=envelope_user_text or "(attachment)",
             runtime_prompt=prompt_text,
-            title_seed=visible_seed,
+            title_seed=envelope_user_text or "(attachment)",
             input_items=turn_input_items,
             existing_session_runtime_prompt=existing_session_prompt_text,
             delivery_targets=(

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -42,6 +42,7 @@ from ...adapters.chat.artifact_delivery import (
     LegacyArchivePolicy,
     import_and_drain_legacy_outbox,
 )
+from ...adapters.chat.attachments import build_inbound_attachment_metadata
 from ...adapters.chat.bound_live_progress import (
     bound_chat_progress_delivered_message_id,
     mark_bound_chat_progress_delivered,
@@ -113,6 +114,7 @@ from ...core.artifact_delivery import (
     DeliveryIntent,
     delivery_filename,
 )
+from ...core.artifact_filebox_storage import ArtifactFileBoxStorage
 from ...core.chat_queue_control import ChatQueueControlPlane, ChatQueueControlStore
 from ...core.config import (
     ConfigError,
@@ -2591,12 +2593,21 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         workspace_root: Path,
         attachments: tuple[Any, ...],
         channel_id: str,
-    ) -> tuple[str, int, int, Optional[str], Optional[list[dict[str, Any]]]]:
+        source_message_id: Optional[str] = None,
+        source_thread_id: Optional[str] = None,
+    ) -> tuple[
+        str,
+        int,
+        int,
+        Optional[str],
+        Optional[list[dict[str, Any]]],
+        list[dict[str, Any]],
+    ]:
         if not attachments:
-            return prompt_text, 0, 0, None, None
+            return prompt_text, 0, 0, None, None, []
 
         inbox = inbox_dir(workspace_root)
-        inbox.mkdir(parents=True, exist_ok=True)
+        storage = ArtifactFileBoxStorage(workspace_root)
         saved: list[SavedDiscordAttachment] = []
         failed = 0
         for index, attachment in enumerate(attachments, start=1):
@@ -2618,8 +2629,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                     max_size_bytes=DISCORD_ATTACHMENT_MAX_BYTES,
                 )
                 file_name = self._build_attachment_filename(attachment, index=index)
-                path = inbox / file_name
-                path.write_bytes(data)
+                path = storage.save_filebox_file("inbox", file_name, data)
                 original_name = normalized.file_name or path.name
                 mime_type = normalized.mime_type
                 is_audio = normalized.is_audio(mime_type=mime_type)
@@ -2664,7 +2674,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                 )
 
         if not saved:
-            return prompt_text, 0, failed, None, None
+            return prompt_text, 0, failed, None, None, []
 
         provider_name: Optional[str] = None
         if any(item.transcript_text for item in saved):
@@ -2694,12 +2704,26 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             target_conversation_key=f"channel:{channel_id}",
             workspace_scope=f"repo:{workspace_root}",
         )
+        transcript_attachments = [
+            build_inbound_attachment_metadata(
+                path=item.path,
+                original_name=item.original_name,
+                source_surface="discord",
+                source_message_id=source_message_id,
+                source_thread_id=source_thread_id,
+                mime_type=item.mime_type,
+                size_bytes=item.size_bytes,
+                kind="image" if item.is_image else ("audio" if item.is_audio else None),
+            )
+            for item in saved
+        ]
         return (
             payload.prompt_text,
             payload.saved_count,
             payload.failed_count,
             payload.user_visible_transcript,
             cast(Optional[list[dict[str, Any]]], payload.native_input_items_payload),
+            transcript_attachments,
         )
 
     def _build_attachment_filename(self, attachment: Any, *, index: int) -> str:

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -1233,6 +1233,7 @@ async def _run_telegram_managed_thread_turn(
     chat_ux_snapshot: Optional[ChatUxTimingSnapshot] = None,
     user_visible_text: Optional[str] = None,
     title_seed: Optional[str] = None,
+    transcript_attachments: Optional[list[dict[str, Any]]] = None,
 ) -> _TurnRunResult | _TurnRunFailure:
     if chat_ux_snapshot is not None:
         chat_ux_snapshot.record(ChatUxMilestone.ACK_FINISHED)
@@ -1796,6 +1797,10 @@ async def _run_telegram_managed_thread_turn(
         and existing_session_prompt_text.strip()
     ):
         metadata["existing_session_runtime_prompt"] = existing_session_prompt_text
+    if transcript_attachments:
+        metadata["attachments"] = [
+            dict(item) for item in transcript_attachments if isinstance(item, dict)
+        ]
     client_request_id = f"telegram:{topic_key}:{secrets.token_hex(6)}"
     message_request = MessageRequest(
         target_id=thread.thread_target_id,
@@ -3639,6 +3644,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         placeholder_id: Optional[int] = None,
         surface_key_override: Optional[str] = None,
         pma_context_prefix: Optional[str] = None,
+        transcript_attachments: Optional[list[dict[str, Any]]] = None,
     ) -> _TurnRunResult | _TurnRunFailure:
         key = surface_key_override or await self._resolve_topic_key(
             message.chat_id, message.thread_id
@@ -3837,6 +3843,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 chat_ux_snapshot=_chat_ux_snapshot,
                 user_visible_text=user_visible_seed,
                 title_seed=user_visible_seed,
+                transcript_attachments=transcript_attachments,
             )
             _record_pending_planned_injections(result)
             return result
@@ -3869,6 +3876,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 chat_ux_snapshot=_chat_ux_snapshot,
                 user_visible_text=user_visible_seed,
                 title_seed=user_visible_seed,
+                transcript_attachments=transcript_attachments,
             )
             _record_pending_planned_injections(result)
             return result

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
@@ -568,6 +568,33 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
             return
         combined_prompt, input_items = self._build_media_prompt(context, result)
         last_message = context.sorted_messages[-1]
+        source_thread_id = (
+            str(last_message.thread_id) if last_message.thread_id is not None else None
+        )
+        transcript_attachments: list[dict[str, Any]] = []
+        for name, path, size in result.saved_image_inbox_info:
+            transcript_attachments.append(
+                build_inbound_attachment_metadata(
+                    path=Path(path),
+                    original_name=name,
+                    source_surface="telegram",
+                    source_message_id=str(last_message.message_id),
+                    source_thread_id=source_thread_id,
+                    size_bytes=size,
+                    kind="image",
+                )
+            )
+        for name, path, size in result.saved_file_info:
+            transcript_attachments.append(
+                build_inbound_attachment_metadata(
+                    path=Path(path),
+                    original_name=name,
+                    source_surface="telegram",
+                    source_message_id=str(last_message.message_id),
+                    source_thread_id=source_thread_id,
+                    size_bytes=size,
+                )
+            )
         log_event(
             self._logger,
             logging.INFO,
@@ -586,6 +613,7 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
             input_items=input_items,
             record=context.record,
             placeholder_id=placeholder_id,
+            transcript_attachments=transcript_attachments or None,
         )
 
     async def _prepare_media_batch_context(
@@ -1169,9 +1197,9 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
             return ArtifactFileBoxStorage(Path(self._hub_root)).save_filebox_file(
                 "inbox", name, data
             )
-        path = inbox_dir / name
-        path.write_bytes(data)
-        return path
+        return ArtifactFileBoxStorage(Path(workspace_path)).save_filebox_file(
+            "inbox", name, data
+        )
 
     def _format_file_prompt(
         self,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
+from .....core.artifact_filebox_storage import ArtifactFileBoxStorage
 from .....core.artifact_instructions import (
     ArtifactDeliveryContext,
 )
@@ -25,6 +26,7 @@ from .....core.surface_context_capsules import (
     build_artifact_delivery_capsule,
     render_capsules_for_prompt,
 )
+from ....chat.attachments import build_inbound_attachment_metadata
 from ....chat.constants import TOPIC_NOT_BOUND_MESSAGE
 from ....chat.media import IMAGE_CONTENT_TYPES, IMAGE_EXTS
 from ...adapter import TelegramAPIError, TelegramMessage
@@ -308,6 +310,30 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
             input_items=input_items,
             record=record,
             placeholder_id=placeholder_id,
+            transcript_attachments=(
+                [
+                    build_inbound_attachment_metadata(
+                        path=image_inbox_path,
+                        original_name=(
+                            candidate.file_name
+                            or (Path(file_path).name if file_path else None)
+                            or image_inbox_path.name
+                        ),
+                        source_surface="telegram",
+                        source_message_id=str(message.message_id),
+                        source_thread_id=(
+                            str(message.thread_id)
+                            if message.thread_id is not None
+                            else None
+                        ),
+                        mime_type=candidate.mime_type,
+                        size_bytes=file_size or len(data),
+                        kind="image",
+                    )
+                ]
+                if image_inbox_path is not None
+                else None
+            ),
         )
 
     async def _handle_voice_message(
@@ -506,6 +532,25 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
             text_override=prompt_text,
             record=record,
             placeholder_id=placeholder_id,
+            transcript_attachments=[
+                build_inbound_attachment_metadata(
+                    path=file_path_local,
+                    original_name=(
+                        candidate.file_name
+                        or (Path(file_path).name if file_path else None)
+                        or file_path_local.name
+                    ),
+                    source_surface="telegram",
+                    source_message_id=str(message.message_id),
+                    source_thread_id=(
+                        str(message.thread_id)
+                        if message.thread_id is not None
+                        else None
+                    ),
+                    mime_type=candidate.mime_type,
+                    size_bytes=file_size or len(data),
+                )
+            ],
         )
 
     async def _handle_media_batch(
@@ -1120,6 +1165,10 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
         )
         token = secrets.token_hex(6)
         name = f"{stem}-{token}{ext}"
+        if pma_enabled and self._hub_root is not None:
+            return ArtifactFileBoxStorage(Path(self._hub_root)).save_filebox_file(
+                "inbox", name, data
+            )
         path = inbox_dir / name
         path.write_bytes(data)
         return path

--- a/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
@@ -377,6 +377,7 @@ class TelegramCommandHandlers(
         placeholder_id: Optional[int] = None,
         surface_key_override: Optional[str] = None,
         pma_context_prefix: Optional[str] = None,
+        transcript_attachments: Optional[list[dict[str, Any]]] = None,
     ) -> None:
         if placeholder_id is not None:
             send_placeholder = False
@@ -394,6 +395,7 @@ class TelegramCommandHandlers(
             placeholder_id=placeholder_id,
             surface_key_override=surface_key_override,
             pma_context_prefix=pma_context_prefix,
+            transcript_attachments=transcript_attachments,
         )
         if isinstance(outcome, _TurnRunFailure):
             return

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -642,16 +642,21 @@ def _terminal_event_ids_from_timeline(entries: Iterable[dict[str, Any]]) -> list
 def _append_user_message(
     items: list[ManagedThreadTimelineItem],
     *,
+    hub_root: Any,
     managed_thread_id: str,
+    thread: dict[str, Any],
     turn: dict[str, Any],
     sequence: int,
 ) -> int:
     managed_turn_id = str(turn.get("managed_turn_id") or "")
     timestamp = _turn_timestamp(turn)
     metadata = _metadata(turn)
-    attachments = metadata.get("attachments")
-    if not isinstance(attachments, list):
-        attachments = []
+    attachments = _web_attachment_payloads(
+        metadata.get("attachments"),
+        hub_root=hub_root,
+        repo_id=_normalize_optional_text(thread.get("repo_id")),
+        workspace_root=_normalize_optional_text(thread.get("workspace_root")),
+    )
     raw_prompt = str(turn.get("prompt") or "")
     user_visible_text = _normalize_optional_text(metadata.get("user_visible_text"))
     if user_visible_text is None:
@@ -686,11 +691,71 @@ def _append_user_message(
                 "capsule_refs": capsule_refs,
                 "client_turn_id": turn.get("client_turn_id"),
                 "request_kind": turn.get("request_kind"),
-                "attachments": [a for a in attachments if isinstance(a, dict)],
+                "attachments": attachments,
             },
         )
     )
     return sequence + 1
+
+
+def _web_attachment_payloads(
+    raw_attachments: Any,
+    *,
+    hub_root: Any,
+    repo_id: Optional[str],
+    workspace_root: Optional[str],
+) -> list[dict[str, Any]]:
+    if not isinstance(raw_attachments, list):
+        return []
+    attachments: list[dict[str, Any]] = []
+    for raw in raw_attachments:
+        if not isinstance(raw, dict):
+            continue
+        payload = dict(raw)
+        name = _normalize_optional_text(
+            payload.get("name")
+            or payload.get("filename")
+            or payload.get("uploaded_name")
+        )
+        box = _normalize_optional_text(payload.get("box")) or "inbox"
+        if name and not _normalize_optional_text(payload.get("url")):
+            download_url = _web_filebox_download_url(
+                hub_root=hub_root,
+                repo_id=repo_id,
+                workspace_root=workspace_root,
+                box=box,
+                filename=name,
+            )
+            if download_url:
+                payload["url"] = download_url
+        if name:
+            payload.setdefault("filename", name)
+            payload.setdefault("name", name)
+        if not _normalize_optional_text(payload.get("title")) and name:
+            payload["title"] = name
+        payload.setdefault("kind", "file")
+        attachments.append(payload)
+    return attachments
+
+
+def _web_filebox_download_url(
+    *,
+    hub_root: Any,
+    repo_id: Optional[str],
+    workspace_root: Optional[str],
+    box: str,
+    filename: str,
+) -> Optional[str]:
+    encoded_box = quote(box, safe="")
+    encoded_filename = quote(filename, safe="")
+    if repo_id:
+        return (
+            f"/hub/filebox/{quote(repo_id, safe='')}/"
+            f"{encoded_box}/{encoded_filename}"
+        )
+    if workspace_root and Path(workspace_root) == Path(hub_root):
+        return f"/hub/pma/files/{encoded_box}/{encoded_filename}"
+    return None
 
 
 def _capsule_refs_from_metadata(metadata: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1649,6 +1714,7 @@ def _append_turn_timeline_items(
     *,
     hub_root: Any,
     managed_thread_id: str,
+    thread: dict[str, Any],
     turn: dict[str, Any],
     sequence: int,
     turn_timeline_entries: Optional[list[dict[str, Any]]] = None,
@@ -1663,7 +1729,9 @@ def _append_turn_timeline_items(
     )
     sequence = _append_user_message(
         items,
+        hub_root=hub_root,
         managed_thread_id=managed_thread_id,
+        thread=thread,
         turn=turn,
         sequence=sequence,
     )
@@ -1751,6 +1819,7 @@ def build_managed_thread_timeline(
                 items,
                 hub_root=hub_root,
                 managed_thread_id=normalized_thread_id,
+                thread=thread,
                 turn=turn,
                 sequence=sequence,
                 turn_timeline_entries=turn_timeline_entries.get(
@@ -1771,6 +1840,7 @@ def build_managed_thread_timeline(
             items,
             hub_root=hub_root,
             managed_thread_id=normalized_thread_id,
+            thread=thread,
             turn=turns[turn_index],
             sequence=sequence,
             turn_timeline_entries=turn_timeline_entries.get(

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -465,9 +465,11 @@ async def test_discord_message_turns_delete_immediate_placeholder_when_backgroun
 
         async def _with_attachment_context(
             self, *, prompt_text: str, **_kwargs: object
-        ) -> tuple[str, int, int, None, list[dict[str, object]]]:
+        ) -> tuple[
+            str, int, int, None, list[dict[str, object]], list[dict[str, object]]
+        ]:
             _ = prompt_text
-            return "", 0, 1, None, []
+            return "", 0, 1, None, [], []
 
         async def _send_channel_message(
             self, channel_id: str, payload: dict[str, object]
@@ -682,9 +684,11 @@ async def test_discord_message_turns_show_busy_placeholder_for_attachment_prep(
 
         async def _with_attachment_context(
             self, *, prompt_text: str, **_kwargs: object
-        ) -> tuple[str, int, int, None, list[dict[str, object]]]:
+        ) -> tuple[
+            str, int, int, None, list[dict[str, object]], list[dict[str, object]]
+        ]:
             _ = prompt_text
-            return "", 0, 1, None, []
+            return "", 0, 1, None, [], []
 
         async def _send_channel_message(
             self, channel_id: str, payload: dict[str, object]
@@ -891,8 +895,10 @@ async def test_discord_notification_reply_routes_to_managed_thread_with_context(
 
         async def _with_attachment_context(
             self, *, prompt_text: str, **_kwargs: object
-        ) -> tuple[str, int, int, None, list[dict[str, object]]]:
-            return prompt_text, 0, 0, None, []
+        ) -> tuple[
+            str, int, int, None, list[dict[str, object]], list[dict[str, object]]
+        ]:
+            return prompt_text, 0, 0, None, [], []
 
         async def _maybe_inject_github_context(
             self,

--- a/tests/core/orchestration/test_managed_thread_timeline.py
+++ b/tests/core/orchestration/test_managed_thread_timeline.py
@@ -178,7 +178,7 @@ def test_completed_timeline_separates_intermediate_and_final_output(
         item for item in payload["items"] if item["kind"] == "user_message"
     )
     assert user_item["payload"]["attachments"] == [
-        {"attachment_id": "att-1", "title": "notes.txt"}
+        {"attachment_id": "att-1", "title": "notes.txt", "kind": "file"}
     ]
     artifact_item = next(
         item for item in payload["items"] if item["kind"] == "artifact"
@@ -197,6 +197,53 @@ def test_completed_timeline_separates_intermediate_and_final_output(
         item["payload"].get("source_event_type") == "output_delta"
         for item in payload["items"]
     )
+
+
+def test_user_attachment_metadata_gets_web_download_url_and_transcript_artifact(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub_root(tmp_path)
+    workspace = hub_root / "repo"
+    workspace.mkdir(parents=True)
+    store = ManagedThreadStore(hub_root)
+    thread = store.create_thread("codex", workspace, repo_id="repo-1")
+    thread_id = str(thread["managed_thread_id"])
+    turn = create_test_turn(
+        store,
+        thread_id,
+        prompt="Review attachment",
+        metadata={
+            "attachments": [
+                {
+                    "name": "screen shot.png",
+                    "filename": "screen shot.png",
+                    "title": "Screenshot",
+                    "kind": "image",
+                    "box": "inbox",
+                    "size_bytes": 123,
+                }
+            ]
+        },
+    )
+    assert store.mark_turn_finished(
+        str(turn["managed_turn_id"]),
+        status="ok",
+        assistant_text="done",
+    )
+
+    payload = build_managed_thread_timeline(
+        hub_root,
+        thread_store=store,
+        managed_thread_id=thread_id,
+    )
+
+    user_item = next(
+        item for item in payload["items"] if item["kind"] == "user_message"
+    )
+    [attachment] = user_item["payload"]["attachments"]
+    assert attachment["url"] == "/hub/filebox/repo-1/inbox/screen%20shot.png"
+    assert attachment["title"] == "Screenshot"
+    assert attachment["kind"] == "image"
 
 
 def test_multi_chunk_agent_thought_stream_projects_single_clean_reasoning(

--- a/tests/core/orchestration/test_managed_thread_transcript.py
+++ b/tests/core/orchestration/test_managed_thread_transcript.py
@@ -67,6 +67,35 @@ def test_transcript_projects_legacy_injected_prompt_as_model_context() -> None:
     assert row["message"]["model_context_text"] == "repo guidance"
 
 
+def test_transcript_exposes_user_message_attachments_as_artifacts() -> None:
+    rows = transcript_rows_from_timeline_items(
+        [
+            _user_item(
+                {
+                    "text": "Review screenshot",
+                    "attachments": [
+                        {
+                            "kind": "image",
+                            "title": "screen.png",
+                            "url": "/hub/pma/files/inbox/screen.png",
+                            "size_bytes": 42,
+                        }
+                    ],
+                }
+            )
+        ]
+    )
+
+    assert rows[0]["message"]["artifacts"] == [
+        {
+            "kind": "image",
+            "title": "screen.png",
+            "url": "/hub/pma/files/inbox/screen.png",
+            "size_bytes": 42,
+        }
+    ]
+
+
 def test_transcript_omits_intermediate_progress_rows() -> None:
     rows = transcript_rows_from_timeline_items(
         [

--- a/tests/test_discord_voice_input.py
+++ b/tests/test_discord_voice_input.py
@@ -89,18 +89,25 @@ async def test_with_attachment_context_normalizes_discord_voice_transcription_me
         source_url="https://cdn.discordapp.com/attachments/1/2",
     )
 
-    prompt_text, saved_count, failed_count, transcript_message, native_input_items = (
-        await service._with_attachment_context(
-            prompt_text="",
-            workspace_root=tmp_path,
-            attachments=(attachment,),
-            channel_id="123",
-        )
+    (
+        prompt_text,
+        saved_count,
+        failed_count,
+        transcript_message,
+        native_input_items,
+        transcript_attachments,
+    ) = await service._with_attachment_context(
+        prompt_text="",
+        workspace_root=tmp_path,
+        attachments=(attachment,),
+        channel_id="123",
+        source_message_id="msg-1",
     )
 
     assert saved_count == 1
     assert failed_count == 0
     assert native_input_items is None
+    assert transcript_attachments[0]["source_message_id"] == "msg-1"
     assert "hello from discord" in (transcript_message or "")
     assert "Transcript: hello from discord" in prompt_text
 
@@ -213,13 +220,18 @@ async def test_with_attachment_context_uses_effective_provider_for_disclaimer(
         source_url="https://cdn.discordapp.com/attachments/1/2",
     )
 
-    prompt_text, saved_count, failed_count, transcript_message, native_input_items = (
-        await service._with_attachment_context(
-            prompt_text="",
-            workspace_root=tmp_path,
-            attachments=(attachment,),
-            channel_id="123",
-        )
+    (
+        prompt_text,
+        saved_count,
+        failed_count,
+        transcript_message,
+        native_input_items,
+        _transcript_attachments,
+    ) = await service._with_attachment_context(
+        prompt_text="",
+        workspace_root=tmp_path,
+        attachments=(attachment,),
+        channel_id="123",
     )
 
     assert saved_count == 1

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -922,7 +922,7 @@ async def test_document_message_saves_inbox(tmp_path: Path) -> None:
         await service._handle_media_message(message, runtime, "")
     finally:
         await service._app_server_supervisor.close_all()
-    inbox_root = repo / ".codex-autorunner" / "uploads" / "telegram-files"
+    inbox_root = repo / ".codex-autorunner" / "filebox" / "inbox"
     inbox_files = [path for path in inbox_root.rglob("*") if path.is_file()]
     assert inbox_files
 
@@ -952,7 +952,7 @@ async def test_photo_batch_message_saves_inbox(tmp_path: Path) -> None:
         await service._handle_media_batch([message])
     finally:
         await service._app_server_supervisor.close_all()
-    inbox_root = repo / ".codex-autorunner" / "uploads" / "telegram-files"
+    inbox_root = repo / ".codex-autorunner" / "filebox" / "inbox"
     inbox_files = [path for path in inbox_root.rglob("*") if path.is_file()]
     assert inbox_files
     assert any(path.suffix.lower() == ".jpg" for path in inbox_files)


### PR DESCRIPTION
## Summary
- persist inbound Discord and Telegram media as normalized turn attachment metadata
- project managed-thread attachments into timeline/transcript payloads with scoped Web download URLs
- use shared FileBox storage for Discord and hub/PMA Telegram attachment saves

## Validation
- pre-commit aggregate lane passed during commit
- targeted: `.venv/bin/python -m pytest tests/test_discord_voice_input.py tests/adapters/discord/test_service_routing.py tests/core/orchestration/test_managed_thread_timeline.py tests/core/orchestration/test_managed_thread_transcript.py tests/test_managed_threads_messages.py tests/core/test_document_file_intents.py -q`
- targeted: Black and Ruff on touched Python files

## Notes
A critique pass called out that `/transcript`, not only `/timeline`, is the Web Chat acceptance contract, and that URL scope should be resolved at projection time. This PR keeps adapter metadata URL-free and enriches the timeline, which the transcript projection consumes.