### PR TITLE
fix(opencode): never evict supervisor handles with active turns in flight

### DIFF
--- a/src/codex_autorunner/agents/opencode/supervisor.py
+++ b/src/codex_autorunner/agents/opencode/supervisor.py
@@ -1548,6 +1548,7 @@ class OpenCodeSupervisor:
             self._logger,
             "opencode",
             last_used_at_getter=lambda h: h.last_used_at or 0.0,
+            active_getter=lambda h: h.active_turns > 0,
         )
 
     def _handle_mode(self, handle: OpenCodeHandle) -> str:

--- a/tests/test_opencode_handle_eviction.py
+++ b/tests/test_opencode_handle_eviction.py
@@ -1,0 +1,93 @@
+"""OpenCode supervisor handle-eviction behavior.
+
+Regression tests: eviction driven by ``max_handles`` must never pick a
+handle that has active turns in flight. Evicting a busy handle terminates
+its managed OpenCode server mid-turn and surfaces as
+``Cannot send a request, as the client has been closed.``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from codex_autorunner.agents.opencode.supervisor import (
+    OpenCodeHandle,
+    OpenCodeSupervisor,
+)
+
+
+def _make_handle(
+    workspace_id: str, *, active_turns: int = 0, last_used_at: float = 0.0
+) -> OpenCodeHandle:
+    return OpenCodeHandle(
+        workspace_id=workspace_id,
+        workspace_root=Path(f"/tmp/opencode-{workspace_id}"),
+        process=None,
+        client=None,
+        managed_process_record=None,
+        base_url=None,
+        health_info=None,
+        version=None,
+        openapi_spec=None,
+        start_lock=asyncio.Lock(),
+        stdout_task=None,
+        last_used_at=last_used_at,
+        active_turns=active_turns,
+    )
+
+
+def _make_supervisor(max_handles: int) -> OpenCodeSupervisor:
+    return OpenCodeSupervisor(
+        command=["opencode", "serve"],
+        logger=logging.getLogger("test.opencode-eviction"),
+        max_handles=max_handles,
+    )
+
+
+class TestEvictLRUHandle:
+    def test_idle_handle_evicted_when_at_capacity(self) -> None:
+        supervisor = _make_supervisor(max_handles=1)
+        supervisor._handles["ws-a"] = _make_handle("ws-a", last_used_at=10.0)
+
+        evicted = supervisor._evict_lru_handle_locked()
+
+        assert evicted is not None
+        assert evicted.workspace_id == "ws-a"
+
+    def test_busy_handle_is_never_evicted(self) -> None:
+        supervisor = _make_supervisor(max_handles=1)
+        supervisor._handles["ws-a"] = _make_handle(
+            "ws-a", active_turns=1, last_used_at=10.0
+        )
+
+        evicted = supervisor._evict_lru_handle_locked()
+
+        assert evicted is None
+        assert "ws-a" in supervisor._handles
+
+    def test_busiest_workspace_survives_when_only_candidate_is_busy(self) -> None:
+        supervisor = _make_supervisor(max_handles=1)
+        # ws-a is older but busy; ws-b is newer but idle.
+        supervisor._handles["ws-a"] = _make_handle(
+            "ws-a", active_turns=2, last_used_at=1.0
+        )
+        supervisor._handles["ws-b"] = _make_handle(
+            "ws-b", active_turns=0, last_used_at=100.0
+        )
+
+        evicted = supervisor._evict_lru_handle_locked()
+
+        # At capacity, only ws-b is evictable; busy ws-a must survive.
+        assert evicted is not None
+        assert evicted.workspace_id == "ws-b"
+        assert "ws-a" in supervisor._handles
+
+    def test_eviction_skipped_logs_when_all_handles_busy(self) -> None:
+        supervisor = _make_supervisor(max_handles=1)
+        supervisor._handles["ws-a"] = _make_handle(
+            "ws-a", active_turns=1, last_used_at=10.0
+        )
+
+        assert supervisor._evict_lru_handle_locked() is None


### PR DESCRIPTION
## Problem

The OpenCode supervisor's `max_handles` eviction path (`_evict_lru_handle_locked` in `agents/opencode/supervisor.py`) does not pass `active_getter` to `evict_lru_handle_locked`, unlike the codex `app_server` supervisor which passes `active_getter=lambda h: ... active_turn_count > 0`.

With the default `opencode.max_handles: 1`, starting a turn in a second workspace evicts the LRU handle **even when it has active turns in flight**, terminating its managed OpenCode server mid-turn. In-flight turns then fail with:

```
Cannot send a request, as the client has been closed.
```

## Reproduction (observed on a production hub)

Two concurrent Telegram threads both bound to opencode, on different workspaces:

- t0: thread A (workspace `dtrinity-solidity-workspace`) starts a turn → opencode server spawned for that workspace
- t1: thread B (workspace `codex-autorunner`) starts a turn → supervisor at capacity (max_handles=1) evicts the LRU handle = A's handle, killing A's server
- A's in-flight turn dies mid-stream with `Cannot send a request, as the client has been closed.`
- B's server is spawned; next message on A respawns A's server and kills B's — the two threads kill each other indefinitely

Hub log evidence:
```
opencode.handle.evicted reason=max_handles ... active_turns:1
opencode.handle.closing reason=max_handles ... active_turns:1
```
Orchestration DB also shows a long tail of `Backend thread lost after restart` (110+) correlated with cross-workspace overlap.

## Fix

Pass `active_getter=lambda h: h.active_turns > 0` so busy handles are never eviction candidates, mirroring the app_server supervisor. If every handle is busy, eviction is skipped (emitting the existing `opencode.handle.eviction.skipped reason=active` event) and the new handle is still created — so at-capacity behavior is unchanged for the all-idle case.

## Tests

New `tests/test_opencode_handle_eviction.py`:
- idle handle evicted when at capacity (existing behavior preserved)
- busy handle is never evicted (regression)
- mixed busy/idle at capacity: idle handle selected, busy handle survives (regression)
- all-busy at capacity: eviction skipped

All 4 pass: `pytest tests/test_opencode_handle_eviction.py -v` → `4 passed`.
