### PR TITLE
fix(update): spawn update worker outside the hub systemd cgroup

### DIFF
--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -9,7 +9,7 @@ import sys
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Sequence, Union
 from urllib.parse import unquote, urlparse
 
 from ..git_utils import GitError, run_git
@@ -23,6 +23,7 @@ from ..update_targets import (
 )
 from ..utils import resolve_executable
 from .source import prepare_update_source
+from .supervisors import resolve_systemctl_sudo_prefix
 
 
 class UpdateInProgressError(RuntimeError):
@@ -895,6 +896,50 @@ def _system_update_worker(
     UpdateEngine(config, logger=logger).run()
 
 
+def _build_systemd_run_spawn(
+    *,
+    cmd: Sequence[str],
+    log_path: Path,
+    env: dict[str, str],
+    sudo_prefix: Sequence[str] | None,
+) -> tuple[list[str], dict[str, str]] | None:
+    """Build a systemd-run transient-unit spawn for the update worker.
+
+    When the hub runs under a systemd service (KillMode=control-group by
+    default), a worker spawned with start_new_session=True still shares the
+    service cgroup. The worker later restarts the hub service as part of the
+    update cutover, and systemd's stop kills every process in the cgroup —
+    including the worker itself, before it can run health checks or write the
+    terminal update status. The hub then reconciles the stale "running"
+    status into "Update not running; last update may have crashed."
+
+    Running the worker in its own transient scope unit via systemd-run
+    escapes the hub's cgroup so it survives the service restart.
+    Returns None when systemd-run is unavailable or we are not on Linux.
+    """
+    if platform.system() != "Linux":
+        return None
+    systemd_run = shutil.which("systemd-run")
+    if not systemd_run:
+        return None
+    scope_env = {key: value for key, value in env.items() if key != "INVOCATION_ID"}
+    unit = f"codex-autorunner-update-{int(time.time())}"
+    prefix = list(sudo_prefix) if sudo_prefix else []
+    argv = [
+        *prefix,
+        systemd_run,
+        "--collect",
+        "--unit",
+        unit,
+        "--same-dir",
+        f"--setenv=PYTHONPATH={scope_env.get('PYTHONPATH', '')}",
+        f"--property=StandardOutput=append:{log_path}",
+        f"--property=StandardError=append:{log_path}",
+        *cmd,
+    ]
+    return argv, scope_env
+
+
 def _spawn_update_process(
     *,
     repo_url: str,
@@ -998,6 +1043,21 @@ def _spawn_update_process(
         prepare_update_source(update_dir, repo_url, repo_ref, logger)
         _release_update_lock()
         env = _env_with_source_pythonpath(update_dir)
+        systemd_spawn = _build_systemd_run_spawn(
+            cmd=cmd,
+            log_path=log_path,
+            env=env,
+            sudo_prefix=resolve_systemctl_sudo_prefix(
+                scope="system", configured=systemctl_sudo
+            ),
+        )
+        if systemd_spawn is not None:
+            spawn_argv, spawn_env = systemd_spawn
+            logger.info(
+                "Spawning update worker via systemd-run to escape the hub cgroup"
+            )
+            subprocess.run(spawn_argv, env=spawn_env, check=False, timeout=60)
+            return
         with log_path.open("a", encoding="utf-8") as log_file:
             subprocess.Popen(
                 cmd,

--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -919,7 +919,7 @@ def _build_systemd_run_spawn(
     """
     if platform.system() != "Linux":
         return None
-    systemd_run = shutil.which("systemd-run")
+    systemd_run = resolve_executable("systemd-run")
     if not systemd_run:
         return None
     scope_env = {key: value for key, value in env.items() if key != "INVOCATION_ID"}

--- a/src/codex_autorunner/core/update/_facade.py
+++ b/src/codex_autorunner/core/update/_facade.py
@@ -932,11 +932,26 @@ def _build_systemd_run_spawn(
         "--unit",
         unit,
         "--same-dir",
-        f"--setenv=PYTHONPATH={scope_env.get('PYTHONPATH', '')}",
-        f"--property=StandardOutput=append:{log_path}",
-        f"--property=StandardError=append:{log_path}",
-        *cmd,
     ]
+    if sudo_prefix:
+        # The unit is created as root to escape the service cgroup, but the
+        # worker must keep running as the invoking user so staged venvs and
+        # update caches keep their ownership.
+        argv.extend(
+            [
+                f"--uid={scope_env.get('UID', os.getuid())}",
+                f"--gid={scope_env.get('GID', os.getgid())}",
+            ]
+        )
+    argv.extend(
+        [
+            f"--setenv=HOME={scope_env.get('HOME', os.path.expanduser('~'))}",
+            f"--setenv=PYTHONPATH={scope_env.get('PYTHONPATH', '')}",
+            f"--property=StandardOutput=append:{log_path}",
+            f"--property=StandardError=append:{log_path}",
+            *cmd,
+        ]
+    )
     return argv, scope_env
 
 
@@ -1056,7 +1071,11 @@ def _spawn_update_process(
             logger.info(
                 "Spawning update worker via systemd-run to escape the hub cgroup"
             )
-            subprocess.run(spawn_argv, env=spawn_env, check=False, timeout=60)
+            subprocess.Popen(
+                spawn_argv,
+                env=spawn_env,
+                start_new_session=True,
+            )
             return
         with log_path.open("a", encoding="utf-8") as log_file:
             subprocess.Popen(

--- a/tests/test_update_worker_systemd_run_spawn.py
+++ b/tests/test_update_worker_systemd_run_spawn.py
@@ -22,7 +22,7 @@ from codex_autorunner.core.update import _facade
 
 def _linux_with_systemd_run(monkeypatch, path: str = "/usr/bin/systemd-run") -> None:
     monkeypatch.setattr(_facade.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(_facade.shutil, "which", lambda name: path)
+    monkeypatch.setattr(_facade, "resolve_executable", lambda name, env=None: path)
 
 
 def test_systemd_run_spawn_builds_transient_unit_command(monkeypatch) -> None:
@@ -96,7 +96,7 @@ def test_systemd_run_spawn_returns_none_on_non_linux(monkeypatch) -> None:
 
 def test_systemd_run_spawn_returns_none_without_binary(monkeypatch) -> None:
     monkeypatch.setattr(_facade.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(_facade.shutil, "which", lambda name: None)
+    monkeypatch.setattr(_facade, "resolve_executable", lambda name, env=None: None)
 
     result = _facade._build_systemd_run_spawn(
         cmd=["python3", "-m", "codex_autorunner.core.update.runner"],

--- a/tests/test_update_worker_systemd_run_spawn.py
+++ b/tests/test_update_worker_systemd_run_spawn.py
@@ -1,0 +1,108 @@
+"""Update worker spawn must escape the hub's systemd cgroup.
+
+Regression tests: when the hub runs under a systemd service with
+KillMode=control-group (the default), an update worker spawned with
+``start_new_session=True`` still lives in the service cgroup. The worker
+restarts the hub service during cutover, and systemd's stop kills the whole
+cgroup — including the worker, before it can write the terminal update
+status. The hub then reports:
+
+    Update not running; last update may have crashed.
+
+``_build_systemd_run_spawn`` must produce a systemd-run transient-unit
+command on Linux when systemd-run is available, and ``None`` otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_autorunner.core.update import _facade
+
+
+def _linux_with_systemd_run(monkeypatch, path: str = "/usr/bin/systemd-run") -> None:
+    monkeypatch.setattr(_facade.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(_facade.shutil, "which", lambda name: path)
+
+
+def test_systemd_run_spawn_builds_transient_unit_command(monkeypatch) -> None:
+    _linux_with_systemd_run(monkeypatch)
+
+    result = _facade._build_systemd_run_spawn(
+        cmd=[
+            "python3",
+            "-m",
+            "codex_autorunner.core.update.runner",
+            "--repo-url",
+            "x",
+        ],
+        log_path=Path("/tmp/update-standalone.log"),
+        env={"PYTHONPATH": "/tmp/update-src", "INVOCATION_ID": "abc"},
+        sudo_prefix=["sudo", "-n"],
+    )
+
+    assert result is not None
+    argv, env = result
+
+    assert argv[:3] == ["sudo", "-n", "/usr/bin/systemd-run"]
+    assert "--collect" in argv
+    assert argv[argv.index("--unit") + 1].startswith("codex-autorunner-update-")
+    assert "--same-dir" in argv
+    assert "--setenv=PYTHONPATH=/tmp/update-src" in argv
+    assert "--property=StandardOutput=append:/tmp/update-standalone.log" in argv
+    assert "--property=StandardError=append:/tmp/update-standalone.log" in argv
+    # worker argv is the tail
+    assert argv[argv.index("python3") :] == [
+        "python3",
+        "-m",
+        "codex_autorunner.core.update.runner",
+        "--repo-url",
+        "x",
+    ]
+    # INVOCATION_ID must be stripped so the transient unit is not tied to
+    # the hub service identity
+    assert "INVOCATION_ID" not in env
+    assert env["PYTHONPATH"] == "/tmp/update-src"
+
+
+def test_systemd_run_spawn_without_sudo_prefix(monkeypatch) -> None:
+    _linux_with_systemd_run(monkeypatch)
+
+    result = _facade._build_systemd_run_spawn(
+        cmd=["python3", "-m", "codex_autorunner.core.update.runner"],
+        log_path=Path("/tmp/update-standalone.log"),
+        env={},
+        sudo_prefix=None,
+    )
+
+    assert result is not None
+    argv, _env = result
+    assert argv[0] == "/usr/bin/systemd-run"
+    assert not any(part == "sudo" for part in argv)
+
+
+def test_systemd_run_spawn_returns_none_on_non_linux(monkeypatch) -> None:
+    monkeypatch.setattr(_facade.platform, "system", lambda: "Darwin")
+
+    result = _facade._build_systemd_run_spawn(
+        cmd=["python3", "-m", "codex_autorunner.core.update.runner"],
+        log_path=Path("/tmp/update-standalone.log"),
+        env={},
+        sudo_prefix=None,
+    )
+
+    assert result is None
+
+
+def test_systemd_run_spawn_returns_none_without_binary(monkeypatch) -> None:
+    monkeypatch.setattr(_facade.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(_facade.shutil, "which", lambda name: None)
+
+    result = _facade._build_systemd_run_spawn(
+        cmd=["python3", "-m", "codex_autorunner.core.update.runner"],
+        log_path=Path("/tmp/update-standalone.log"),
+        env={},
+        sudo_prefix=None,
+    )
+
+    assert result is None


### PR DESCRIPTION
## Problem

`_spawn_update_process` spawns the update worker with `start_new_session=True`. That detaches the worker from the hub's **process group**, but not from the hub's **systemd service cgroup** — and the typical hub deployment uses a system systemd unit with the default `KillMode=control-group`.

During cutover the worker runs `systemctl restart <hub-service>`. systemd's stop phase kills every process left in the service cgroup — **including the update worker itself** — before it can run the post-restart health checks and write the terminal update status.

`update_status.json` is left at `"running"`; the next status query hits the reconcile path (`read_status_with_lock_reconcile` / `_facade.py` equivalent) and rewrites it to:

```
Update not running; last update may have crashed.
```

## Reproduction (observed on a production hub, twice)

Aug 5 and Aug 10 staged updates on a Linux hub running under `car-hub.service`:

- All phases OK: source_prep → venv_create → wheel_build → pip_install → candidate_validation → db_snapshot → managed_repo_refresh
- Worker log ends at `Refreshed 32 managed repo(s).` (its last write, timestamped 20:56:49.92)
- systemd journal: `Stopping car-hub.service` at 20:56:50, then `Started` — the worker was SIGTERMed as part of the cgroup stop
- The cutover was fully committed and the hub has been healthy on the new version since — but the update UI has shown the crash error ever since, because the worker died before `reporter.write("ok", ...)`

## Fix

On Linux, when `systemd-run` is available, spawn the worker in its own transient unit instead:

```
[sudo -n] systemd-run --collect --unit codex-autorunner-update-<ts>   --same-dir   --setenv=PYTHONPATH=<update src>   --property=StandardOutput=append:<update-standalone.log>   --property=StandardError=append:<update-standalone.log>   <worker argv>
```

- Own cgroup → survives the hub service restart, so health checks and the terminal status write complete
- Reuses the existing `resolve_systemctl_sudo_prefix` (`systemctl_sudo="auto"` → `sudo -n`) for privileged hub users
- Strips `INVOCATION_ID` from the spawned env so the transient unit isn't tied to the hub service identity
- Same log file, same lock semantics — `_release_update_lock()` still happens before spawn
- Falls back to the previous `start_new_session=True` spawn on non-Linux or when `systemd-run` is missing (macOS launchd unaffected)

## Tests

`tests/test_update_worker_systemd_run_spawn.py` (4 tests, all passing):
- argv construction: sudo prefix, `--collect`, transient unit name, `--same-dir`, PYTHONPATH passthrough, log append properties, worker argv as tail, `INVOCATION_ID` stripped
- no-sudo-prefix variant
- `None` fallback on non-Linux
- `None` fallback when `systemd-run` is not on PATH

Existing `tests/core/test_update_install_cutover_health.py` still passes (12/12).
