### PR TITLE
Fix Linux systemd hub and chat supervision

### DIFF
--- a/docs/ops/systemd-discord.service
+++ b/docs/ops/systemd-discord.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=Codex Autorunner hub
-After=network.target
+Description=Codex Autorunner Discord bot
+After=network.target car-hub.service
+Wants=car-hub.service
 StartLimitIntervalSec=300
 StartLimitBurst=20
 
@@ -9,8 +10,7 @@ Type=simple
 WorkingDirectory=/home/you/car-workspace
 EnvironmentFile=%h/.config/codex-autorunner/codex-autorunner.env
 # Replace the ExecStart path with `which car` or the codex-autorunner binary.
-# Use CAR_BASE_PATH=/ if you do not need a base path.
-ExecStart=/home/you/.local/bin/car hub serve --host 127.0.0.1 --port 4173 --path /home/you/car-workspace --base-path ${CAR_BASE_PATH}
+ExecStart=/home/you/.local/bin/car discord start --path /home/you/car-workspace
 Restart=always
 RestartSec=5
 

--- a/docs/ops/systemd-telegram.service
+++ b/docs/ops/systemd-telegram.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Codex Autorunner Telegram bot
-After=network.target
+After=network.target car-hub.service
+Wants=car-hub.service
+StartLimitIntervalSec=300
+StartLimitBurst=20
 
 [Service]
 Type=simple
@@ -8,8 +11,8 @@ WorkingDirectory=/home/you/car-workspace
 EnvironmentFile=%h/.config/codex-autorunner/codex-autorunner.env
 # Replace the ExecStart path with `which car` or the codex-autorunner binary.
 ExecStart=/home/you/.local/bin/car telegram start --path /home/you/car-workspace
-Restart=on-failure
-RestartSec=3
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=default.target

--- a/docs/ops/systemd.md
+++ b/docs/ops/systemd.md
@@ -1,7 +1,7 @@
-# systemd Runbook (Hub + Telegram)
+# systemd Runbook (Hub + Chat Surfaces)
 
 This runbook covers running CAR in hub mode with systemd on Linux. It includes
-user and system service guidance plus templates for hub and Telegram.
+user and system service guidance plus templates for hub, Telegram, and Discord.
 
 ## Prerequisites
 
@@ -25,6 +25,8 @@ CAR_AUTH_TOKEN=replace_me
 OPENAI_API_KEY=replace_me
 CAR_TELEGRAM_BOT_TOKEN=replace_me
 CAR_TELEGRAM_CHAT_ID=replace_me
+CAR_DISCORD_BOT_TOKEN=replace_me
+CAR_DISCORD_APP_ID=replace_me
 EOF
 chmod 600 ~/.config/codex-autorunner/codex-autorunner.env
 ```
@@ -57,6 +59,7 @@ update:
   linux_service_names:
     hub: car-hub
     telegram: car-telegram
+    discord: car-discord
 ```
 
 `update.backend` accepts `auto`, `launchd`, `systemd-user`, or `systemd-system`.
@@ -77,6 +80,12 @@ refresh now fails with a clear message instead of silently aborting.
 7) `journalctl --user -u car-hub -f`
 8) Health check: `curl -fsS http://127.0.0.1:4173/health`
 
+The hub unit should be the canonical owner of the hub process. Chat surfaces
+should attach to this supervised hub instead of starting an incidental hub owner
+from a bot/session process. If `car doctor` reports that the configured hub port
+is owned outside `car-hub.service`, stop the incidental process and start
+`car-hub.service` before starting chat services.
+
 ## Telegram service
 
 1) Copy `docs/ops/systemd-telegram.service` to
@@ -86,6 +95,21 @@ refresh now fails with a clear message instead of silently aborting.
 3) `systemctl --user daemon-reload`
 4) `systemctl --user enable --now car-telegram`
 5) `journalctl --user -u car-telegram -f`
+
+## Discord service
+
+1) Copy `docs/ops/systemd-discord.service` to
+   `~/.config/systemd/user/car-discord.service`.
+2) Ensure the env file includes `CAR_DISCORD_BOT_TOKEN` and
+   `CAR_DISCORD_APP_ID`.
+3) `systemctl --user daemon-reload`
+4) `systemctl --user enable --now car-discord`
+5) `journalctl --user -u car-discord -f`
+
+Both chat service templates declare `Wants=car-hub.service` and
+`After=car-hub.service`. They remain separate supervised units, but startup
+ordering points them at the canonical hub instead of making either bot the
+long-running owner of the hub process.
 
 ## System service (root-managed)
 
