### PR TITLE
Address attachment sharing review follow-ups

### DIFF
--- a/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
@@ -1267,7 +1267,7 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
                         ),
                     )
                 )
-        inbox_dir = self._files_inbox_dir(workspace_path, topic_key)
+        inbox_dir = filebox_inbox_dir(Path(workspace_path))
         topic_dir = self._files_topic_dir(workspace_path, topic_key)
         return render_capsules_for_prompt(
             (

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -748,13 +748,13 @@ def _web_filebox_download_url(
 ) -> Optional[str]:
     encoded_box = quote(box, safe="")
     encoded_filename = quote(filename, safe="")
+    if workspace_root and Path(workspace_root) == Path(hub_root):
+        return f"/hub/pma/files/{encoded_box}/{encoded_filename}"
     if repo_id:
         return (
             f"/hub/filebox/{quote(repo_id, safe='')}/"
             f"{encoded_box}/{encoded_filename}"
         )
-    if workspace_root and Path(workspace_root) == Path(hub_root):
-        return f"/hub/pma/files/{encoded_box}/{encoded_filename}"
     return None
 
 

--- a/tests/core/orchestration/test_managed_thread_timeline.py
+++ b/tests/core/orchestration/test_managed_thread_timeline.py
@@ -246,6 +246,49 @@ def test_user_attachment_metadata_gets_web_download_url_and_transcript_artifact(
     assert attachment["kind"] == "image"
 
 
+def test_hub_root_attachment_metadata_prefers_pma_download_url_with_repo_context(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub_root(tmp_path)
+    store = ManagedThreadStore(hub_root)
+    thread = store.create_thread("codex", hub_root, repo_id="repo-1")
+    thread_id = str(thread["managed_thread_id"])
+    turn = create_test_turn(
+        store,
+        thread_id,
+        prompt="Review PMA attachment",
+        metadata={
+            "attachments": [
+                {
+                    "name": "screen shot.png",
+                    "filename": "screen shot.png",
+                    "title": "Screenshot",
+                    "kind": "image",
+                    "box": "inbox",
+                    "size_bytes": 123,
+                }
+            ]
+        },
+    )
+    assert store.mark_turn_finished(
+        str(turn["managed_turn_id"]),
+        status="ok",
+        assistant_text="done",
+    )
+
+    payload = build_managed_thread_timeline(
+        hub_root,
+        thread_store=store,
+        managed_thread_id=thread_id,
+    )
+
+    user_item = next(
+        item for item in payload["items"] if item["kind"] == "user_message"
+    )
+    [attachment] = user_item["payload"]["attachments"]
+    assert attachment["url"] == "/hub/pma/files/inbox/screen%20shot.png"
+
+
 def test_multi_chunk_agent_thought_stream_projects_single_clean_reasoning(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_telegram_files_pma.py
+++ b/tests/test_telegram_files_pma.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,6 +10,7 @@ from codex_autorunner.adapters.telegram.client import (
     TelegramForwardOrigin,
     TelegramMessage,
 )
+from codex_autorunner.adapters.telegram.config import TelegramMediaCandidate
 from codex_autorunner.adapters.telegram.handlers.commands.files import (
     FilesCommands,
     MediaBatchContext,
@@ -43,6 +45,7 @@ class _FilesHandlerStub(FilesCommands):
         self._config = SimpleNamespace(media=media_cfg)
         self._hub_root = hub_root
         self._router = _RouterStub(record)
+        self._logger = logging.getLogger(__name__)
         self._sent: list[str] = []
 
     def _with_conversation_id(
@@ -144,3 +147,99 @@ def test_build_media_prompt_includes_forwarded_caption(tmp_path: Path) -> None:
     assert "Forwarded message from Ops [message 9]:" in prompt
     assert "caption here" in prompt
     assert input_items is None
+
+
+def test_repo_mode_inbox_file_saves_to_filebox(tmp_path: Path) -> None:
+    handler = FilesCommands.__new__(FilesCommands)
+    handler._hub_root = tmp_path / "hub"
+    candidate = TelegramMediaCandidate(
+        kind="document",
+        file_id="file-1",
+        file_name="notes.txt",
+        mime_type="text/plain",
+        file_size=5,
+    )
+
+    saved_path = handler._save_inbox_file(
+        str(tmp_path),
+        "10:20",
+        b"hello",
+        candidate=candidate,
+        file_path=None,
+        pma_enabled=False,
+    )
+
+    assert saved_path.parent == tmp_path / ".codex-autorunner" / "filebox" / "inbox"
+    assert saved_path.read_bytes() == b"hello"
+
+
+@pytest.mark.anyio
+async def test_media_batch_passes_transcript_attachments(tmp_path: Path) -> None:
+    handler = _FilesHandlerStub(
+        tmp_path / "hub",
+        TelegramTopicRecord(workspace_path=str(tmp_path), pma_enabled=False),
+    )
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=10,
+        thread_id=20,
+        from_user_id=2,
+        text=None,
+        date=None,
+        is_topic_message=True,
+    )
+    context = MediaBatchContext(
+        first_message=message,
+        sorted_messages=[message],
+        record=TelegramTopicRecord(workspace_path=str(tmp_path), pma_enabled=False),
+        runtime=None,
+        topic_key="10:20",
+        max_image_bytes=1024,
+        max_file_bytes=1024,
+    )
+    saved_path = tmp_path / ".codex-autorunner" / "filebox" / "inbox" / "notes.txt"
+    saved_path.parent.mkdir(parents=True)
+    saved_path.write_bytes(b"hello")
+    result = MediaBatchResult(
+        saved_image_paths=[],
+        saved_image_inbox_info=[],
+        saved_file_info=[("notes.txt", str(saved_path), 5)],
+        stats=MediaBatchStats(),
+    )
+    captured: dict[str, object] = {}
+
+    async def _prepare_media_batch_context(
+        _messages: list[TelegramMessage],
+    ) -> MediaBatchContext:
+        return context
+
+    async def _process_media_messages(_context: MediaBatchContext) -> MediaBatchResult:
+        return result
+
+    def _build_media_prompt(
+        _context: MediaBatchContext,
+        _result: MediaBatchResult,
+    ) -> tuple[str, None]:
+        return "File received.", None
+
+    async def _handle_normal_message(
+        _message: TelegramMessage,
+        _runtime: object,
+        **kwargs: object,
+    ) -> None:
+        captured.update(kwargs)
+
+    handler._prepare_media_batch_context = _prepare_media_batch_context
+    handler._process_media_messages = _process_media_messages
+    handler._build_media_prompt = _build_media_prompt
+    handler._handle_normal_message = _handle_normal_message
+
+    await handler._handle_media_batch([message])
+
+    [attachment] = captured["transcript_attachments"]
+    assert attachment["box"] == "inbox"
+    assert attachment["name"] == "notes.txt"
+    assert attachment["source_surface"] == "telegram"
+    assert attachment["source_message_id"] == "2"
+    assert attachment["source_thread_id"] == "20"


### PR DESCRIPTION
Follow-up to #2053 after review feedback.\n\nChanges:\n- Prefer PMA download URLs when attachment metadata points at hub-root storage, even if the thread also has repo context.\n- Point Telegram repo-mode upload hints at the repo FileBox inbox that inbound attachments are saved into.\n- Add regression coverage for repo-mode Telegram FileBox saves, Telegram media-batch transcript attachments, and PMA attachment URLs with repo context.\n\nValidation:\n- Focused: `.venv/bin/python -m pytest tests/test_discord_voice_input.py tests/adapters/discord/test_service_routing.py tests/core/orchestration/test_managed_thread_timeline.py tests/core/orchestration/test_managed_thread_transcript.py tests/test_managed_threads_messages.py tests/core/test_document_file_intents.py tests/test_telegram_files_pma.py -q` -> 258 passed\n- Commit hook aggregate lane passed: guardrails, black, ruff, import boundaries, mypy, full pytest, frontend build, frontend tests