### PR TITLE
Send Telegram and Discord messages without replies

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -98,6 +98,11 @@ _AUTO_WORKERS="$("$PYTHON_BIN" -c 'import os;print(os.cpu_count() or 4)' 2>/dev/
 FAST_TEST_WORKERS="${CODEX_FAST_TEST_WORKERS:-$_AUTO_WORKERS}"
 export CAR_PYTEST_RUN_TOKEN="${CAR_PYTEST_RUN_TOKEN:-check-$("$PYTHON_BIN" -c 'import uuid; print(uuid.uuid4().hex[:8])')}"
 FAST_TEST_BASETEMP="$("$PYTHON_BIN" scripts/pytest_basetemp.py --repo-root "$REPO_ROOT")"
+CHAT_APPS_PYTEST_RUN_TOKEN="${CAR_PYTEST_RUN_TOKEN}-chat-apps"
+CHAT_APPS_PYTEST_BASETEMP="$(
+  CAR_PYTEST_RUN_TOKEN="$CHAT_APPS_PYTEST_RUN_TOKEN" \
+    "$PYTHON_BIN" scripts/pytest_basetemp.py --repo-root "$REPO_ROOT"
+)"
 STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACMRD 2>/dev/null || true)"
 
 # --- Lane detection (if not explicitly set) ----------------------------------
@@ -373,7 +378,10 @@ _run_chat_apps_lane() {
     echo "Run 'make test-chat-surface-lab' or set CODEX_CHECK_RUN_CHAT_SURFACE_LAB=1 to include it."
   else
     echo "Running chat-surface lab deterministic checks..."
-    make test-chat-surface-lab PYTHON="$PYTHON_BIN"
+    make test-chat-surface-lab \
+      PYTHON="$PYTHON_BIN" \
+      CAR_PYTEST_RUN_TOKEN="$CHAT_APPS_PYTEST_RUN_TOKEN" \
+      PYTEST_BASETEMP="$CHAT_APPS_PYTEST_BASETEMP"
   fi
 }
 

--- a/src/codex_autorunner/adapters/discord/adapter.py
+++ b/src/codex_autorunner/adapters/discord/adapter.py
@@ -530,12 +530,6 @@ class DiscordChatAdapter(ChatAdapter):
                     payload["components"] = self._build_action_components(
                         request.actions
                     )
-                if request.reply_to and idx == 0:
-                    payload["message_reference"] = {
-                        "message_id": request.reply_to.message_id,
-                        "channel_id": channel_id,
-                    }
-
                 response = await self._rest.create_channel_message(
                     channel_id=channel_id, payload=payload
                 )

--- a/src/codex_autorunner/adapters/discord/channel_messaging.py
+++ b/src/codex_autorunner/adapters/discord/channel_messaging.py
@@ -18,6 +18,9 @@ async def send_channel_message(
     payload: dict[str, Any],
 ) -> dict[str, Any]:
     payload = dict(payload)
+    # CAR responses are standalone messages. Inbound message references are
+    # still parsed for routing/context, but never carry into outbound sends.
+    payload.pop("message_reference", None)
     content = payload.get("content")
     if isinstance(content, str):
         payload["content"] = sanitize_discord_outbound_text(content)

--- a/src/codex_autorunner/adapters/discord/outbox.py
+++ b/src/codex_autorunner/adapters/discord/outbox.py
@@ -77,6 +77,7 @@ def _discord_send_payload(payload_json: dict[str, Any]) -> dict[str, Any]:
     send_payload = dict(payload_json)
     send_payload.pop(_OUTBOX_PROGRESS_KEY, None)
     send_payload.pop(_OUTBOX_CLEANUP_KEY, None)
+    send_payload.pop("message_reference", None)
     return send_payload
 
 

--- a/src/codex_autorunner/adapters/telegram/client.py
+++ b/src/codex_autorunner/adapters/telegram/client.py
@@ -1269,8 +1269,6 @@ class TelegramBotClient:
         }
         if message_thread_id is not None:
             payload["message_thread_id"] = message_thread_id
-        if reply_to_message_id is not None:
-            payload["reply_to_message_id"] = reply_to_message_id
         if reply_markup is not None:
             payload["reply_markup"] = reply_markup
         if parse_mode is not None:
@@ -1304,8 +1302,6 @@ class TelegramBotClient:
         data: dict[str, Any] = {"chat_id": chat_id}
         if message_thread_id is not None:
             data["message_thread_id"] = message_thread_id
