### PR TITLE
feat(tests): allow relocating the pytest hermetic temp root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,10 @@
 # Default: 0
 # CODEX_FAST_TEST_VERIFY_NODEIDS=0
 
+# Place the pytest hermetic temp tree (basetemp, HOME, XDG dirs) somewhere other
+# than the OS temp dir. Absolute path required. Unset uses the OS temp dir.
+# CAR_PYTEST_TEMP_BASE=/mnt/scratch/car-pytest
+
 # Enable dead-code checks during local development (normally only in CI).
 # Default: 0
 # CODEX_LOCAL_CHECK_INCLUDE_DEADCODE=0

--- a/docs/ops/env-and-defaults.md
+++ b/docs/ops/env-and-defaults.md
@@ -180,6 +180,23 @@ Local provider:
 | `CODEX_FAST_TEST_VERIFY_NODEIDS` | Verify collected test node IDs match the JUnit report. | `0` |
 | `CODEX_LOCAL_CHECK_INCLUDE_DEADCODE` | Enable dead-code checks during local development (normally only in CI). | `0` |
 
+## Pytest hermetic temp roots
+
+The test suite builds a per-run, per-worker temp tree (basetemp, `HOME`, XDG
+dirs) under `<base>/cp-<repo-hash>/t/<run-token>/`. `<base>` is the OS temp dir
+by default; `TMPDIR`/`TMP`/`TEMP` are deliberately ignored when choosing it, so
+an ambient per-process temp dir cannot fragment the roots the cleanup pass has
+to find again later.
+
+| Env var | Purpose | Default |
+| --- | --- | --- |
+| `CAR_PYTEST_TEMP_BASE` | Absolute path to place the temp tree somewhere other than the OS temp dir -- a different volume, or a host that forbids worktrees under the system temp dir. Relative values are rejected. | unset (use the OS temp dir) |
+| `CAR_PYTEST_RUN_TOKEN` | Names the per-run subdirectory. Two pytest sessions sharing a token share a basetemp, and pytest wipes an explicit basetemp at session start -- so concurrent runs need distinct tokens. | random per run; set by `Makefile` and `scripts/check.sh` |
+| `CAR_PYTEST_TEMP_ROOT_MAX_BYTES` | Size ceiling for the repo temp root before the session-end cleanup prunes it. | `5368709120` (5 GiB) |
+
+Setting `CAR_PYTEST_TEMP_BASE` does not orphan roots created before the change:
+cleanup still sweeps the OS temp dir as well as the configured base.
+
 ## Workspace PATH bootstrap
 
 For app-server-backed agent runtimes (web terminal/PMA and Telegram) and Discord `!<shell command>` passthrough, CAR prepends workspace-local paths to `PATH`:

--- a/docs/ops/validation-and-testing.md
+++ b/docs/ops/validation-and-testing.md
@@ -75,6 +75,21 @@ executes core + Web checks without chat-app validation.
 
 All tests use isolated temp directories via pytest fixtures (`tmp_path`, `tmp_path_factory`) rather than writing to shared `/tmp` paths.
 
+### Where the Temp Tree Lives
+
+`tests/support/hermetic_roots.py` builds a per-run, per-worker tree (basetemp,
+`HOME`, XDG dirs) under `<base>/cp-<repo-hash>/t/<run-token>/`, and
+`src/codex_autorunner/core/pytest_temp_cleanup.py` prunes it. `<base>` is the OS
+temp dir by default, chosen while ignoring `TMPDIR`/`TMP`/`TEMP` so an ambient
+per-process temp dir cannot fragment the roots cleanup has to find again.
+
+Set `CAR_PYTEST_TEMP_BASE` to an absolute path to place that tree on another
+volume — useful when the system disk is small, or when host policy forbids
+creating Git worktrees under the OS temp dir (several suites create real
+worktrees inside their basetemp). Cleanup keeps sweeping the OS temp dir too, so
+switching bases does not orphan existing roots. See
+[env-and-defaults.md](env-and-defaults.md) for the full variable table.
+
 ### Anti-Regression Guard
 
 `scripts/check_test_tmp_usage.py` scans test files for non-hermetic `/tmp` patterns:
@@ -129,6 +144,8 @@ The following modules were migrated from timing-based sync to deterministic wait
 | `scripts/check.sh` | Lane-aware validation runner (local pre-commit) |
 | `scripts/chat_surface_latency_budgets.py` | Deterministic chat-surface budget suite writer |
 | `scripts/check_test_tmp_usage.py` | Hermetic /tmp usage guard |
