### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ The shim tries `PYTHONPATH=src` first and bootstraps a local `.venv` if dependen
 
 ## ⭐ Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Git-on-my-level/codex-autorunner&type=Date)](https://star-history.com/#Git-on-my-level/codex-autorunner&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Git-on-my-level/codex-autorunner&type=Date)](https://star-history.dera.page/#Git-on-my-level/codex-autorunner&Date)


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken: it no longer renders because the chart endpoint is affected by GitHub's stargazer API restrictions, which is a regression for anyone landing on the repo page. This updates the chart to a working host so the star history displays correctly again.