-        if reply_to_message_id is not None:
-            data["reply_to_message_id"] = reply_to_message_id
         if caption is not None:
             data["caption"] = caption
         if parse_mode is not None:

--- a/tests/adapters/discord/test_adapter.py
+++ b/tests/adapters/discord/test_adapter.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
-from codex_autorunner.adapters.chat.models import ChatMessageEvent
+from codex_autorunner.adapters.chat.adapter import SendTextRequest
+from codex_autorunner.adapters.chat.models import (
+    ChatMessageEvent,
+    ChatMessageRef,
+    ChatThreadRef,
+)
 from codex_autorunner.adapters.chat.renderer import RenderedText
 from codex_autorunner.adapters.discord import adapter as discord_adapter_module
 from codex_autorunner.adapters.discord.adapter import (
     DiscordChatAdapter,
     DiscordTextRenderer,
 )
+from codex_autorunner.adapters.discord.channel_messaging import send_channel_message
 
 
 class _UnusedRestClient:
@@ -29,6 +36,17 @@ class _FollowupRestClient:
         _ = (application_id, interaction_token, payload)
         self.calls += 1
         return {"id": f"message-{self.calls}", "channel_id": "channel-1"}
+
+
+class _ChannelMessageRestClient:
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, object]] = []
+
+    async def create_channel_message(
+        self, *, channel_id: str, payload: dict[str, object]
+    ) -> dict[str, object]:
+        self.payloads.append({"channel_id": channel_id, **payload})
+        return {"id": f"message-{len(self.payloads)}"}
 
 
 def _message_payload(
@@ -305,6 +323,52 @@ def test_discord_text_renderer_split_text_has_no_part_prefix() -> None:
 
     assert len(chunks) > 1
     assert all(not chunk.text.startswith("Part ") for chunk in chunks)
+
+
+def test_adapter_sends_text_without_message_reference() -> None:
+    rest = _ChannelMessageRestClient()
+    adapter = DiscordChatAdapter(
+        rest_client=rest,  # type: ignore[arg-type]
+        application_id="app-1",
+    )
+    thread = ChatThreadRef(platform="discord", chat_id="channel-1")
+    reply_ref = ChatMessageRef(thread=thread, message_id="origin-1")
+
+    async def _send() -> None:
+        await adapter.send_text(
+            SendTextRequest(
+                thread=thread,
+                text="standalone response",
+                reply_to=reply_ref,
+            )
+        )
+
+    asyncio.run(_send())
+
+    assert rest.payloads == [
+        {"channel_id": "channel-1", "content": "standalone response"}
+    ]
+
+
+def test_channel_sender_drops_stale_message_reference() -> None:
+    rest = _ChannelMessageRestClient()
+
+    async def _send() -> None:
+        await send_channel_message(
+            rest,
+            logging.getLogger("test"),
+            "channel-1",
+            {
+                "content": "standalone response",
+                "message_reference": {"message_id": "origin-1"},
+            },
+        )
+
+    asyncio.run(_send())
+
+    assert rest.payloads == [
+        {"channel_id": "channel-1", "content": "standalone response"}
+    ]
 
 
 def test_adapter_prunes_interaction_token_cache(monkeypatch) -> None:

--- a/tests/adapters/discord/test_outbox_retry.py
+++ b/tests/adapters/discord/test_outbox_retry.py
@@ -312,6 +312,52 @@ async def test_outbox_retry_resumes_from_first_unsent_chunk(tmp_path: Path) -> N
 
 
 @pytest.mark.anyio
+async def test_outbox_replay_drops_stale_reference_from_every_chunk(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    clock = _Clock()
+    sent_payloads: list[dict] = []
+
+    async def send_message(_channel_id: str, payload: dict) -> dict:
+        sent_payloads.append(payload)
+        return {"id": f"msg-{len(sent_payloads)}"}
+
+    manager = DiscordOutboxManager(
+        store,
+        send_message=send_message,
+        logger=logging.getLogger("test"),
+        now_fn=clock.now,
+        sleep_fn=clock.sleep,
+    )
+
+    try:
+        await store.initialize()
+        content = ("a" * 1500) + "\n" + ("b" * 1500)
+        await store.enqueue_outbox(
+            OutboxRecord(
+                record_id="stale-reply-1",
+                channel_id="chan-1",
+                message_id=None,
+                operation="send",
+                payload_json={
+                    "content": content,
+                    "message_reference": {"message_id": "origin-1"},
+                },
+                created_at=now_iso(),
+            )
+        )
+
+        await manager._flush(await store.list_outbox())
+
+        assert len(sent_payloads) == 2
+        assert all("message_reference" not in payload for payload in sent_payloads)
+        assert await store.get_outbox("stale-reply-1") is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_flush_drops_previously_exhausted_record(tmp_path: Path) -> None:
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
     clock = _Clock()

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -3724,7 +3724,7 @@ async def test_car_agent_without_name_returns_picker_when_bound(tmp_path: Path) 
         menu = components[0]["components"][0]
         assert menu["custom_id"] == "agent_select"
         values = {opt["value"] for opt in menu["options"]}
-        assert values == {"codex", "opencode", "hermes"}
+        assert values == {"codex", "opencode", "hermes", "omp"}
     finally:
         await store.close()
 

--- a/tests/core/test_pma_tail_serialization.py
+++ b/tests/core/test_pma_tail_serialization.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import time
-
 from codex_autorunner.core.orchestration.progress_projection import (
     ProgressProjectionItem,
 )
@@ -12,6 +10,26 @@ from codex_autorunner.core.pma.tail_serialization import (
     build_live_activity_projection,
 )
 from codex_autorunner.core.ports.run_event import Interrupted
+
+
+class _CountingId(str):
+    comparisons = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).comparisons += 1
+        return super().__eq__(other)
+
+    __hash__ = str.__hash__
+
+
+class _CountingEventId(int):
+    comparisons = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).comparisons += 1
+        return super().__eq__(other)
+
+    __hash__ = int.__hash__
 
 
 def test_live_activity_coalesces_only_assistant_updates() -> None:
