### PR TITLE
Wake SCM queued managed turns

### DIFF
--- a/src/codex_autorunner/adapters/github/polling.py
+++ b/src/codex_autorunner/adapters/github/polling.py
@@ -239,9 +239,11 @@ class GitHubScmPollingService:
         github_service_factory: Optional[GitHubServiceFactory] = None,
         watch_store: Optional[ScmPollingWatchStore] = None,
         event_store: Optional[ScmEventStore] = None,
+        queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._hub_root = Path(hub_root)
         self._raw_config = raw_config or {}
+        self._queue_worker_starter_fn = queue_worker_starter_fn
         if github_service_factory is None:
             from .service import GitHubService
 
@@ -274,6 +276,7 @@ class GitHubScmPollingService:
             checkout_root=checkout_root,
             reaction_config=reaction_config or self._raw_config,
             publish_executor_factory=build_github_publish_executors,
+            queue_worker_starter_fn=self._queue_worker_starter_fn,
             schedule_deferred_publish_drain=True,
         )
 
@@ -1122,10 +1125,15 @@ def build_hub_scm_poll_processor(
     hub_root: Path,
     raw_config: Optional[dict[str, Any]] = None,
 ):
-    def processor(limit: int = 20) -> dict[str, int]:
+    def processor(
+        limit: int = 20,
+        *,
+        queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
+    ) -> dict[str, int]:
         return GitHubScmPollingService(
             hub_root,
             raw_config=raw_config,
+            queue_worker_starter_fn=queue_worker_starter_fn,
         ).process(limit=limit)
 
     return processor

--- a/src/codex_autorunner/adapters/github/publisher.py
+++ b/src/codex_autorunner/adapters/github/publisher.py
@@ -356,8 +356,12 @@ def build_github_enqueue_managed_turn_executor(
     *,
     hub_root: Path,
     raw_config: Optional[dict[str, Any]] = None,
+    queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
 ) -> PublishActionExecutor:
-    base_executor = build_enqueue_managed_turn_executor(hub_root=hub_root)
+    base_executor = build_enqueue_managed_turn_executor(
+        hub_root=hub_root,
+        queue_worker_starter_fn=queue_worker_starter_fn,
+    )
 
     def executor(operation: PublishOperation) -> Optional[dict[str, Any]]:
         from ..chat.bound_live_progress import bound_chat_live_progress_targets