@@ -97,7 +121,7 @@ If you need a system service:
 - `sudo systemctl daemon-reload`
 - `sudo systemctl enable --now car-hub`
 
-The same pattern applies to `car-telegram.service`.
+The same pattern applies to `car-telegram.service` and `car-discord.service`.
 
 ### Self-update for a system service
 
@@ -155,4 +179,8 @@ script is a thin compatibility wrapper. The hub spawns
 
 - Hub logs: `journalctl --user -u car-hub -f`
 - Telegram logs: `journalctl --user -u car-telegram -f`
+- Discord logs: `journalctl --user -u car-discord -f`
 - Health: `curl -fsS http://<host>:<port>/health` (prefix base path if set)
+- Supervisor checks: `car doctor --repo <hub-root>` warns when an enabled chat
+  surface unit is inactive or when the configured hub port is owned outside the
+  expected `linux_service_names.hub` systemd cgroup.

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/files.py
@@ -1267,7 +1267,7 @@ class FilesCommands(FileBoxCommandsMixin, TelegramCommandSupportMixin):
                         ),
                     )
                 )
-        inbox_dir = self._files_inbox_dir(workspace_path, topic_key)
+        inbox_dir = filebox_inbox_dir(Path(workspace_path))
         topic_dir = self._files_topic_dir(workspace_path, topic_key)
         return render_capsules_for_prompt(
             (

--- a/src/codex_autorunner/core/diagnostics/registry.py
+++ b/src/codex_autorunner/core/diagnostics/registry.py
@@ -14,6 +14,7 @@ from .hub import (
 )
 from .pma import pma_doctor_checks
 from .repository import doctor
+from .systemd import linux_systemd_doctor_checks
 from .types import DoctorCheck, DoctorReport
 
 
@@ -49,6 +50,10 @@ def runtime_doctor_providers(
         DoctorProvider(
             name="hub_destination",
             collect=lambda: hub_destination_doctor_checks(hub_config),
+        ),
+        DoctorProvider(
+            name="systemd",
+            collect=lambda: linux_systemd_doctor_checks(hub_config),
         ),
         DoctorProvider(
             name="hermes",

--- a/src/codex_autorunner/core/diagnostics/systemd.py
+++ b/src/codex_autorunner/core/diagnostics/systemd.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import platform
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from ..config import HubConfig
+from .types import DoctorCheck
+
+
+@dataclass(frozen=True)
+class _SystemdUnitState:
+    name: str
+    load_state: str
+    active_state: str
+    sub_state: str
+
+
+def linux_systemd_doctor_checks(hub_config: HubConfig) -> list[DoctorCheck]:
+    """Collect Linux/systemd supervision checks for always-on hub installs."""
+    if platform.system().lower() != "linux":
+        return []
+
+    backend = str(getattr(hub_config, "update_backend", "auto") or "auto")
+    if backend not in {"auto", "systemd-user", "systemd-system"}:
+        return []
+
+    service_names = _service_names(hub_config)
+    checks: list[DoctorCheck] = []
+    checks.extend(_chat_surface_unit_checks(hub_config, service_names, backend))
+    checks.extend(_hub_port_owner_checks(hub_config, service_names))
+    return checks
+
+
+def _service_names(hub_config: HubConfig) -> dict[str, str]:
+    raw_names = getattr(hub_config, "update_linux_service_names", {}) or {}
+    names: dict[str, str] = {}
+    if isinstance(raw_names, Mapping):
+        for key, value in raw_names.items():
+            text = str(value or "").strip()
+            if text:
+                names[str(key)] = text
+    return names
+
+
+def _chat_surface_unit_checks(
+    hub_config: HubConfig, service_names: Mapping[str, str], backend: str
+) -> list[DoctorCheck]:
+    checks: list[DoctorCheck] = []
+    raw = hub_config.raw if isinstance(hub_config.raw, dict) else {}
+    enabled_surfaces = {
+        "telegram": _surface_enabled(raw, "telegram_bot"),
+        "discord": _surface_enabled(raw, "discord_bot"),
+    }
+
+    for surface, enabled in enabled_surfaces.items():
+        if not enabled:
+            continue
+        service_name = service_names.get(surface)
+        if not service_name:
+            continue
+        state = _systemctl_show(service_name, backend=backend)
+        if state is None:
+            checks.append(
+                DoctorCheck(
+                    name=f"{surface.title()} systemd unit",
+                    passed=True,
+                    message=(
+                        f"Could not inspect {service_name}; skipping systemd "
+                        "chat-unit state check."
+                    ),
+                    check_id=f"systemd.{surface}.unit",
+                    severity="warning",
+                )
+            )
+            continue
+        if state.load_state == "not-found":
+            checks.append(
+                DoctorCheck(
+                    name=f"{surface.title()} systemd unit",
+                    passed=False,
+                    message=f"{service_name} is configured but not installed.",
+                    check_id=f"systemd.{surface}.unit",
+                    severity="warning",
+                    fix=(
+                        f"Install and enable the {service_name} systemd unit, or "
+                        f"remove update.linux_service_names.{surface}."
+                    ),
+                )
+            )
+            continue
+        if state.active_state == "active":
+            checks.append(
+                DoctorCheck(
+                    name=f"{surface.title()} systemd unit",
+                    passed=True,
+                    message=f"{service_name} is active ({state.sub_state}).",
+                    check_id=f"systemd.{surface}.unit",
+                    severity="info",
+                )
+            )
+            continue
+        if state.active_state == "inactive":
+            checks.append(
+                DoctorCheck(
+                    name=f"{surface.title()} systemd unit",
+                    passed=False,
+                    message=(
+                        f"{service_name} is inactive ({state.sub_state}) even "
+                        f"though {surface} is enabled."
+                    ),
+                    check_id=f"systemd.{surface}.unit",
+                    severity="warning",
+                    fix=(
+                        f"Start {service_name} and use Restart=always with a "
+                        "restart delay for always-on chat surfaces."
+                    ),
+                )
+            )
+            continue
+        checks.append(
+            DoctorCheck(
+                name=f"{surface.title()} systemd unit",
+                passed=False,
+                message=f"{service_name} is {state.active_state} ({state.sub_state}).",
+                check_id=f"systemd.{surface}.unit",
+                severity="error" if state.active_state == "failed" else "warning",
+                fix=f"Inspect with `systemctl status {service_name}`.",
+            )
+        )
+
+    return checks
+
+
+def _hub_port_owner_checks(
+    hub_config: HubConfig, service_names: Mapping[str, str]
+) -> list[DoctorCheck]:
+    hub_service = service_names.get("hub")
+    if not hub_service:
+        return []
+    port = getattr(hub_config, "server_port", None)
+    if not isinstance(port, int) or port <= 0:
+        return []
+
+    owner = _listening_port_owner(port)
+    if owner is None:
+        return []
+    pid = owner.get("pid")
+    if not isinstance(pid, int):
+        return []
+
+    cgroups = _process_cgroups(pid)
+    if not cgroups:
+        return [
+            DoctorCheck(
+                name="Hub systemd ownership",
+                passed=True,
+                message=(
+                    f"Port {port} is owned by pid {pid}, but cgroup ownership "
+                    "could not be inspected."
+                ),
+                check_id="systemd.hub.port_owner",
+                severity="warning",
+            )
+        ]
+
+    if _cgroups_include_service(cgroups, hub_service):
+        return [
+            DoctorCheck(
+                name="Hub systemd ownership",
+                passed=True,
+                message=f"Port {port} is owned by {hub_service} (pid {pid}).",
+                check_id="systemd.hub.port_owner",
+                severity="info",
+            )
+        ]
+
+    cgroup_desc = "; ".join(cgroups)
+    return [
+        DoctorCheck(
+            name="Hub systemd ownership",
+            passed=False,
+            message=(
+                f"Port {port} is owned by pid {pid} outside expected service "
+                f"{hub_service}: {cgroup_desc}"
+            ),
+            check_id="systemd.hub.port_owner",
+            severity="warning",
+            fix=(
+                f"Stop the incidental hub process, then start {hub_service} so "
+                "systemd owns the canonical hub."
+            ),
+        )
+    ]
+
+
+def _surface_enabled(raw: Mapping[str, object], section: str) -> bool:
+    value = raw.get(section)
+    return isinstance(value, Mapping) and value.get("enabled") is True
+
+
+def _systemctl_show(service_name: str, *, backend: str) -> _SystemdUnitState | None:
+    cmd = ["systemctl"]
+    if backend in {"auto", "systemd-user"}:
+        cmd.append("--user")
+    cmd.extend(
+        [
+            "show",
+            service_name,
+            "--property=LoadState",
+            "--property=ActiveState",
+            "--property=SubState",
+            "--no-pager",
+        ]
+    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 and not proc.stdout:
+        return None
+    values: dict[str, str] = {}
+    for line in (proc.stdout or "").splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value.strip()
+    return _SystemdUnitState(
+        name=service_name,
+        load_state=values.get("LoadState", ""),
+        active_state=values.get("ActiveState", ""),
+        sub_state=values.get("SubState", ""),
+    )
+
+
+def _listening_port_owner(port: int) -> dict[str, object] | None:
+    return _listening_port_owner_from_ss(port) or _listening_port_owner_from_lsof(port)
+
+
+def _listening_port_owner_from_ss(port: int) -> dict[str, object] | None:
+    try:
+        proc = subprocess.run(
+            ["ss", "-H", "-ltnp", f"sport = :{port}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    match = re.search(r"pid=(\d+)", proc.stdout or "")
+    if not match:
+        return None
+    return {"pid": int(match.group(1)), "source": "ss"}
+
+
+def _listening_port_owner_from_lsof(port: int) -> dict[str, object] | None:
+    try:
+        proc = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-Fp"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    for line in (proc.stdout or "").splitlines():
+        if line.startswith("p") and line[1:].isdigit():
+            return {"pid": int(line[1:]), "source": "lsof"}
+    return None
+
+
+def _process_cgroups(pid: int) -> tuple[str, ...]:
+    path = Path("/proc") / str(pid) / "cgroup"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+    return tuple(line for line in lines if line.strip())
+
+
+def _cgroups_include_service(cgroups: tuple[str, ...], service_name: str) -> bool:
+    expected = (
+        service_name if service_name.endswith(".service") else f"{service_name}.service"
+    )
+    return any(expected in line for line in cgroups)

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -748,13 +748,13 @@ def _web_filebox_download_url(
 ) -> Optional[str]:
     encoded_box = quote(box, safe="")
     encoded_filename = quote(filename, safe="")
+    if workspace_root and Path(workspace_root) == Path(hub_root):
+        return f"/hub/pma/files/{encoded_box}/{encoded_filename}"
     if repo_id:
         return (
             f"/hub/filebox/{quote(repo_id, safe='')}/"
             f"{encoded_box}/{encoded_filename}"
         )
-    if workspace_root and Path(workspace_root) == Path(hub_root):
-        return f"/hub/pma/files/{encoded_box}/{encoded_filename}"
     return None
 
 

--- a/tests/core/orchestration/test_managed_thread_timeline.py
+++ b/tests/core/orchestration/test_managed_thread_timeline.py
@@ -246,6 +246,49 @@ def test_user_attachment_metadata_gets_web_download_url_and_transcript_artifact(
     assert attachment["kind"] == "image"
 
 
+def test_hub_root_attachment_metadata_prefers_pma_download_url_with_repo_context(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub_root(tmp_path)
+    store = ManagedThreadStore(hub_root)
+    thread = store.create_thread("codex", hub_root, repo_id="repo-1")
+    thread_id = str(thread["managed_thread_id"])
+    turn = create_test_turn(
+        store,
+        thread_id,
+        prompt="Review PMA attachment",
+        metadata={
+            "attachments": [
+                {
+                    "name": "screen shot.png",
+                    "filename": "screen shot.png",
+                    "title": "Screenshot",
+                    "kind": "image",
+                    "box": "inbox",
+                    "size_bytes": 123,
+                }
+            ]
+        },
+    )
+    assert store.mark_turn_finished(
+        str(turn["managed_turn_id"]),
+        status="ok",
+        assistant_text="done",
+    )
+
+    payload = build_managed_thread_timeline(
+        hub_root,
+        thread_store=store,
+        managed_thread_id=thread_id,
+    )
+
+    user_item = next(
+        item for item in payload["items"] if item["kind"] == "user_message"
+    )
+    [attachment] = user_item["payload"]["attachments"]
+    assert attachment["url"] == "/hub/pma/files/inbox/screen%20shot.png"
+
+
 def test_multi_chunk_agent_thought_stream_projects_single_clean_reasoning(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/test_systemd_diagnostics.py
+++ b/tests/core/test_systemd_diagnostics.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from codex_autorunner.core.diagnostics import systemd
+
+
+def _hub_config(
+    *,
+    raw: dict[str, object] | None = None,
+    backend: str = "systemd-user",
+    port: int = 4517,
+):
+    return SimpleNamespace(
+        raw=raw or {},
+        update_backend=backend,
+        update_linux_service_names={
+            "hub": "car-hub",
+            "telegram": "car-telegram",
+            "discord": "car-discord",
+        },
+        server_port=port,
+    )
+
+
+def _completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["cmd"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+def test_systemd_doctor_warns_when_enabled_chat_unit_is_inactive(monkeypatch) -> None:
+    monkeypatch.setattr(systemd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(systemd, "_listening_port_owner", lambda _port: None)
+
+    def fake_run(cmd, **_kwargs):
+        assert cmd[:2] == ["systemctl", "--user"]
+        assert "car-discord" in cmd
+        return _completed("LoadState=loaded\nActiveState=inactive\nSubState=dead\n")
+
+    monkeypatch.setattr(systemd.subprocess, "run", fake_run)
+
+    checks = systemd.linux_systemd_doctor_checks(
+        _hub_config(raw={"discord_bot": {"enabled": True}})
+    )
+    by_id = {check.check_id: check for check in checks}
+
+    assert by_id["systemd.discord.unit"].passed is False
+    assert by_id["systemd.discord.unit"].severity == "warning"
+    assert "inactive" in by_id["systemd.discord.unit"].message
+    assert "Restart=always" in (by_id["systemd.discord.unit"].fix or "")
+
+
+def test_systemd_doctor_accepts_active_chat_unit(monkeypatch) -> None:
+    monkeypatch.setattr(systemd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(systemd, "_listening_port_owner", lambda _port: None)
+    monkeypatch.setattr(
+        systemd.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _completed(
+            "LoadState=loaded\nActiveState=active\nSubState=running\n"
+        ),
+    )
+
+    checks = systemd.linux_systemd_doctor_checks(
+        _hub_config(raw={"telegram_bot": {"enabled": True}})
+    )
+    by_id = {check.check_id: check for check in checks}
+
+    assert by_id["systemd.telegram.unit"].passed is True
+    assert by_id["systemd.telegram.unit"].severity == "info"
+
+
+def test_systemd_doctor_warns_when_hub_port_owned_outside_cgroup(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(systemd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(systemd, "_listening_port_owner", lambda _port: {"pid": 1234})
+    monkeypatch.setattr(
+        systemd,
+        "_process_cgroups",
+        lambda _pid: ("0::/user.slice/user-1000.slice/session-2.scope",),
+    )
+
+    checks = systemd.linux_systemd_doctor_checks(_hub_config())
+    by_id = {check.check_id: check for check in checks}
+
+    assert by_id["systemd.hub.port_owner"].passed is False
+    assert by_id["systemd.hub.port_owner"].severity == "warning"
+    assert "outside expected service car-hub" in by_id["systemd.hub.port_owner"].message
+
+
+def test_systemd_doctor_accepts_hub_port_owned_by_expected_cgroup(monkeypatch) -> None:
+    monkeypatch.setattr(systemd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(systemd, "_listening_port_owner", lambda _port: {"pid": 1234})
+    monkeypatch.setattr(
+        systemd,
+        "_process_cgroups",
+        lambda _pid: ("0::/system.slice/car-hub.service",),
+    )
+
+    checks = systemd.linux_systemd_doctor_checks(_hub_config())
+    by_id = {check.check_id: check for check in checks}
+
+    assert by_id["systemd.hub.port_owner"].passed is True
+    assert "car-hub" in by_id["systemd.hub.port_owner"].message
+
+
+def test_systemd_doctor_skips_non_linux(monkeypatch) -> None:
+    monkeypatch.setattr(systemd.platform, "system", lambda: "Darwin")
+
+    assert systemd.linux_systemd_doctor_checks(_hub_config()) == []

--- a/tests/test_telegram_files_pma.py
+++ b/tests/test_telegram_files_pma.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,6 +10,7 @@ from codex_autorunner.adapters.telegram.client import (
     TelegramForwardOrigin,
     TelegramMessage,
 )
+from codex_autorunner.adapters.telegram.config import TelegramMediaCandidate
 from codex_autorunner.adapters.telegram.handlers.commands.files import (
     FilesCommands,
     MediaBatchContext,
@@ -43,6 +45,7 @@ class _FilesHandlerStub(FilesCommands):
         self._config = SimpleNamespace(media=media_cfg)
         self._hub_root = hub_root
         self._router = _RouterStub(record)
+        self._logger = logging.getLogger(__name__)
         self._sent: list[str] = []
 
     def _with_conversation_id(
@@ -144,3 +147,99 @@ def test_build_media_prompt_includes_forwarded_caption(tmp_path: Path) -> None:
     assert "Forwarded message from Ops [message 9]:" in prompt
     assert "caption here" in prompt
     assert input_items is None
+
+
+def test_repo_mode_inbox_file_saves_to_filebox(tmp_path: Path) -> None:
+    handler = FilesCommands.__new__(FilesCommands)
+    handler._hub_root = tmp_path / "hub"
+    candidate = TelegramMediaCandidate(
+        kind="document",
+        file_id="file-1",
+        file_name="notes.txt",
+        mime_type="text/plain",
+        file_size=5,
+    )
+
+    saved_path = handler._save_inbox_file(
+        str(tmp_path),
+        "10:20",
+        b"hello",
+        candidate=candidate,
+        file_path=None,
+        pma_enabled=False,
+    )
+
+    assert saved_path.parent == tmp_path / ".codex-autorunner" / "filebox" / "inbox"
+    assert saved_path.read_bytes() == b"hello"
+
+
+@pytest.mark.anyio
+async def test_media_batch_passes_transcript_attachments(tmp_path: Path) -> None:
+    handler = _FilesHandlerStub(
+        tmp_path / "hub",
+        TelegramTopicRecord(workspace_path=str(tmp_path), pma_enabled=False),
+    )
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=10,
+        thread_id=20,
+        from_user_id=2,
+        text=None,
+        date=None,
+        is_topic_message=True,
+    )
+    context = MediaBatchContext(
+        first_message=message,
+        sorted_messages=[message],
+        record=TelegramTopicRecord(workspace_path=str(tmp_path), pma_enabled=False),
+        runtime=None,
+        topic_key="10:20",
+        max_image_bytes=1024,
+        max_file_bytes=1024,
+    )
+    saved_path = tmp_path / ".codex-autorunner" / "filebox" / "inbox" / "notes.txt"
+    saved_path.parent.mkdir(parents=True)
+    saved_path.write_bytes(b"hello")
+    result = MediaBatchResult(
+        saved_image_paths=[],
+        saved_image_inbox_info=[],
+        saved_file_info=[("notes.txt", str(saved_path), 5)],
+        stats=MediaBatchStats(),
+    )
+    captured: dict[str, object] = {}
+
+    async def _prepare_media_batch_context(
+        _messages: list[TelegramMessage],
+    ) -> MediaBatchContext:
+        return context
+
+    async def _process_media_messages(_context: MediaBatchContext) -> MediaBatchResult:
+        return result
+
+    def _build_media_prompt(
+        _context: MediaBatchContext,
+        _result: MediaBatchResult,
+    ) -> tuple[str, None]:
+        return "File received.", None
+
+    async def _handle_normal_message(
+        _message: TelegramMessage,
+        _runtime: object,
+        **kwargs: object,
+    ) -> None:
+        captured.update(kwargs)
+
+    handler._prepare_media_batch_context = _prepare_media_batch_context
+    handler._process_media_messages = _process_media_messages
+    handler._build_media_prompt = _build_media_prompt
+    handler._handle_normal_message = _handle_normal_message
+
+    await handler._handle_media_batch([message])
+
+    [attachment] = captured["transcript_attachments"]
+    assert attachment["box"] == "inbox"
+    assert attachment["name"] == "notes.txt"
+    assert attachment["source_surface"] == "telegram"
+    assert attachment["source_message_id"] == "2"
+    assert attachment["source_thread_id"] == "20"


### PR DESCRIPTION
## Summary
- make Linux systemd hub/Telegram templates always-restarting with restart limits
- add a Discord systemd template and document canonical hub-owned chat surface setup
- add Linux systemd doctor checks for inactive enabled chat units and hub port cgroup ownership

Closes #2054

## Validation
- `.venv/bin/python -m pytest -q tests/core/test_systemd_diagnostics.py tests/adapters/discord/test_doctor_checks.py tests/test_doctor_checks.py tests/test_config_resolution.py`
- pre-commit aggregate lane: guardrails, black, ruff, import boundaries, mypy, pytest, frontend build/tests, SPA shell check