@@ -106,14 +124,16 @@ def test_persisted_tail_serializes_turn_interrupted_as_interrupted_event() -> No
 
 
 def test_grouped_progress_tail_event_collects_ids_linearly() -> None:
+    _CountingId.comparisons = 0
+    _CountingEventId.comparisons = 0
     grouped_items = [
         ProgressProjectionItem(
-            item_id=f"tool:{idx % 700}",
+            item_id=_CountingId(f"tool:{idx % 700}"),
             kind="tool",
             state="completed",
             title="Tool completed",
             summary=f"Tool {idx}",
-            event_ids=(idx, idx + 1),
+            event_ids=(_CountingEventId(idx), _CountingEventId(idx + 1)),
             timestamp="2026-06-25T00:00:00+00:00",
             group_id="group-1",
             group_kind="tool",
@@ -122,16 +142,15 @@ def test_grouped_progress_tail_event_collects_ids_linearly() -> None:
         for idx in range(1, 5001)
     ]
 
-    started = time.perf_counter()
     payload = _tail_event_from_progress_item(
         grouped_items[-1],
         received_at="2026-06-25T00:00:00+00:00",
         progress_items=grouped_items,
     )
-    elapsed = time.perf_counter() - started
 
     assert payload["progress_item_ids"][:3] == ["tool:1", "tool:2", "tool:3"]
     assert len(payload["progress_item_ids"]) == 700
     assert payload["progress_event_ids"][:3] == [1, 2, 3]
     assert payload["progress_event_ids"][-1] == 5001
-    assert elapsed < 1.0
+    assert _CountingId.comparisons < len(grouped_items) * 4
+    assert _CountingEventId.comparisons < len(grouped_items) * 4

--- a/tests/test_pytest_basetemp_script.py
+++ b/tests/test_pytest_basetemp_script.py
@@ -29,3 +29,14 @@ def test_pytest_basetemp_script_prints_run_scoped_path(
     assert basetemp.parent.name == run_token
     assert basetemp.parent.parent.name == "t"
     assert basetemp.parent.parent.parent.name.startswith("cp-")
+
+
+def test_check_script_gives_parallel_chat_apps_lane_a_disjoint_basetemp() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    check_script = (repo_root / "scripts" / "check.sh").read_text()
+
+    assert (
+        'CHAT_APPS_PYTEST_RUN_TOKEN="${CAR_PYTEST_RUN_TOKEN}-chat-apps"' in check_script
+    )
+    assert 'CAR_PYTEST_RUN_TOKEN="$CHAT_APPS_PYTEST_RUN_TOKEN"' in check_script
+    assert 'PYTEST_BASETEMP="$CHAT_APPS_PYTEST_BASETEMP"' in check_script

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -507,6 +507,7 @@ async def test_send_message_chunks_long_text() -> None:
         response = await client.send_message(
             123,
             text,
+            reply_to_message_id=456,
             reply_markup={"inline_keyboard": [[{"text": "OK", "callback_data": "ok"}]]},
             parse_mode="Markdown",
         )
@@ -517,6 +518,8 @@ async def test_send_message_chunks_long_text() -> None:
     assert len(calls) == 2
     first_payload = calls[0]["payload"]
     second_payload = calls[1]["payload"]
+    assert "reply_to_message_id" not in first_payload
+    assert "reply_to_message_id" not in second_payload
     assert "reply_markup" in first_payload
     assert "reply_markup" not in second_payload
     assert isinstance(first_payload.get("text"), str)

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -457,9 +457,12 @@ async def test_normal_message_runs_turn(tmp_path: Path) -> None:
     bind_message = build_message("/bind", message_id=10)
     try:
         await service._handle_bind(bind_message, str(repo))
-        new_message = build_message("/new", message_id=11)
-        with pytest.raises(RuntimeError, match="orchestration service unavailable"):
-            await service._handle_new(new_message)
+        key = await service._router.resolve_key(
+            bind_message.chat_id, bind_message.thread_id
+        )
+        runtime = service._router.runtime_for(key)
+        message = build_message("hello", message_id=11)
+        await service._handle_normal_message(message, runtime)
         await _drain_spawned_tasks(service)
         await _wait_for_bot_text(fake_bot, "fixture reply")
     finally:
@@ -986,6 +989,7 @@ async def test_photo_batch_inbox_save_failure_still_processes_image(
         transcript_message_id: Optional[int] = None,
         transcript_text: Optional[str] = None,
         placeholder_id: Optional[int] = None,
+        transcript_attachments: Optional[list[dict[str, object]]] = None,
     ) -> None:
         captured["text_override"] = text_override
         captured["input_items"] = input_items

--- a/tests/test_telegram_chat_adapter_ops.py
+++ b/tests/test_telegram_chat_adapter_ops.py
@@ -31,11 +31,13 @@ class _DummyPoller:
 @pytest.mark.anyio
 async def test_adapter_ops_call_expected_telegram_methods(tmp_path: Path) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
+    multipart_bodies: list[bytes] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
         method = request.url.path.rsplit("/", 1)[-1]
         if method == "sendDocument":
             payload = {"_multipart": True}
+            multipart_bodies.append(request.content)
         elif request.content:
             payload = json.loads(request.content.decode("utf-8"))
         else:
@@ -93,13 +95,17 @@ async def test_adapter_ops_call_expected_telegram_methods(tmp_path: Path) -> Non
     send_payload = calls[0][1]
     assert send_payload["chat_id"] == 123
     assert send_payload["message_thread_id"] == 45
-    assert send_payload["reply_to_message_id"] == 12
+    assert "reply_to_message_id" not in send_payload
     assert send_payload["parse_mode"] == "Markdown"
     assert send_payload["reply_markup"]["inline_keyboard"][0][0]["text"] == "Resume"
     assert (
         send_payload["reply_markup"]["inline_keyboard"][0][0]["callback_data"]
         == "resume:1"
     )
+
+    document_payload = calls[3][1]
+    assert "reply_to_message_id" not in document_payload
+    assert b"reply_to_message_id" not in multipart_bodies[0]
 
     edit_payload = calls[1][1]
     assert edit_payload["chat_id"] == 123


### PR DESCRIPTION
## Summary

- Send CAR Telegram messages as standalone messages, including chunked replies and document uploads.
- Send CAR Discord messages without outbound reply references, including shared sender and outbox replay paths.
- Make the pre-commit hook reliable by isolating pytest temp directories and refreshing stale deterministic test expectations.

## Why

Reply metadata forces noisy notifications. Standalone messages are less disruptive while inbound reply context remains available for routing and context.

## Validation

- Normal pre-commit hook passed end-to-end.
- Core checks: 10,001 tests passed, plus Ruff, Black, and mypy.
- Web Hub checks passed, including build and 1,010 Vitest tests.
- Focused regression suite: 116 passed.
- Chat surface lab: 20 passed; latency suite green (7/7).