@@ -429,11 +433,13 @@ def build_github_publish_executors(
     checkout_root: Path,
     raw_config: Optional[dict[str, Any]] = None,
     github_service_factory: Optional[GitHubServiceFactory] = None,
+    queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
 ) -> dict[str, PublishActionExecutor]:
     return {
         "enqueue_managed_turn": build_github_enqueue_managed_turn_executor(
             hub_root=hub_root,
             raw_config=raw_config,
+            queue_worker_starter_fn=queue_worker_starter_fn,
         ),
         "react_pr_review_comment": build_react_pr_review_comment_executor(
             checkout_root=checkout_root,

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -1,11 +1,12 @@
 import asyncio
+import inspect
 import logging
 import sqlite3
 import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 from ..discovery import discover_and_init
 from ..manifest import Manifest
@@ -857,6 +858,15 @@ class HubSupervisor:
                 "rate_limited_skipped": 0,
             }
         try:
+            if "queue_worker_starter_fn" in inspect.signature(processor).parameters:
+                processor_with_starter: Any = processor
+                return cast(
+                    dict[str, int],
+                    processor_with_starter(
+                        limit,
+                        queue_worker_starter_fn=self._request_managed_thread_queue_worker_start,
+                    ),
+                )
             return processor(limit)
         except (RuntimeError, OSError, ValueError, TypeError, sqlite3.Error):
             logger.exception("Failed processing SCM automation polling watches")

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -1004,8 +1004,17 @@ def build_enqueue_managed_turn_executor(
     *,
     hub_root: Path,
     thread_store: Optional[ManagedThreadStore] = None,
+    queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
 ) -> PublishActionExecutor:
     store = thread_store or ManagedThreadStore(hub_root)
+
+    def _request_queue_worker_start(result: Mapping[str, Any]) -> None:
+        if not result.get("queued") or queue_worker_starter_fn is None:
+            return
+        thread_target_id = _normalize_optional_text(result.get("thread_target_id"))
+        if thread_target_id is None:
+            return
+        queue_worker_starter_fn(thread_target_id)
 
     def executor(operation: PublishOperation) -> dict[str, Any]:
         payload = _normalize_mapping(operation.payload)
@@ -1030,13 +1039,15 @@ def build_enqueue_managed_turn_executor(
         client_request_id = _operation_digest(operation, prefix="publish-turn")
         existing = store.get_turn_by_client_turn_id_any_thread(client_request_id)
         if existing is not None:
-            return _managed_turn_result(
+            result = _managed_turn_result(
                 thread_target_id=existing["managed_thread_id"],
                 client_request_id=client_request_id,
                 turn=existing,
                 existed=True,
                 correlation_id=correlation_id,
             )
+            _request_queue_worker_start(result)
+            return result
         runtime_status = _thread_runtime_status(_active_thread)
         log_context = (
             correlation_id,
@@ -1078,7 +1089,7 @@ def build_enqueue_managed_turn_executor(
                     payload=queue_payload,
                 )
                 if merged_turn is not None:
-                    return _managed_turn_result(
+                    result = _managed_turn_result(
                         thread_target_id=thread_target_id,
                         client_request_id=(
                             _normalize_optional_text(merged_turn.get("client_turn_id"))
@@ -1089,6 +1100,8 @@ def build_enqueue_managed_turn_executor(
                         correlation_id=correlation_id,
                         turn_request=request,
                     )
+                    _request_queue_worker_start(result)
+                    return result
             created = store.create_turn(
                 thread_target_id,
                 prompt=request.prompt_text or "",
@@ -1149,6 +1162,7 @@ def build_enqueue_managed_turn_executor(
                     turn_request=request,
                 )
                 result["rebound_from_thread_target_id"] = rebound_from_thread_target_id
+                _request_queue_worker_start(result)
                 return result
             created = store.create_turn(
                 thread_target_id,
@@ -1187,6 +1201,7 @@ def build_enqueue_managed_turn_executor(
         )
         if rebound_from_thread_target_id is not None:
             result["rebound_from_thread_target_id"] = rebound_from_thread_target_id
+        _request_queue_worker_start(result)
         return result
 
     return executor

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional, Protocol
+from typing import Any, Callable, Optional, Protocol
 
 from .automation import (
     AutomationEvent,
@@ -167,6 +167,7 @@ class PublishExecutorFactory(Protocol):
         hub_root: Path,
         checkout_root: Path,
         raw_config: Optional[dict[str, Any]] = None,
+        queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
     ) -> Mapping[str, PublishActionExecutor]: ...
 
 
@@ -1305,10 +1306,14 @@ def _default_publish_processor(
     journal: PublishJournalStore,
     publish_executor_factory: Optional[PublishExecutorFactory] = None,
     checkout_root: Optional[Path] = None,
+    queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
 ) -> PublishOperationProcessor:
     raw_config = load_hub_config(hub_root).raw
     executors: dict[str, PublishActionExecutor] = {
-        "enqueue_managed_turn": build_enqueue_managed_turn_executor(hub_root=hub_root),
+        "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+            hub_root=hub_root,
+            queue_worker_starter_fn=queue_worker_starter_fn,
+        ),
         "notify_chat": build_notify_chat_executor(hub_root=hub_root),
     }
     if publish_executor_factory is not None:
@@ -1319,6 +1324,7 @@ def _default_publish_processor(
                     hub_root=hub_root,
                     checkout_root=checkout_root or hub_root,
                     raw_config=raw_config,
+                    queue_worker_starter_fn=queue_worker_starter_fn,
                 ).items()
             }
         )
@@ -1363,6 +1369,7 @@ class ScmAutomationService:
         checkout_root: Optional[Path] = None,
         automation_store: Optional[AutomationStore] = None,
         automation_rule_engine: Optional[ScmAutomationRuleEvaluator] = None,
+        queue_worker_starter_fn: Optional[Callable[[str], None]] = None,
         schedule_deferred_publish_drain: bool = False,
     ) -> None:
         self._hub_root = Path(hub_root)
@@ -1395,6 +1402,7 @@ class ScmAutomationService:
                 journal=resolved_journal,
                 publish_executor_factory=publish_executor_factory,
                 checkout_root=self._checkout_root,
+                queue_worker_starter_fn=queue_worker_starter_fn,
             )
         else:
             raise TypeError(

--- a/src/codex_autorunner/surfaces/web/services/hub_startup.py
+++ b/src/codex_autorunner/surfaces/web/services/hub_startup.py
@@ -791,10 +791,26 @@ class HubStartupService:
         )
         if not callable(register_starter):
             return None
+        loop = asyncio.get_running_loop()
 
         def _start_queue_worker(thread_id: str) -> None:
+            def _on_loop() -> None:
+                try:
+                    ensure_managed_thread_queue_worker(app, thread_id)
+                except (
+                    RuntimeError,
+                    TypeError,
+                    AttributeError,
+                ) as exc:  # intentional: external callback must not crash
+                    safe_log(
+                        app.state.logger,
+                        logging.WARNING,
+                        "Managed-thread queue worker startup failed",
+                        exc,
+                    )
+
             try:
-                ensure_managed_thread_queue_worker(app, thread_id)
+                loop.call_soon_threadsafe(_on_loop)
             except (
                 RuntimeError,
                 TypeError,
@@ -803,7 +819,7 @@ class HubStartupService:
                 safe_log(
                     app.state.logger,
                     logging.WARNING,
-                    "Managed-thread queue worker startup failed",
+                    "Managed-thread queue worker startup dispatch failed",
                     exc,
                 )
 

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -1039,6 +1039,47 @@ def test_enqueue_managed_turn_executor_queues_on_running_scm_thread(
     )
 
 
+def test_enqueue_managed_turn_executor_starts_worker_for_queued_scm_turn(
+    tmp_path: Path,
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = ManagedThreadStore(hub_root)
+    thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        metadata={"head_branch": "feature/scm-rebind"},
+    )
+    thread_store.create_turn(thread["managed_thread_id"], prompt="already running")
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=thread["managed_thread_id"],
+    )
+    operation = _create_scm_enqueue_operation(
+        journal=PublishJournalStore(hub_root),
+        thread_target_id=thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
+        operation_key="enqueue:scm:worker-start",
+    )
+    started_threads: list[str] = []
+
+    result = build_enqueue_managed_turn_executor(
+        hub_root=hub_root,
+        thread_store=thread_store,
+        queue_worker_starter_fn=started_threads.append,
+    )(operation)
+
+    assert result["queued"] is True
+    assert started_threads == [thread["managed_thread_id"]]
+
+
 def test_enqueue_managed_turn_executor_merges_into_existing_queued_scm_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/surfaces/web/test_hub_startup_service.py
+++ b/tests/surfaces/web/test_hub_startup_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+import threading
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -133,6 +135,59 @@ async def test_deferred_startup_continues_after_managed_thread_restore_failure(
 
     assert app.state.hub_deferred_startup_complete is True
     assert "Managed-thread queue worker restore failed at hub startup" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_managed_thread_queue_starter_marshals_to_event_loop_from_background_thread(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    context = _make_context(tmp_path)
+    app = _make_app(context)
+
+    captured_starters: list[Callable[[str], None]] = []
+    loop_thread_id = threading.get_ident()
+    observed: dict[str, int | str] = {}
+    started = asyncio.Event()
+
+    app.state.hub_supervisor = SimpleNamespace(
+        set_managed_thread_queue_worker_starter=lambda starter: captured_starters.append(
+            starter
+        ),
+    )
+
+    def _fake_ensure(_app: object, thread_id: str) -> None:
+        observed["thread_id"] = thread_id
+        observed["caller_thread"] = threading.get_ident()
+        started.set()
+
+    monkeypatch.setattr(hub_startup, "ensure_managed_thread_queue_worker", _fake_ensure)
+
+    service = hub_startup.HubStartupService(
+        context=context,
+        mount_manager=_FakeMountManager(),
+        endpoint_host=None,
+        endpoint_port=None,
+        base_path=None,
+    )
+
+    service._register_managed_thread_queue_starter(app)
+    assert len(captured_starters) == 1
+    starter = captured_starters[0]
+
+    background_thread_id: list[int] = []
+
+    def _invoke_from_background() -> None:
+        background_thread_id.append(threading.get_ident())
+        starter("thread-scm")
+
+    bg = threading.Thread(target=_invoke_from_background)
+    bg.start()
+    bg.join(timeout=5.0)
+
+    await asyncio.wait_for(started.wait(), timeout=5.0)
+    assert observed["thread_id"] == "thread-scm"
+    assert observed["caller_thread"] == loop_thread_id
+    assert observed["caller_thread"] != background_thread_id[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -3582,6 +3582,52 @@ def test_process_automation_timers_processes_due_unified_schedules(
         supervisor.shutdown()
 
 
+def test_process_scm_polls_passes_registered_queue_worker_starter(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _write_default_hub_config(hub_root)
+    captured: dict[str, object] = {}
+
+    def _processor(limit: int = 20, *, queue_worker_starter_fn=None):
+        captured["limit"] = limit
+        captured["queue_worker_starter_fn"] = queue_worker_starter_fn
+        if queue_worker_starter_fn is not None:
+            queue_worker_starter_fn("thread-scm")
+        return {
+            "due": 1,
+            "polled": 1,
+            "events_emitted": 1,
+            "expired": 0,
+            "closed": 0,
+            "errors": 0,
+            "candidate_workspaces": 0,
+            "candidate_workspaces_scanned": 0,
+            "bindings_discovered": 0,
+            "watches_armed": 0,
+            "discovery_errors": 0,
+            "invalid_bindings_skipped": 0,
+            "rate_limited_skipped": 0,
+        }
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        scm_poll_processor=_processor,
+    )
+    started_threads: list[str] = []
+    try:
+        supervisor.set_managed_thread_queue_worker_starter(started_threads.append)
+
+        result = supervisor.process_scm_automation_polls(limit=3)
+
+        assert result["events_emitted"] == 1
+        assert captured["limit"] == 3
+        assert callable(captured["queue_worker_starter_fn"])
+        assert started_threads == ["thread-scm"]
+    finally:
+        supervisor.shutdown()
+
+
 def _seed_due_managed_thread_schedule(hub_root: Path) -> str:
     store = AutomationStore(hub_root)
     thread = ManagedThreadStore(hub_root).create_thread("codex", hub_root)


### PR DESCRIPTION
## Summary
- thread the managed-thread queue worker starter through SCM publish enqueue executors
- pass the registered hub queue-worker starter into GitHub polling at poll time
- add regressions proving queued SCM enqueues and SCM poll processing request worker startup

## Root Cause
SCM automation could create a queued managed turn for a bound PR thread without waking that thread's queue worker. The webhook inline drain path had an after-the-fact worker ensure, but the publish executor used by GitHub polling and deferred SCM drains only persisted the queued turn and returned success. `notify_chat` then waited for the enqueue dependency to reach confirmed runtime start, but the turn stayed queued until the dependency timeout, producing the reported "managed turn stayed queued" failure.

## Validation
- `.venv/bin/python -m pytest -q tests/core/test_publish_executor.py tests/core/test_scm_automation_service.py tests/surfaces/web/services/test_scm_webhook_service.py tests/adapters/github/test_polling.py::test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat tests/adapters/github/test_polling.py::test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_comments tests/test_hub_supervisor.py::test_process_scm_polls_passes_registered_queue_worker_starter`
- `.venv/bin/python -m ruff check src/codex_autorunner/core/publish_operation_executors.py src/codex_autorunner/core/scm_automation_service.py src/codex_autorunner/adapters/github/publisher.py src/codex_autorunner/adapters/github/polling.py src/codex_autorunner/core/hub.py tests/core/test_publish_executor.py tests/test_hub_supervisor.py`
- `.venv/bin/python -m black --check src/codex_autorunner/core/publish_operation_executors.py src/codex_autorunner/core/scm_automation_service.py src/codex_autorunner/adapters/github/publisher.py src/codex_autorunner/adapters/github/polling.py src/codex_autorunner/core/hub.py tests/core/test_publish_executor.py tests/test_hub_supervisor.py`
- pre-commit core lane: guardrails, strict mypy, and `pytest -m "not integration and not slow"` (`9953 passed`)