+| `tests/support/hermetic_roots.py` | Per-run/per-worker temp, `HOME`, and state roots |
+| `src/codex_autorunner/core/pytest_temp_cleanup.py` | Temp-root discovery and cleanup |
 | `scripts/test_tmp_usage_allowlist.json` | Allowlist for known /tmp exceptions |
 | `tests/support/waits.py` | Deterministic wait helpers for tests |
 | `.github/workflows/ci.yml` | CI pipeline with lane-based job routing |

--- a/src/codex_autorunner/core/pytest_temp_cleanup.py
+++ b/src/codex_autorunner/core/pytest_temp_cleanup.py
@@ -9,9 +9,10 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Hashable, Iterable, TypeVar
+from typing import Callable, Hashable, Iterable, Mapping, TypeVar
 
 _PYTEST_RUNTIME_TEMP_SUBDIR = "t"
+PYTEST_TEMP_BASE_ENV = "CAR_PYTEST_TEMP_BASE"
 _DEFAULT_LSOF_TIMEOUT_SECONDS = 10.0
 _TEMP_ENV_KEYS = ("TMPDIR", "TMP", "TEMP")
 _CAR_TEMP_DIR_PREFIXES = (
@@ -60,15 +61,63 @@ class TempCleanupSummary:
     active_processes: tuple[TempRootProcess, ...] = ()
 
 
+def configured_temp_base(
+    environ: Mapping[str, str] | None = None,
+) -> Path | None:
+    """Return the operator-configured base for repo pytest temp roots.
+
+    ``system_temp_root()`` deliberately ignores ``TMPDIR``/``TMP``/``TEMP`` so
+    that an ambient, per-process temp dir cannot fragment the roots this module
+    has to find again later. That leaves no way to place the roots elsewhere,
+    which matters when the OS temp dir is the wrong volume for them -- a
+    sandbox that forbids it, a small system disk, or a host policy that only
+    permits scratch under a dedicated mount.
+
+    ``CAR_PYTEST_TEMP_BASE`` is the deliberate opt-in counterpart: explicit,
+    named, and set once for a whole machine or CI runner, so it does not
+    reintroduce the ambient-inheritance problem. Unset (the default) keeps the
+    historical system-temp behaviour.
+    """
+
+    env = os.environ if environ is None else environ
+    raw = (env.get(PYTEST_TEMP_BASE_ENV) or "").strip()
+    if not raw:
+        return None
+    base = Path(raw).expanduser()
+    if not base.is_absolute():
+        raise ValueError(
+            f"{PYTEST_TEMP_BASE_ENV} must be an absolute path, got {raw!r}. "
+            "A relative value would resolve against the current working "
+            "directory, so each caller would get a different temp root."
+        )
+    return base.resolve(strict=False)
+
+
+def candidate_repo_temp_bases() -> tuple[Path, ...]:
+    """Every base that may hold this repo's temp roots, newest policy first.
+
+    When a base is configured we still scan the system temp dir: roots created
+    before the switchover are otherwise orphaned, and nothing would ever clean
+    them up again.
+    """
+
+    roots: dict[Path, Path] = {}
+    configured = configured_temp_base()
+    if configured is not None:
+        roots.setdefault(configured, configured)
+    for candidate in candidate_system_temp_roots():
+        roots.setdefault(candidate, candidate)
+    return tuple(roots.values())
+
+
 def repo_pytest_runtime_root(repo_root: Path, *, temp_base: Path | None = None) -> Path:
     key = hashlib.sha1(
         str(Path(repo_root).expanduser().resolve(strict=False)).encode("utf-8")
     ).hexdigest()[:10]
-    base_root = (
-        Path(temp_base).expanduser().resolve(strict=False)
-        if temp_base is not None
-        else system_temp_root()
-    )
+    if temp_base is not None:
+        base_root = Path(temp_base).expanduser().resolve(strict=False)
+    else:
+        base_root = configured_temp_base() or system_temp_root()
     return base_root / f"cp-{key}"
 
 
@@ -100,7 +149,7 @@ def existing_repo_pytest_runtime_roots(
         return (runtime_root,) if runtime_root.exists() else ()
 
     roots: dict[Path, Path] = {}
-    for base_root in candidate_system_temp_roots():
+    for base_root in candidate_repo_temp_bases():
         candidate = repo_pytest_runtime_root(repo_root, temp_base=base_root)
         if not candidate.exists():
             continue
@@ -164,7 +213,7 @@ def discover_repo_temp_paths(
     if temp_base is not None:
         candidate_roots = (Path(temp_base),)
     else:
-        candidate_roots = candidate_system_temp_roots()
+        candidate_roots = candidate_repo_temp_bases()
     discovered: dict[Path, Path] = {}
     for base_root in candidate_roots:
         root = Path(base_root).expanduser().resolve(strict=False)

--- a/tests/core/test_hermetic_roots.py
+++ b/tests/core/test_hermetic_roots.py
@@ -105,7 +105,8 @@ def test_prune_inactive_pytest_temp_runs_routes_through_cleanup_module(
         roots_module,
         "_load_pytest_temp_cleanup_module",
         lambda _repo: SimpleNamespace(
-            cleanup_repo_pytest_temp_runs=_cleanup_repo_pytest_temp_runs
+            cleanup_repo_pytest_temp_runs=_cleanup_repo_pytest_temp_runs,
+            configured_temp_base=lambda _environ: None,
         ),
     )
 
@@ -135,7 +136,8 @@ def test_prune_inactive_repo_temp_roots_routes_through_cleanup_module(
         roots_module,
         "_load_pytest_temp_cleanup_module",
         lambda _repo: SimpleNamespace(
-            cleanup_repo_managed_temp_paths=_cleanup_repo_managed_temp_paths
+            cleanup_repo_managed_temp_paths=_cleanup_repo_managed_temp_paths,
+            configured_temp_base=lambda _environ: None,
         ),
     )
 
@@ -147,3 +149,40 @@ def test_prune_inactive_repo_temp_roots_routes_through_cleanup_module(
     roots.prune_inactive_repo_temp_roots(min_age_seconds=321.0)
 
     assert calls == [(roots.repo_root, {"run-q"}, 321.0)]
+
+
+def test_from_repo_root_honours_configured_temp_base(
+    tmp_path: Path, monkeypatch
+) -> None:
+    system_tmp = tmp_path / "system-tmp"
+    configured = tmp_path / "configured"
+    monkeypatch.setattr(roots_module, "_system_temp_root", lambda _repo: system_tmp)
+
+    repo_root = tmp_path / "repo"
+    env = {
+        "CAR_PYTEST_RUN_TOKEN": "run-123",
+        "CAR_PYTEST_TEMP_BASE": str(configured),
+    }
+
+    roots = roots_module.HermeticTestRoots.from_repo_root(repo_root, environ=env)
+
+    assert roots.temp_base == configured.resolve()
+    assert roots.pytest_runtime_root.parent == configured.resolve()
+    assert roots.pytest_basetemp_root == (
+        configured.resolve() / f"cp-{roots.runtime_key}" / "t" / "run-123" / "basetemp"
+    )
+
+
+def test_from_repo_root_falls_back_to_system_temp_when_base_unset(
+    tmp_path: Path, monkeypatch
+) -> None:
+    system_tmp = tmp_path / "system-tmp"
+    monkeypatch.setattr(roots_module, "_system_temp_root", lambda _repo: system_tmp)
+
+    repo_root = tmp_path / "repo"
+    env = {"CAR_PYTEST_RUN_TOKEN": "run-123"}
+
+    roots = roots_module.HermeticTestRoots.from_repo_root(repo_root, environ=env)
+
+    assert roots.temp_base is None
+    assert roots.pytest_runtime_root.parent == system_tmp

--- a/tests/core/test_pytest_temp_cleanup.py
+++ b/tests/core/test_pytest_temp_cleanup.py
@@ -5,6 +5,8 @@ import os
 import time
 from pathlib import Path
 
+import pytest
+
 from codex_autorunner.core import pytest_temp_cleanup as cleanup_module
 from codex_autorunner.core.pytest_temp_cleanup import (
     TempPathScanResult,
@@ -245,3 +247,91 @@ def test_cleanup_temp_paths_retries_transient_directory_not_empty(
     assert summary.deleted == 1
     assert summary.failed == 0
     assert target.exists() is False
+
+
+def test_configured_temp_base_returns_none_when_unset_or_blank() -> None:
+    assert cleanup_module.configured_temp_base({}) is None
+    assert cleanup_module.configured_temp_base({"CAR_PYTEST_TEMP_BASE": ""}) is None
+    assert cleanup_module.configured_temp_base({"CAR_PYTEST_TEMP_BASE": "   "}) is None
+
+
+def test_configured_temp_base_resolves_absolute_path(tmp_path: Path) -> None:
+    base = tmp_path / "scratch"
+
+    resolved = cleanup_module.configured_temp_base({"CAR_PYTEST_TEMP_BASE": str(base)})
+
+    assert resolved == base.resolve()
+
+
+def test_configured_temp_base_rejects_relative_path() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        cleanup_module.configured_temp_base({"CAR_PYTEST_TEMP_BASE": "relative/dir"})
+
+    assert "absolute path" in str(excinfo.value)
+
+
+def test_repo_pytest_runtime_root_honours_configured_temp_base(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    configured = tmp_path / "configured"
+    monkeypatch.setenv("CAR_PYTEST_TEMP_BASE", str(configured))
+
+    runtime_root = cleanup_module.repo_pytest_runtime_root(repo_root)
+
+    assert runtime_root.parent == configured.resolve()
+
+
+def test_explicit_temp_base_overrides_configured_temp_base(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    monkeypatch.setenv("CAR_PYTEST_TEMP_BASE", str(tmp_path / "configured"))
+    explicit = tmp_path / "explicit"
+
+    runtime_root = cleanup_module.repo_pytest_runtime_root(
+        repo_root, temp_base=explicit
+    )
+
+    assert runtime_root.parent == explicit.resolve()
+
+
+def test_candidate_repo_temp_bases_keeps_system_temp_after_switchover(
+    tmp_path: Path, monkeypatch
+) -> None:
+    system_tmp = tmp_path / "system-tmp"
+    configured = tmp_path / "configured"
+    monkeypatch.setattr(
+        cleanup_module, "candidate_system_temp_roots", lambda: (system_tmp,)
+    )
+    monkeypatch.setenv("CAR_PYTEST_TEMP_BASE", str(configured))
+
+    bases = cleanup_module.candidate_repo_temp_bases()
+
+    assert bases == (configured.resolve(), system_tmp)
+
+
+def test_cleanup_repo_pytest_temp_runs_sweeps_configured_and_system_bases(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    system_tmp = tmp_path / "system-tmp"
+    configured = tmp_path / "configured"
+    monkeypatch.setattr(
+        cleanup_module, "candidate_system_temp_roots", lambda: (system_tmp,)
+    )
+
+    legacy_run = repo_pytest_temp_root(repo_root, temp_base=system_tmp) / "old-run"
+    legacy_run.mkdir(parents=True)
+    (legacy_run / "leftover.txt").write_text("x")
+    configured_run = repo_pytest_temp_root(repo_root, temp_base=configured) / "new-run"
+    configured_run.mkdir(parents=True)
+    (configured_run / "leftover.txt").write_text("x")
+
+    monkeypatch.setenv("CAR_PYTEST_TEMP_BASE", str(configured))
+    summary = cleanup_repo_pytest_temp_runs(repo_root)
+
+    assert summary.deleted == 2
+    assert not legacy_run.exists()
+    assert not configured_run.exists()

--- a/tests/support/hermetic_roots.py
+++ b/tests/support/hermetic_roots.py
@@ -42,6 +42,11 @@ def _system_temp_root(repo_root: Path) -> Path:
     return cleanup_module.system_temp_root()
 
 
+def _configured_temp_base(repo_root: Path, environ: dict[str, str]) -> Path | None:
+    cleanup_module = _load_pytest_temp_cleanup_module(repo_root)
+    return cleanup_module.configured_temp_base(environ)
+
+
 @dataclass(frozen=True)
 class HermeticTestRoots:
     repo_root: Path
@@ -58,6 +63,7 @@ class HermeticTestRoots:
     pytest_home_root: Path
     pytest_opencode_state_root: Path
     pytest_global_state_root: Path
+    temp_base: Path | None = None
 
     @classmethod
     def from_repo_root(
@@ -75,9 +81,13 @@ class HermeticTestRoots:
             )
         )
 
-        pytest_runtime_root = (
-            _system_temp_root(resolved_repo_root) / f"cp-{runtime_key}"
+        temp_base = _configured_temp_base(resolved_repo_root, env)
+        base_root = (
+            temp_base
+            if temp_base is not None
+            else _system_temp_root(resolved_repo_root)
         )
+        pytest_runtime_root = base_root / f"cp-{runtime_key}"
         pytest_temp_root = pytest_runtime_root / "t"
         pytest_temp_run_root = pytest_temp_root / run_token
         pytest_basetemp_root = pytest_temp_run_root / "basetemp"
@@ -106,6 +116,7 @@ class HermeticTestRoots:
             pytest_home_root=pytest_home_root,
             pytest_opencode_state_root=pytest_opencode_state_root,
             pytest_global_state_root=pytest_global_state_root,
+            temp_base=temp_base,
         )
 
     def load_pytest_temp_cleanup_module(self) -> ModuleType:
@@ -140,6 +151,10 @@ class HermeticTestRoots:
         self, *, min_age_seconds: float = 300.0
     ) -> None:
         cleanup_module = self.load_pytest_temp_cleanup_module()
+        # Deliberately no temp_base: the default resolution already honours
+        # CAR_PYTEST_TEMP_BASE *and* still sweeps the system temp dir, so roots
+        # created before a base switchover keep getting cleaned up. Pinning the
+        # configured base here would narrow the sweep and orphan them.
         cleanup_module.cleanup_repo_pytest_temp_runs(
             self.repo_root,
             keep_run_tokens={self.run_token},
@@ -148,6 +163,7 @@ class HermeticTestRoots:
 
     def prune_inactive_repo_temp_roots(self, *, min_age_seconds: float = 300.0) -> None:
         cleanup_module = self.load_pytest_temp_cleanup_module()
+        # See prune_inactive_pytest_temp_runs for why temp_base is left unset.
         cleanup_module.cleanup_repo_managed_temp_paths(
             self.repo_root,
             keep_run_tokens={self.run_token},


### PR DESCRIPTION
## Problem

The hermetic test tree — basetemp, `HOME`, XDG dirs — is always built under the OS temp dir. `system_temp_root()` deliberately strips `TMPDIR`/`TMP`/`TEMP` when choosing that base, so an ambient per-process temp dir cannot fragment the roots the cleanup pass has to find again later. That is the right default, but it leaves **no** way to place the tree anywhere else.

That matters when the OS temp dir is the wrong volume: a small system disk, a sandbox that forbids it, or a host policy that only permits Git worktrees under a dedicated mount. Several suites (`tests/core/test_pma_hygiene.py`, `tests/test_hub_foundation.py`, `tests/surfaces/web/test_hub_ticket_routes.py`) create **real** Git worktrees inside their basetemp, so on such a host they fail with errors that read like repo regressions but are entirely environmental.

## Change

`CAR_PYTEST_TEMP_BASE` — the deliberate opt-in counterpart to the ignored ambient vars. Absolute path, explicitly named, set once for a machine or CI runner, so it does not reintroduce the ambient-inheritance problem the stripping exists to prevent.

- **Unset (the default) keeps existing behaviour byte for byte.**
- An explicit `temp_base=` argument still wins, so the cleanup module's own tests are untouched.
- Relative values are rejected with a clear error rather than silently resolving against the current working directory.

Cleanup deliberately keeps sweeping the OS temp dir *alongside* the configured base (`candidate_repo_temp_bases()`), so roots created before a switchover are still reclaimed rather than orphaned. That also means `car cleanup` and the session pruners pick up the configured base with no extra plumbing — resolution happens once, at the bottom.

## Verification

- `make check` green: **10014 passed**, mypy clean across 1006 source files, ruff/black clean.
- 9 new tests covering: unset/blank handling, absolute resolution, relative rejection, runtime-root resolution, explicit-argument precedence, cross-base sweeping, and both `HermeticTestRoots` paths.
- `scripts/check_test_tmp_usage.py` passes — the guard is a syntactic scan for literal `/tmp` strings in `tests/`, which this does not introduce.
- End to end: with the var set, `scripts/pytest_basetemp.py` prints `<base>/cp-<hash>/t/<token>/basetemp`; unset, it prints the unchanged `/private/tmp/...` path.

## Notes

No version bump or changelog — this repo does those in dedicated release commits.

The two sibling variables (`CAR_PYTEST_RUN_TOKEN`, `CAR_PYTEST_TEMP_ROOT_MAX_BYTES`) were undocumented; since this adds a third to the family, `docs/ops/env-and-defaults.md` now documents all three in one table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
